### PR TITLE
test(preferences): cover formatAmount branches

### DIFF
--- a/docs/components/Preferences.md
+++ b/docs/components/Preferences.md
@@ -90,8 +90,9 @@ Coverage targets (≥ 95%):
 | `formatAmount` – USD | zero, fraction, large, negative, default currency |
 | `formatAmount` – NGN | typical, zero, large |
 | `formatAmount` – compact | thousands (`K`), millions (`M`), zero |
+| Custom currency handling | default and compact formats preserve caller-provided currency |
 | Re-render consumer | `consumer component re-renders with updated format` |
-| Outside provider | `returns default fallback without throwing` |
+| Outside provider | default fallback formatting and no-op `updatePreference` |
 
 Run tests:
 

--- a/src/lib/__tests__/preferences.test.tsx
+++ b/src/lib/__tests__/preferences.test.tsx
@@ -86,6 +86,16 @@ describe('formatAmount – usd (default)', () => {
     const { result } = renderHook(() => usePreferences(), { wrapper });
     expect(result.current.formatAmount(50)).toBe('$50.00');
   });
+
+  it('respects a custom currency for the default format', () => {
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    const expected = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'EUR',
+    }).format(1250);
+
+    expect(result.current.formatAmount(1250, 'EUR')).toBe(expected);
+  });
 });
 
 describe('formatAmount – ngn', () => {
@@ -129,6 +139,18 @@ describe('formatAmount – compact', () => {
     const { result } = renderHook(() => usePreferences(), { wrapper });
     act(() => { result.current.updatePreference('amountFormat', 'compact'); });
     expect(result.current.formatAmount(0, 'USD')).toMatch(/\$0/);
+  });
+
+  it('keeps a custom currency when compact notation is enabled', () => {
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    act(() => { result.current.updatePreference('amountFormat', 'compact'); });
+    const expected = new Intl.NumberFormat('en-US', {
+      notation: 'compact',
+      style: 'currency',
+      currency: 'EUR',
+    }).format(1_500);
+
+    expect(result.current.formatAmount(1_500, 'EUR')).toBe(expected);
   });
 });
 
@@ -188,5 +210,17 @@ describe('usePreferences outside provider', () => {
     const { result } = renderHook(() => usePreferences());
     expect(result.current.preferences.theme).toBe('system');
     expect(result.current.formatAmount(100, 'USD')).toBe('$100.00');
+  });
+
+  it('provides a no-op updatePreference fallback and honors custom currency formatting', () => {
+    const { result } = renderHook(() => usePreferences());
+    const expected = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'EUR',
+    }).format(100);
+
+    expect(() => result.current.updatePreference('theme', 'dark')).not.toThrow();
+    expect(result.current.preferences.theme).toBe('system');
+    expect(result.current.formatAmount(100, 'EUR')).toBe(expected);
   });
 });

--- a/src/lib/preferences.tsx
+++ b/src/lib/preferences.tsx
@@ -84,6 +84,11 @@ export function PreferencesProvider({ children }: { children: React.ReactNode })
     setPreferences(prev => ({ ...prev, [key]: value }));
   };
 
+  /**
+   * Format monetary values using the active amount preference.
+   * USD keeps the caller-provided currency, NGN forces Nigerian Naira,
+   * and compact keeps the caller-provided currency with compact notation.
+   */
   const formatAmount = (amount: number, currency: string = 'USD') => {
     const { amountFormat } = preferences;
     


### PR DESCRIPTION
## Problem
The existing preferences tests covered the main `formatAmount` paths, but did not explicitly guard custom currency handling for the default and compact formats or the fallback behavior outside the provider.

## Solution
- Add assertions for caller-provided currencies in default and compact amount formats.
- Cover the outside-provider fallback with a no-op `updatePreference` check.
- Update the component testing notes to reflect the covered paths.

## Verification
- `npm.cmd ci`
- `npm.cmd test -- --runInBand src/lib/__tests__/preferences.test.tsx`
- `npm.cmd run lint`
- `npm.cmd run build`
- `git diff --check`

Closes #92