### PR TITLE
docs: add architecture, route map, and provider overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,35 @@ Open [http://localhost:3000](http://localhost:3000).
 | `npm run lint` | Run ESLint             |
 | `npm test`    | Run Jest tests           |
 
+## Architecture
+
+The project is built on Next.js App Router. The UI layer shares components, whilst global state is handled via an ordered provider stack.
+
+### Route Map
+
+| Route | Description | Status |
+|-------|-------------|--------|
+| `/` | Landing page / Home | Placeholder (contains a login form demo and toast demo) |
+| `/contracts` | Contracts list | Placeholder handler (uses local storage stub) |
+| `/contracts/[id]` | Contract details | Placeholder (sample milestones and stubbed action handlers) |
+| `/milestones` | Milestones list | Implemented (filterable status list) |
+| `/reputation` | User reputation | Placeholder (empty state) |
+
+### Provider Stack
+
+Providers are wired in `src/app/layout.tsx` with a specific nesting order:
+
+1. **[`PreferencesProvider`](src/lib/preferences.tsx)** (Outermost)
+   Provides user-level preferences (locale, currency) which can be consumed by any subsequent provider or component.
+2. **[`ToastProvider`](src/components/toast/toast-provider.tsx)**
+   Provides the global notification system. Placed here so that the wallet context or other deeper components can trigger alerts.
+3. **[`WalletProvider`](src/contexts/WalletContext.tsx)** (Innermost)
+   Manages Stellar wallet connections. It can consume preferences and dispatch toast notifications if connections fail or succeed.
+
+### Shared Components
+
+Shared components live in `src/components/` (e.g., `src/components/toast/`). Shared utilities and domain types live in `src/lib/` and `src/types/`.
+
 ## Toast notifications
 
 The app includes a global accessible toast system for transient feedback:


### PR DESCRIPTION
## Description
**What was done:**
Added a comprehensive "Architecture" section to `README.md`. It includes a route map detailing the current implementation status of our pages (distinguishing active pages from placeholders) and an overview of the global provider stack nesting order.

**Why it was done:**
Contributors needed a clear route map (`/`, `/contracts`, `/contracts/[id]`, `/milestones`, `/reputation`) and an explanation of the specific ordering (`PreferencesProvider` → `ToastProvider` → `WalletProvider`) used in `src/app/layout.tsx` to quickly orient themselves within the repository.

**How it was verified:**
- Verified that referenced files (`src/lib/preferences.tsx`, `src/components/toast/toast-provider.tsx`, and `src/contexts/WalletContext.tsx`) actually exist.
- Ensured provider nesting descriptions accurately reflect the layout context.
- Ran `npm run build` locally to confirm the frontend build remains unbroken.
*(Note: Rendered preview of the README confirms that all markdown tables format correctly and relative links resolve properly).*

closes #100 