### PR TITLE
ci(security): add npm audit gate for high and critical advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,23 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      # Fail the build on high or critical advisories.
+      # Re-run once on transient registry errors (exit code 2 = connectivity).
+      # To waive an unavoidable advisory add its ID to .npmrc:
+      #   audit-level=high
+      # or use: npm audit --audit-level=high --ignore <advisory-id> (npm ≥ 10)
+      # Document the waiver reason in a comment here and in the PR description.
+      - name: Dependency audit
+        run: |
+          npm audit --audit-level=high --production || {
+            EXIT=$?
+            # exit 2 = network/registry error, not a vulnerability finding
+            if [ $EXIT -eq 2 ]; then
+              echo "::warning::npm audit could not reach the registry; retrying..."
+              sleep 10
+              npm audit --audit-level=high --production
+            else
+              exit $EXIT
+            fi
+          }

--- a/README.md
+++ b/README.md
@@ -78,8 +78,29 @@ GitHub Actions runs on push and pull requests to `main`:
 - Lint (`npm run lint`)
 - Build (`npm run build`)
 - Tests (`npm test`)
+- Dependency audit (`npm audit --audit-level=high --production`)
 
 Ensure these pass locally before pushing.
+
+### Security audits
+
+The pipeline runs `npm audit --audit-level=high --production` after tests. Any **high** or **critical** advisory blocks the merge.
+
+**Triage a finding**
+
+1. Run `npm audit` locally to read the advisory details and affected package.
+2. Check whether a patched version exists: `npm audit fix` (add `--force` only if you accept semver-major bumps and have reviewed the changelog).
+3. If no fix is available and the advisory is a false positive or cannot be exploited in this context, document the reason and add the advisory ID to a `.nsprc` / `audit-resolve.json` file (npm ≥ 10: `npm audit --ignore <id>`).
+
+**Waiving an advisory in CI**
+
+Add the `--ignore <advisory-id>` flag to the audit step in `.github/workflows/ci.yml` and leave a comment explaining the waiver, the expected fix date, and a link to the advisory. Example:
+
+```yaml
+# Advisory 1234567 – lodash prototype pollution, not reachable in production
+# Revisit when lodash@5 is released (tracked in #123).
+run: npm audit --audit-level=high --production --ignore 1234567
+```
 
 ## License
 


### PR DESCRIPTION
## Summary

Closes #99

Hardens CI with a dependency audit step that blocks merges on high/critical advisories.

## Changes

- `.github/workflows/ci.yml` — added `Dependency audit` step after tests:
  - Runs `npm audit --audit-level=high --production`
  - Retries once on transient registry errors (exit code 2); vulnerability findings (exit 1) fail immediately
  - Inline comments document the retry logic and how to waive an advisory
- `README.md` — added `### Security audits` subsection under CI/CD with triage steps and waiver YAML example

## Security notes

- Scoped to `--production` to avoid noise from dev-only packages
- High and critical advisories block the merge
- Transient registry failures emit a warning and retry once rather than flaking the build

## Audit output

Run locally to verify: `npm audit --audit-level=high --production`