### PR TITLE
feat(ui): add icon-and-label status badge token

### DIFF
--- a/docs/components/StatusBadge.md
+++ b/docs/components/StatusBadge.md
@@ -20,13 +20,17 @@ This component eliminates duplicated status styling logic that previously existe
 
 ## Status Types
 
-The component supports the following status types:
+Each status renders an icon + label token so meaning is never conveyed by color alone (WCAG 1.4.1).
 
-- **Active** - Emerald theme (`bg-emerald-100 text-emerald-800`)
-- **Completed** - Sky theme (`bg-sky-100 text-sky-800`)
-- **Disputed** - Rose theme (`bg-rose-100 text-rose-800`)
-- **Pending** - Amber theme (`bg-amber-100 text-amber-800`)
-- **Paid** - Emerald theme (`bg-emerald-100 text-emerald-800`)
+| Status    | Icon | Color token                  |
+|-----------|------|------------------------------|
+| Active    | ▶    | `--status-success-*`         |
+| Completed | ✓    | `--status-info-*`            |
+| Disputed  | ⚠    | `--status-error-*`           |
+| Pending   | ⏳   | `--status-warning-*`         |
+| Paid      | ✔    | `--status-success-*`         |
+
+Icons are rendered in a child `<span aria-hidden="true">` so screen readers only announce the label text.
 
 ## Usage Examples
 
@@ -120,6 +124,5 @@ Both components now import `StatusBadge` and the shared `StatusType` type, ensur
 
 Potential improvements for future iterations:
 - Configurable badge sizes (small, medium, large)
-- Icon support for status-specific icons
 - Additional status types as business requirements evolve
 - Animation transitions on status changes

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -2,7 +2,8 @@
  * StatusBadge Component
  *
  * A reusable badge component that displays contract and milestone statuses
- * with consistent styling and color mapping.
+ * with an icon + label token, ensuring meaning is never conveyed by color alone.
+ * Meets WCAG 2.1 AA requirements.
  */
 
 export type StatusType = 'Active' | 'Completed' | 'Disputed' | 'Pending' | 'Paid';
@@ -16,17 +17,11 @@ export interface StatusBadgeProps {
 
 /**
  * Unified color and style map for all status types.
- * Ensures consistent visual representation across the application.
  *
  * a11y/theming-27: previously these were fixed Tailwind pastel pairs
  * (e.g. `bg-emerald-100 text-emerald-800`) which never changed with
- * `data-theme`. In dark mode the light pastel background sat directly on
- * the dark surface with no contrast issue for the text itself, but it
- * read as a jarring "light sticker" inconsistent with the themed UI, and
- * the equivalent pattern in toast-provider.tsx had outright AA failures.
- * Replaced with CSS variables defined in globals.css so both themes get
- * an audited, intentional pair. Light-mode variable values are identical
- * to the original Tailwind hex values, so the light theme is unchanged.
+ * `data-theme`. Replaced with CSS variables defined in globals.css so
+ * both themes get an audited, intentional pair.
  * Ratios recorded in docs/components/Accessibility.md.
  */
 const statusColorMap: Record<StatusType, string> = {
@@ -37,12 +32,19 @@ const statusColorMap: Record<StatusType, string> = {
   Paid: 'bg-[var(--status-success-bg)] text-[var(--status-success-foreground)]',
 };
 
+/** Non-color icon token paired with each status (aria-hidden; label provides text). */
+const statusIconMap: Record<StatusType, string> = {
+  Active:    '▶',
+  Completed: '✓',
+  Disputed:  '⚠',
+  Pending:   '⏳',
+  Paid:      '✔',
+};
+
 /**
- * StatusBadge component renders a styled badge pill for contract and milestone statuses.
- *
- * @param status - The status value to display (Active, Completed, Disputed, Pending, or Paid)
- * @param className - Optional additional CSS classes
- * @returns A styled badge element with appropriate color based on status
+ * StatusBadge renders a pill with an icon + label for each status.
+ * The icon is decorative (`aria-hidden`); meaning is also carried by the
+ * visible label and `aria-label`, so it is never color-only.
  *
  * @example
  * ```tsx
@@ -53,10 +55,11 @@ const statusColorMap: Record<StatusType, string> = {
 const StatusBadge = ({ status, className = '' }: StatusBadgeProps) => {
   return (
     <span
-      className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${statusColorMap[status]} ${className}`}
+      className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-semibold ${statusColorMap[status]} ${className}`}
       role="status"
       aria-label={`Status: ${status}`}
     >
+      <span aria-hidden="true">{statusIconMap[status]}</span>
       {status}
     </span>
   );

--- a/src/components/__tests__/StatusBadge.test.tsx
+++ b/src/components/__tests__/StatusBadge.test.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import StatusBadge, { StatusType } from '../StatusBadge';
 
+const STATUS_ICONS: Record<StatusType, string> = {
+  Active:    '▶',
+  Completed: '✓',
+  Disputed:  '⚠',
+  Pending:   '⏳',
+  Paid:      '✔',
+};
+
 describe('StatusBadge', () => {
   describe('rendering', () => {
     it('renders the status text', () => {
@@ -17,6 +25,24 @@ describe('StatusBadge', () => {
         expect(screen.getByText(status)).toBeInTheDocument();
         unmount();
       });
+    });
+
+    it('renders an icon for each status', () => {
+      const statuses: StatusType[] = ['Active', 'Completed', 'Disputed', 'Pending', 'Paid'];
+
+      statuses.forEach((status) => {
+        const { container, unmount } = render(<StatusBadge status={status} />);
+        const iconSpan = container.querySelector('span[aria-hidden="true"]');
+        expect(iconSpan).toBeInTheDocument();
+        expect(iconSpan?.textContent).toBe(STATUS_ICONS[status]);
+        unmount();
+      });
+    });
+
+    it('icon span has aria-hidden="true"', () => {
+      const { container } = render(<StatusBadge status="Active" />);
+      const iconSpan = container.querySelector('span[aria-hidden="true"]');
+      expect(iconSpan).toHaveAttribute('aria-hidden', 'true');
     });
   });
 

--- a/src/components/__tests__/__snapshots__/StatusBadge.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/StatusBadge.test.tsx.snap
@@ -3,9 +3,14 @@
 exports[`StatusBadge snapshot tests matches snapshot for Active status 1`] = `
 <span
   aria-label="Status: Active"
-  class="inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-success-bg)] text-[var(--status-success-foreground)] "
+  class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-success-bg)] text-[var(--status-success-foreground)] "
   role="status"
 >
+  <span
+    aria-hidden="true"
+  >
+    ▶
+  </span>
   Active
 </span>
 `;
@@ -13,9 +18,14 @@ exports[`StatusBadge snapshot tests matches snapshot for Active status 1`] = `
 exports[`StatusBadge snapshot tests matches snapshot for Completed status 1`] = `
 <span
   aria-label="Status: Completed"
-  class="inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-info-bg)] text-[var(--status-info-foreground)] "
+  class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-info-bg)] text-[var(--status-info-foreground)] "
   role="status"
 >
+  <span
+    aria-hidden="true"
+  >
+    ✓
+  </span>
   Completed
 </span>
 `;
@@ -23,9 +33,14 @@ exports[`StatusBadge snapshot tests matches snapshot for Completed status 1`] = 
 exports[`StatusBadge snapshot tests matches snapshot for Disputed status 1`] = `
 <span
   aria-label="Status: Disputed"
-  class="inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-error-bg)] text-[var(--status-error-foreground)] "
+  class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-error-bg)] text-[var(--status-error-foreground)] "
   role="status"
 >
+  <span
+    aria-hidden="true"
+  >
+    ⚠
+  </span>
   Disputed
 </span>
 `;
@@ -33,9 +48,14 @@ exports[`StatusBadge snapshot tests matches snapshot for Disputed status 1`] = `
 exports[`StatusBadge snapshot tests matches snapshot for Paid status 1`] = `
 <span
   aria-label="Status: Paid"
-  class="inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-success-bg)] text-[var(--status-success-foreground)] "
+  class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-success-bg)] text-[var(--status-success-foreground)] "
   role="status"
 >
+  <span
+    aria-hidden="true"
+  >
+    ✔
+  </span>
   Paid
 </span>
 `;
@@ -43,9 +63,14 @@ exports[`StatusBadge snapshot tests matches snapshot for Paid status 1`] = `
 exports[`StatusBadge snapshot tests matches snapshot for Pending status 1`] = `
 <span
   aria-label="Status: Pending"
-  class="inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-warning-bg)] text-[var(--status-warning-foreground)] "
+  class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-warning-bg)] text-[var(--status-warning-foreground)] "
   role="status"
 >
+  <span
+    aria-hidden="true"
+  >
+    ⏳
+  </span>
   Pending
 </span>
 `;
@@ -53,9 +78,14 @@ exports[`StatusBadge snapshot tests matches snapshot for Pending status 1`] = `
 exports[`StatusBadge snapshot tests matches snapshot with additional className 1`] = `
 <span
   aria-label="Status: Active"
-  class="inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-success-bg)] text-[var(--status-success-foreground)] ml-2"
+  class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-success-bg)] text-[var(--status-success-foreground)] ml-2"
   role="status"
 >
+  <span
+    aria-hidden="true"
+  >
+    ▶
+  </span>
   Active
 </span>
 `;


### PR DESCRIPTION
## Summary

Fixes #53

Each `StatusBadge` variant now pairs an icon with its label so status meaning is never conveyed by color alone, satisfying WCAG 1.4.1 (Use of Color).

## Changes

- **`StatusBadge.tsx`** — added `statusIconMap` mapping each `StatusType` to a unicode icon; icon rendered in `<span aria-hidden="true">` beside the label; added `gap-1` to the outer span
- **`StatusBadge.test.tsx`** — new tests for icon rendering and `aria-hidden` attribute
- **Snapshots** — regenerated to reflect updated DOM structure  
- **`docs/components/StatusBadge.md`** — icon token table added; removed stale 'future enhancement' bullet

## Icon tokens

| Status    | Icon |
|-----------|------|
| Active    | ▶    |
| Completed | ✓    |
| Disputed  | ⚠    |
| Pending   | ⏳   |
| Paid      | ✔    |

## Accessibility

- Icons are `aria-hidden`; screen readers announce only the label text via `aria-label` and visible text
- Color contrast unchanged (CSS variable tokens, previously audited)
- All 23 StatusBadge tests pass