### PR TITLE
test(forms): cover ErrorSummary focus handling and anchor links

### DIFF
--- a/docs/components/Accessibility.md
+++ b/docs/components/Accessibility.md
@@ -36,6 +36,23 @@ All a11y regression tests are colocated in `src/components/__tests__/a11y.test.t
 | `ReputationProfile` | No reputation, full score + history, partial (score without history), null score |
 | `EmptyState` | Text-only, with illustration variant, with primary action, with both actions |
 
+## ErrorSummary focus and anchors
+
+[`ErrorSummary`](../../src/components/ErrorSummary.tsx) is the form-level alert
+used to summarize validation errors. It renders nothing until errors are
+present. Once errors appear, it renders a `role="alert"` region with
+`tabIndex={-1}` so focus can move to the summary without adding it to the normal
+tab order.
+
+Each error is rendered as an anchor whose `href` points to the invalid field's
+`id`, for example `#email`. This lets keyboard and screen-reader users jump from
+the summary to the exact field that needs attention. Duplicate `fieldId` values
+are still rendered as separate messages, preserving all validation feedback.
+
+Colocated tests live in `src/components/__tests__/ErrorSummary.test.tsx` and
+cover the empty state, focus transition, anchor targets, duplicate field ids,
+and axe validation.
+
 ## Running
 
 ```bash

--- a/src/components/__tests__/ErrorSummary.test.tsx
+++ b/src/components/__tests__/ErrorSummary.test.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { assertNoA11yViolations } from '@/test-utils/a11y';
+import { ErrorSummary } from '../ErrorSummary';
+
+const exampleErrors = [
+  { fieldId: 'full-name', message: 'Enter your full name.' },
+  { fieldId: 'email', message: 'Enter a valid email address.' },
+];
+
+function ErrorSummaryHarness() {
+  const [errors, setErrors] = useState<{ fieldId: string; message: string }[]>([]);
+
+  return (
+    <>
+      <button type="button" onClick={() => setErrors(exampleErrors)}>
+        Show errors
+      </button>
+      <ErrorSummary errors={errors} />
+    </>
+  );
+}
+
+describe('ErrorSummary', () => {
+  it('renders nothing when there are no errors', () => {
+    const { container } = render(<ErrorSummary errors={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders an alert region that can receive programmatic focus', () => {
+    render(<ErrorSummary errors={exampleErrors} />);
+
+    const summary = screen.getByRole('alert');
+
+    expect(summary).toHaveAttribute('tabIndex', '-1');
+    expect(summary).toHaveAccessibleName('There is a problem');
+  });
+
+  it('focuses the summary when errors transition from empty to populated', async () => {
+    render(<ErrorSummaryHarness />);
+
+    screen.getByRole('button', { name: /show errors/i }).focus();
+    expect(screen.getByRole('button', { name: /show errors/i })).toHaveFocus();
+
+    await act(async () => {
+      screen.getByRole('button', { name: /show errors/i }).click();
+    });
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveFocus());
+  });
+
+  it('renders each error as an anchor link to the invalid field id', () => {
+    render(<ErrorSummary errors={exampleErrors} />);
+
+    expect(screen.getByRole('link', { name: 'Enter your full name.' })).toHaveAttribute('href', '#full-name');
+    expect(screen.getByRole('link', { name: 'Enter a valid email address.' })).toHaveAttribute('href', '#email');
+  });
+
+  it('renders duplicate field ids as separate list items with matching anchors', () => {
+    render(
+      <ErrorSummary
+        errors={[
+          { fieldId: 'milestone-title', message: 'Enter a title.' },
+          { fieldId: 'milestone-title', message: 'Title must be under 80 characters.' },
+        ]}
+      />
+    );
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getByRole('link', { name: 'Enter a title.' })).toHaveAttribute('href', '#milestone-title');
+    expect(screen.getByRole('link', { name: 'Title must be under 80 characters.' })).toHaveAttribute('href', '#milestone-title');
+  });
+
+  it('has no axe violations when errors are shown', async () => {
+    const { container } = render(<ErrorSummary errors={exampleErrors} />);
+
+    await assertNoA11yViolations(container);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #91.

Adds focused test coverage for the ErrorSummary accessibility behavior used by the home form validation flow.

## Changes

- Added `src/components/__tests__/ErrorSummary.test.tsx`
- Covered empty state, alert semantics, focus on new errors, anchor hrefs, duplicate field ids, and axe validation
- Documented ErrorSummary focus and anchor behavior in `docs/components/Accessibility.md`

## Testing

- `npm test -- ErrorSummary.test.tsx --runInBand`
  - 1 suite passed, 6 tests passed
- `npm run lint`
  - No ESLint warnings or errors
- `npm test -- --runInBand`
  - 24 suites passed, 165 tests passed
- `npm run build`
  - Build completed successfully

## Risk

Low risk: this PR adds regression tests and documentation only. It does not change production component behavior or dependencies.

## Bounty / reward

This PR addresses the GrantFox/OSS bounty issue #91. Please let me know if any additional claim step is needed after review.

## Notes

`npm ci` reports pre-existing dependency audit warnings, including a Next.js 14.2.18 security warning. This PR does not change dependencies.
