### PR TITLE
feat(theming): add header theme toggle wired to preferences

### DIFF
--- a/docs/components/Preferences.md
+++ b/docs/components/Preferences.md
@@ -99,3 +99,59 @@ Run tests:
 ```bash
 npm test -- --testPathPattern=preferences --coverage
 ```
+
+---
+
+## ThemeToggle
+
+`src/components/ThemeToggle.tsx`
+
+One-click header button that toggles between `light` and `dark` themes. Uses the same `updatePreference('theme', ...)` call as `SettingsPanel`, so the two stay in sync.
+
+### Behaviour
+
+| Current theme | Button action | Result |
+|---|---|---|
+| `'light'` | click | sets `'dark'` |
+| `'dark'` | click | sets `'light'` |
+| `'system'` | click | sets `'dark'` (gives the user an explicit state) |
+
+`'system'` remains available via **Settings → Appearance → system**.
+
+### SSR safety
+
+The component renders `null` until its `useEffect` fires (mounted guard), preventing hydration mismatch. No flash of incorrect icon occurs because the `PreferencesProvider` also waits for `isHydrated`.
+
+### Accessibility
+
+- `aria-label` reflects the *next* action: `"Switch to dark theme"` / `"Switch to light theme"`.
+- `aria-pressed` reflects the *current* dark state (`true` when dark, `false` otherwise).
+- Inherits project focus-ring via `focus-visible:ring-2 focus-visible:ring-[var(--primary)]`.
+
+### Usage
+
+Mount once in the app header (already done in `src/app/layout.tsx`):
+
+```tsx
+import { ThemeToggle } from '@/components/ThemeToggle';
+
+<div className="flex items-center gap-2">
+  <ThemeToggle />
+  <WalletConnectButton />
+</div>
+```
+
+### Testing
+
+File: `src/components/__tests__/ThemeToggle.test.tsx`
+
+| Test | Description |
+|---|---|
+| SSR guard | button present after mount |
+| Light label/icon | moon icon, aria-label "Switch to dark theme", aria-pressed false |
+| Dark label/icon | sun icon, aria-label "Switch to light theme", aria-pressed true |
+| light → dark | click updates preference to dark |
+| dark → light | click updates preference to light |
+| system → dark | first click from system sets dark |
+| aria-pressed | reflects dark state after toggle |
+| localStorage | toggled value persisted |

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,20 @@
 import React from 'react';
+import '@testing-library/jest-dom';
+
+// Mock matchMedia (not implemented in jsdom)
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
 
 // Mock next/link to a plain <a> to avoid intersection/prefetch behavior
 jest.mock('next/link', () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,6 +24,7 @@ import { WalletProvider } from '@/contexts/WalletContext';
 import { WalletConnectButton } from '@/components/WalletConnectButton';
 import RouteAnnouncer from '@/components/RouteAnnouncer';
 import Navbar from '@/components/Navbar';
+import { ThemeToggle } from '@/components/ThemeToggle';
 
 export default function RootLayout({
   children,
@@ -58,7 +59,10 @@ export default function RootLayout({
                     </span>
                   </div>
                   <Navbar />
-                  <WalletConnectButton />
+                  <div className="flex items-center gap-2">
+                    <ThemeToggle />
+                    <WalletConnectButton />
+                  </div>
                 </header>
                 <main className="flex-1 p-6" tabIndex={-1} id="main-content">
                   {children}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import React from 'react';
+import { usePreferences } from '@/lib/preferences';
+
+/**
+ * ThemeToggle — inline header button that cycles between light and dark.
+ *
+ * - Reads `preferences.theme` via `usePreferences()`.
+ * - Toggles between `'light'` and `'dark'` (treats `'system'` as dark for
+ *   the first click so the user gets an explicit state immediately).
+ * - Renders `null` before hydration to prevent SSR mismatch (the
+ *   `PreferencesProvider` already guards `isHydrated`, so on the first
+ *   client render `preferences.theme` is the resolved stored value).
+ */
+export function ThemeToggle() {
+  const { preferences, updatePreference } = usePreferences();
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  const isDark = preferences.theme === 'dark';
+  const next = isDark ? 'light' : 'dark';
+  const label = isDark ? 'Switch to light theme' : 'Switch to dark theme';
+
+  return (
+    <button
+      type="button"
+      onClick={() => updatePreference('theme', next)}
+      aria-label={label}
+      aria-pressed={isDark}
+      className="rounded-md p-2 text-slate-600 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
+    >
+      {isDark ? (
+        /* Sun icon — shown in dark mode to switch to light */
+        <svg aria-hidden="true" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707-.707M6.343 6.343l-.707-.707M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8z" />
+        </svg>
+      ) : (
+        /* Moon icon — shown in light/system mode to switch to dark */
+        <svg aria-hidden="true" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/components/__tests__/ThemeToggle.test.tsx
+++ b/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeToggle } from '../ThemeToggle';
+import { PreferencesProvider, usePreferences } from '@/lib/preferences';
+
+// Helper: render inside the provider
+const renderToggle = () =>
+  render(
+    <PreferencesProvider>
+      <ThemeToggle />
+    </PreferencesProvider>,
+  );
+
+// Helper: render toggle alongside a component that can inspect preferences
+function ToggleWithState() {
+  const { preferences } = usePreferences();
+  return (
+    <>
+      <ThemeToggle />
+      <span data-testid="theme">{preferences.theme}</span>
+    </>
+  );
+}
+
+const renderWithState = () =>
+  render(
+    <PreferencesProvider>
+      <ToggleWithState />
+    </PreferencesProvider>,
+  );
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders null on the server (before mount)', () => {
+    // Simulate pre-mount by checking no button exists before useEffect fires
+    // We rely on the mounted guard: the component returns null until useEffect.
+    // In the Jest environment useEffect runs synchronously via act, so we
+    // just verify the button IS present after render (positive case).
+    renderToggle();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('shows moon icon and "Switch to dark theme" label when theme is light', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ theme: 'light' }),
+    );
+    renderToggle();
+    const btn = screen.getByRole('button', { name: /switch to dark theme/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('shows sun icon and "Switch to light theme" label when theme is dark', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ theme: 'dark' }),
+    );
+    renderToggle();
+    const btn = screen.getByRole('button', { name: /switch to light theme/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('toggles light → dark and calls updatePreference', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ theme: 'light' }),
+    );
+    renderWithState();
+    expect(screen.getByTestId('theme').textContent).toBe('light');
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /switch to dark theme/i }));
+    });
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+  });
+
+  it('toggles dark → light and calls updatePreference', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ theme: 'dark' }),
+    );
+    renderWithState();
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /switch to light theme/i }));
+    });
+
+    expect(screen.getByTestId('theme').textContent).toBe('light');
+  });
+
+  it('treats "system" as non-dark and toggles to dark on first click', () => {
+    // default theme is 'system'
+    renderWithState();
+    expect(screen.getByTestId('theme').textContent).toBe('system');
+
+    // moon icon shown (not dark), so clicking goes to dark
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /switch to dark theme/i }));
+    });
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark');
+  });
+
+  it('aria-pressed reflects current dark state accurately', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ theme: 'light' }),
+    );
+    renderToggle();
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+
+    act(() => {
+      fireEvent.click(btn);
+    });
+
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('persists the toggled theme to localStorage', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ theme: 'light' }),
+    );
+    renderToggle();
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /switch to dark theme/i }));
+    });
+
+    const saved = JSON.parse(
+      localStorage.getItem('talenttrust-user-preferences') || '{}',
+    );
+    expect(saved.theme).toBe('dark');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a one-click light/dark toggle button to the header so users can switch themes without opening the Settings drawer.

## Changes

- **`src/components/ThemeToggle.tsx`** — new `'use client'` component that reads `preferences.theme` and calls `updatePreference('theme', ...)`, toggling between `light` and `dark`. `'system'` remains reachable via Settings.
- **`src/app/layout.tsx`** — mounts `<ThemeToggle />` in the header between the brand name and `<WalletConnectButton />`. Sticky/backdrop-blur styling untouched.
- **`src/components/__tests__/ThemeToggle.test.tsx`** — 8 tests: SSR guard, light label/icon, dark label/icon, light→dark, dark→light, system→dark, aria-pressed state, localStorage persistence.
- **`docs/components/Preferences.md`** — new ThemeToggle section covering behaviour, SSR safety, accessibility, usage, and test coverage table.

## Accessibility

- `aria-label` reflects the *next* action: "Switch to dark theme" / "Switch to light theme".
- `aria-pressed` reflects the *current* dark state.
- Inherits project focus-ring via `focus-visible:ring-2 focus-visible:ring-[var(--primary)]`.

## Test output

```
Test Suites: 21 passed, 21 total
Tests:       133 passed, 133 total
Snapshots:   1 passed, 1 total
```

`npm run lint`: ✔ No ESLint warnings or errors  
`npm run build`: ✔ Compiled successfully, 7 static pages generated

Closes #132