### PR TITLE
  feat(contracts): Accessible Create Contract Form with Validation (#80)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('jest').Config} */
 const config = {
   testEnvironment: 'jsdom',
+  watchman: false,
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: ['/node_modules/', '/.next/'],
   moduleNameMapper: {
@@ -13,6 +14,13 @@ const config = {
   transformIgnorePatterns: [
     '/node_modules/(?!(next|next/dist)/)',
   ],
+  // Use the test-specific tsconfig so the TS language server resolves
+  // Jest globals (describe, test, expect, etc.) inside test files.
+  globals: {
+    'ts-jest': {
+      tsconfig: './tsconfig.test.json',
+    },
+  },
 };
 
 module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^14.6.1",
         "@types/axe-core": "^2.0.2",
-        "@types/jest": "^30.0.0",
+        "@types/jest": "^29.5.14",
         "@types/node": "^22.9.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -1542,16 +1542,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@jest/diff-sequences": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
-      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -1613,16 +1603,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/get-type": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
-      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -1637,30 +1617,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/pattern": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -2354,67 +2310,15 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
-      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "^30.0.0",
-        "pretty-format": "^30.0.0"
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
-    },
-    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
-      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/schemas": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/jest/node_modules/ansi-styles": {
       "version": "5.2.0",
@@ -2429,152 +2333,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@types/jest/node_modules/ci-info": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@types/jest/node_modules/expect": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
-      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "30.3.0",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-diff": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
-      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/diff-sequences": "30.3.0",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
-      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "jest-diff": "30.3.0",
-        "pretty-format": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-message-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
-      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.3.0",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3",
-        "pretty-format": "30.3.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-mock": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
-      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
       },
       "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@types/jest/node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/axe-core": "^2.0.2",
-    "@types/jest": "^30.0.0",
+    "@types/jest": "^29.5.14",
     "@types/node": "^22.9.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/src/app/__tests__/csp.test.ts
+++ b/src/app/__tests__/csp.test.ts
@@ -15,7 +15,6 @@ describe('Content Security Policy', () => {
   test('development includes unsafe-eval and unsafe-inline', async () => {
     (process.env as any).NODE_ENV = 'development';
     // Re-require after resetModules so the module re-evaluates with the new env
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const nextConfig = require('../../../next.config');
     const result = await nextConfig.headers();
     const cspHeader = result[0].headers.find((h: any) => h.key === 'Content-Security-Policy');
@@ -27,7 +26,6 @@ describe('Content Security Policy', () => {
 
   test('production omits unsafe-eval and unsafe-inline', async () => {
     (process.env as any).NODE_ENV = 'production';
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const nextConfig = require('../../../next.config');
     const result = await nextConfig.headers();
     const cspHeader = result[0].headers.find((h: any) => h.key === 'Content-Security-Policy');

--- a/src/app/__tests__/csp.test.ts
+++ b/src/app/__tests__/csp.test.ts
@@ -1,17 +1,23 @@
 // src/app/__tests__/csp.test.ts
-import { headers as getHeaders } from "../../../../next.config";
+
 
 describe('Content Security Policy', () => {
   const originalEnv = process.env.NODE_ENV;
 
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
   afterAll(() => {
-    process.env.NODE_ENV = originalEnv;
+    (process.env as any).NODE_ENV = originalEnv;
   });
 
   test('development includes unsafe-eval and unsafe-inline', async () => {
-    process.env.NODE_ENV = 'development';
-    // Re-import to pick up new env
-    const result = await (await import('../../../../next.config')).default.headers();
+    (process.env as any).NODE_ENV = 'development';
+    // Re-require after resetModules so the module re-evaluates with the new env
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const nextConfig = require('../../../next.config');
+    const result = await nextConfig.headers();
     const cspHeader = result[0].headers.find((h: any) => h.key === 'Content-Security-Policy');
     expect(cspHeader).toBeDefined();
     const value: string = cspHeader.value;
@@ -20,8 +26,10 @@ describe('Content Security Policy', () => {
   });
 
   test('production omits unsafe-eval and unsafe-inline', async () => {
-    process.env.NODE_ENV = 'production';
-    const result = await (await import('../../../../next.config')).default.headers();
+    (process.env as any).NODE_ENV = 'production';
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const nextConfig = require('../../../next.config');
+    const result = await nextConfig.headers();
     const cspHeader = result[0].headers.find((h: any) => h.key === 'Content-Security-Policy');
     expect(cspHeader).toBeDefined();
     const value: string = cspHeader.value;

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -2,51 +2,51 @@
 
 import React, { useState, useCallback } from 'react';
 import EmptyState from '../../components/EmptyState';
-import { listContracts, saveContract } from '@/lib/repository';
+import CreateContractForm from '@/components/contracts/CreateContractForm';
+import { listContracts } from '@/lib/repository';
+
 import type { Contract } from '@/types/domain';
 
 const ContractsPage: React.FC = () => {
   // Initialise from localStorage on first render; subsequent saves trigger
   // a state update so the list reflects newly added items immediately.
   const [contracts, setContracts] = useState<Contract[]>(() => listContracts());
+  const [showForm, setShowForm] = useState(false);
+
+  /** Opens the create-contract form. */
+  const handleCreateContract = useCallback(() => {
+    setShowForm(true);
+  }, []);
 
   /**
-   * Placeholder handler — wire up a form/modal here to collect contract
-   * details, then call `saveContract` and refresh local state.
-   *
-   * Example (once a form is implemented):
-   *   const newContract = collectContractFromForm();
-   *   saveContract(newContract);
-   *   setContracts(listContracts());
+   * Called by CreateContractForm after it has already persisted the contract
+   * via `saveContract`. Re-reads localStorage so the list reflects the new
+   * record, then closes the form.
    */
-  const handleCreateContract = useCallback(() => {
-    // TODO: open a creation form/modal; replace stub data with real input.
-    const stub: Contract = {
-      contractName: `Contract ${Date.now()}`,
-      parties: [
-        { label: 'Client', address: '0x0000000000000000000000000000000000000001' },
-        { label: 'Freelancer', address: '0x0000000000000000000000000000000000000002' },
-      ],
-      totalValue: 0,
-      currency: 'USD',
-      status: 'Pending',
-      createdAt: new Date().toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-      }),
-      milestoneCount: 0,
-    };
-
-    saveContract(stub);
-    // Re-read storage so the component reflects the persisted state.
+  const handleFormSuccess = useCallback(() => {
     setContracts(listContracts());
+    setShowForm(false);
+  }, []);
+
+  /** Closes the form without making any changes. */
+  const handleFormCancel = useCallback(() => {
+    setShowForm(false);
   }, []);
 
   return (
     <main className="min-h-screen p-8">
       <h1 className="text-2xl font-bold mb-6">Contracts</h1>
-      {contracts.length === 0 ? (
+
+      {showForm && (
+        <div className="mb-8">
+          <CreateContractForm
+            onSuccess={handleFormSuccess}
+            onCancel={handleFormCancel}
+          />
+        </div>
+      )}
+
+      {!showForm && contracts.length === 0 && (
         <EmptyState
           illustration="contracts"
           title="No contracts found"
@@ -54,24 +54,38 @@ const ContractsPage: React.FC = () => {
           actionLabel="Create Contract"
           onAction={handleCreateContract}
         />
-      ) : (
-        // TODO: Replace with a proper ContractSummary list component.
-        <ul className="space-y-4">
-          {contracts.map((contract, idx) => (
-            <li
-              key={`${contract.contractName}-${idx}`}
-              className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm"
+      )}
+
+      {!showForm && contracts.length > 0 && (
+        <>
+          <div className="mb-4 flex justify-end">
+            <button
+              type="button"
+              onClick={handleCreateContract}
+              className="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
             >
-              <p className="font-semibold text-slate-900">{contract.contractName}</p>
-              <p className="text-sm text-slate-500">
-                {contract.status} · Created {contract.createdAt}
-              </p>
-            </li>
-          ))}
-        </ul>
+              Create Contract
+            </button>
+          </div>
+          {/* TODO: Replace with a proper ContractSummary list component. */}
+          <ul className="space-y-4">
+            {contracts.map((contract, idx) => (
+              <li
+                key={`${contract.contractName}-${idx}`}
+                className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm"
+              >
+                <p className="font-semibold text-slate-900">{contract.contractName}</p>
+                <p className="text-sm text-slate-500">
+                  {contract.status} · Created {contract.createdAt}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </>
       )}
     </main>
   );
 };
 
 export default ContractsPage;
+

--- a/src/components/contracts/CreateContractForm.tsx
+++ b/src/components/contracts/CreateContractForm.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import React, { useState } from 'react';
+import { FormField } from '@/components/FormField';
+import { ErrorSummary } from '@/components/ErrorSummary';
+import { useToast } from '@/components/toast/toast-provider';
+import { saveContract } from '@/lib/repository';
+import { normalizeStellarAddress } from '@/lib/stellarAddress';
+import { validateContract } from '@/lib/validateContract';
+import type { ValidationError } from '@/lib/validateLogin';
+import type { Contract } from '@/types/domain';
+
+/**
+ * Props for the `CreateContractForm` component.
+ */
+export interface CreateContractFormProps {
+  /**
+   * Called with the newly constructed and persisted `Contract` object
+   * immediately after a successful form submission.
+   * The parent is responsible for updating its own state (e.g. re-reading
+   * from localStorage) and dismissing the form.
+   */
+  onSuccess: (contract: Contract) => void;
+  /**
+   * Called when the user presses the Cancel button without submitting.
+   * The parent is responsible for hiding the form.
+   */
+  onCancel: () => void;
+}
+
+/** Supported currency options presented in the currency selector. */
+const CURRENCY_OPTIONS = ['USD', 'XLM', 'EUR', 'GBP'] as const;
+
+/**
+ * `CreateContractForm` — an accessible, validated inline form for creating
+ * a new TalentTrust escrow contract.
+ *
+ * Accessibility contract:
+ * - The form is labelled by a visible `<h2>` via `aria-labelledby`.
+ * - Every field is wrapped in `FormField`, which wires `<label>`,
+ *   `aria-invalid`, and `aria-describedby` automatically.
+ * - On validation failure, `ErrorSummary` is rendered and auto-focused
+ *   via its own internal `useEffect`, moving screen reader focus to the
+ *   error digest without an explicit `ref` here.
+ * - Success is communicated through a polite `useToast` notification;
+ *   no `alert()` is used.
+ */
+const CreateContractForm: React.FC<CreateContractFormProps> = ({ onSuccess, onCancel }) => {
+  const { showSuccess } = useToast();
+
+  const [contractName, setContractName] = useState('');
+  const [freelancerAddress, setFreelancerAddress] = useState('');
+  const [totalValue, setTotalValue] = useState('');
+  const [currency, setCurrency] = useState<string>(CURRENCY_OPTIONS[0]);
+  const [errors, setErrors] = useState<ValidationError[]>([]);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const validationErrors = validateContract({
+      contractName,
+      freelancerAddress,
+      totalValue,
+      currency,
+    });
+
+    if (validationErrors.length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    // Clear any previous errors before persisting.
+    setErrors([]);
+
+    const contract: Contract = {
+      contractName: contractName.trim(),
+      parties: [
+        { label: 'Client', address: 'TalentTrust Client' },
+        { label: 'Freelancer', address: normalizeStellarAddress(freelancerAddress) },
+      ],
+      totalValue: parseFloat(totalValue),
+      currency,
+      status: 'Pending',
+      createdAt: new Date().toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      }),
+      milestoneCount: 0,
+    };
+
+    saveContract(contract);
+    showSuccess({ title: 'Contract created', description: `"${contract.contractName}" has been saved.` });
+    onSuccess(contract);
+  };
+
+  const inputClass =
+    'w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition';
+
+  return (
+    <section
+      aria-labelledby="create-contract-heading"
+      className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+    >
+      <h2
+        id="create-contract-heading"
+        className="text-xl font-semibold text-slate-900 mb-6"
+      >
+        Create a new contract
+      </h2>
+
+      <ErrorSummary errors={errors} />
+
+      <form onSubmit={handleSubmit} noValidate>
+        <FormField
+          id="contractName"
+          label="Contract name"
+          error={errors.find((e) => e.fieldId === 'contractName')?.message}
+          required
+        >
+          <input
+            type="text"
+            value={contractName}
+            onChange={(e) => setContractName(e.target.value)}
+            placeholder="e.g. Website Redesign"
+            autoComplete="off"
+            className={inputClass}
+          />
+        </FormField>
+
+        <FormField
+          id="freelancerAddress"
+          label="Freelancer Stellar address"
+          helperText="Must be a valid Stellar public key starting with G"
+          error={errors.find((e) => e.fieldId === 'freelancerAddress')?.message}
+          required
+        >
+          <input
+            type="text"
+            value={freelancerAddress}
+            onChange={(e) => setFreelancerAddress(e.target.value)}
+            placeholder="GABC…"
+            autoComplete="off"
+            className={`${inputClass} font-mono`}
+          />
+        </FormField>
+
+        <FormField
+          id="totalValue"
+          label="Total value"
+          error={errors.find((e) => e.fieldId === 'totalValue')?.message}
+          required
+        >
+          <input
+            type="number"
+            value={totalValue}
+            onChange={(e) => setTotalValue(e.target.value)}
+            placeholder="0.00"
+            min="0.01"
+            step="any"
+            className={inputClass}
+          />
+        </FormField>
+
+        <FormField
+          id="currency"
+          label="Currency"
+          error={errors.find((e) => e.fieldId === 'currency')?.message}
+          required
+        >
+          <select
+            value={currency}
+            onChange={(e) => setCurrency(e.target.value)}
+            className={inputClass}
+          >
+            {CURRENCY_OPTIONS.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </FormField>
+
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+          <button
+            type="submit"
+            className="rounded-2xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          >
+            Create Contract
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-2xl border border-slate-300 bg-white px-6 py-2.5 text-sm font-semibold text-slate-900 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+};
+
+export default CreateContractForm;

--- a/src/components/contracts/__tests__/CreateContractForm.test.tsx
+++ b/src/components/contracts/__tests__/CreateContractForm.test.tsx
@@ -67,10 +67,10 @@ describe('CreateContractForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByRole('alert', { name: /there is a problem/i })).toBeInTheDocument();
     });
 
-    const summary = screen.getByRole('alert');
+    const summary = screen.getByRole('alert', { name: /there is a problem/i });
     expect(summary).toHaveTextContent(/contract name is required/i);
     expect(summary).toHaveTextContent(/freelancer address is required/i);
     expect(summary).toHaveTextContent(/total value must be a positive number/i);
@@ -94,7 +94,7 @@ describe('CreateContractForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(screen.getByRole('alert', { name: /there is a problem/i })).toHaveTextContent(
         /must be a valid stellar g\.\.\. address/i
       );
     });
@@ -117,7 +117,7 @@ describe('CreateContractForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(screen.getByRole('alert', { name: /there is a problem/i })).toHaveTextContent(
         /total value must be a positive number/i
       );
     });
@@ -140,7 +140,7 @@ describe('CreateContractForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(
+      expect(screen.getByRole('alert', { name: /there is a problem/i })).toHaveTextContent(
         /total value must be a positive number/i
       );
     });
@@ -186,7 +186,7 @@ describe('CreateContractForm', () => {
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
     // No error summary should be visible.
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert', { name: /there is a problem/i })).not.toBeInTheDocument();
   });
 
   it('passes the correctly shaped Contract to onSuccess', async () => {
@@ -227,7 +227,7 @@ describe('CreateContractForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByRole('alert', { name: /there is a problem/i })).toBeInTheDocument();
     });
 
     const links = screen.getAllByRole('link');

--- a/src/components/contracts/__tests__/CreateContractForm.test.tsx
+++ b/src/components/contracts/__tests__/CreateContractForm.test.tsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import CreateContractForm from '../CreateContractForm';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+  }),
+}));
+
+jest.mock('@/lib/repository', () => ({
+  saveContract: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A valid Stellar public key for use in tests. */
+const VALID_ADDRESS = 'GABC' + 'A'.repeat(52); // 56 chars, starts with G, base32
+
+const onSuccess = jest.fn();
+const onCancel = jest.fn();
+
+function renderForm() {
+  return render(<CreateContractForm onSuccess={onSuccess} onCancel={onCancel} />);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CreateContractForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all four fields and both action buttons', () => {
+    renderForm();
+
+    expect(screen.getByLabelText(/contract name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/freelancer stellar address/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/total value/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/currency/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create contract/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it('calls onCancel when the Cancel button is clicked', () => {
+    renderForm();
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('shows an ErrorSummary with all required-field errors on empty submit', async () => {
+    renderForm();
+    fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    const summary = screen.getByRole('alert');
+    expect(summary).toHaveTextContent(/contract name is required/i);
+    expect(summary).toHaveTextContent(/freelancer address is required/i);
+    expect(summary).toHaveTextContent(/total value must be a positive number/i);
+
+    // onSuccess must NOT fire on a validation failure.
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('shows a validation error for an invalid Stellar address', async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText(/contract name/i), {
+      target: { value: 'Design Sprint' },
+    });
+    fireEvent.change(screen.getByLabelText(/freelancer stellar address/i), {
+      target: { value: 'INVALID_ADDRESS' },
+    });
+    fireEvent.change(screen.getByLabelText(/total value/i), {
+      target: { value: '1000' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /must be a valid stellar g\.\.\. address/i
+      );
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('shows a validation error for a non-positive total value', async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText(/contract name/i), {
+      target: { value: 'Design Sprint' },
+    });
+    fireEvent.change(screen.getByLabelText(/freelancer stellar address/i), {
+      target: { value: VALID_ADDRESS },
+    });
+    fireEvent.change(screen.getByLabelText(/total value/i), {
+      target: { value: '-50' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /total value must be a positive number/i
+      );
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('shows a validation error for a zero total value', async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText(/contract name/i), {
+      target: { value: 'Design Sprint' },
+    });
+    fireEvent.change(screen.getByLabelText(/freelancer stellar address/i), {
+      target: { value: VALID_ADDRESS },
+    });
+    fireEvent.change(screen.getByLabelText(/total value/i), {
+      target: { value: '0' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /total value must be a positive number/i
+      );
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('marks invalid fields with aria-invalid="true"', async () => {
+    renderForm();
+    fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/contract name/i)).toHaveAttribute('aria-invalid', 'true');
+      expect(screen.getByLabelText(/freelancer stellar address/i)).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+      expect(screen.getByLabelText(/total value/i)).toHaveAttribute('aria-invalid', 'true');
+    });
+  });
+
+  it('calls onSuccess and showSuccess toast on a valid submission', async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText(/contract name/i), {
+      target: { value: 'Design Sprint' },
+    });
+    fireEvent.change(screen.getByLabelText(/freelancer stellar address/i), {
+      target: { value: VALID_ADDRESS },
+    });
+    fireEvent.change(screen.getByLabelText(/total value/i), {
+      target: { value: '5000' },
+    });
+    // Currency already defaults to USD — no interaction needed.
+
+    fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+    await waitFor(() => {
+      expect(mockShowSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Contract created' })
+      );
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    // No error summary should be visible.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('passes the correctly shaped Contract to onSuccess', async () => {
+    const { saveContract } = await import('@/lib/repository');
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText(/contract name/i), {
+      target: { value: 'Design Sprint' },
+    });
+    fireEvent.change(screen.getByLabelText(/freelancer stellar address/i), {
+      target: { value: VALID_ADDRESS },
+    });
+    fireEvent.change(screen.getByLabelText(/total value/i), {
+      target: { value: '2500' },
+    });
+    // Keep default currency (USD).
+
+    fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+
+    expect(saveContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contractName: 'Design Sprint',
+        totalValue: 2500,
+        currency: 'USD',
+        status: 'Pending',
+        milestoneCount: 0,
+        parties: expect.arrayContaining([
+          expect.objectContaining({ label: 'Freelancer', address: VALID_ADDRESS }),
+        ]),
+      })
+    );
+  });
+
+  it('ErrorSummary anchor links point to the corresponding field ids', async () => {
+    renderForm();
+    fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    const links = screen.getAllByRole('link');
+    const hrefs = links.map((l) => l.getAttribute('href'));
+    expect(hrefs).toContain('#contractName');
+    expect(hrefs).toContain('#freelancerAddress');
+    expect(hrefs).toContain('#totalValue');
+  });
+});

--- a/src/lib/validateContract.ts
+++ b/src/lib/validateContract.ts
@@ -1,0 +1,71 @@
+import { ValidationError } from './validateLogin';
+import { isValidStellarAddress } from './stellarAddress';
+
+/**
+ * The raw string values captured from the Create Contract form fields.
+ * All values are strings because HTML inputs always yield strings.
+ */
+export interface ContractFormValues {
+  /** The display name for the contract. */
+  contractName: string;
+  /** The freelancer's Stellar public key (G... address). */
+  freelancerAddress: string;
+  /**
+   * The total escrow value as a string from the number input.
+   * Parsed to a float during validation; kept as a string here to
+   * mirror the raw DOM value without pre-transforming it.
+   */
+  totalValue: string;
+  /** The ISO 4217 currency code or blockchain token symbol (e.g. "USD", "XLM"). */
+  currency: string;
+}
+
+/**
+ * Validates the Create Contract form fields.
+ *
+ * Rules:
+ * - `contractName`: required (non-empty after trim).
+ * - `freelancerAddress`: required and must pass `isValidStellarAddress` —
+ *   i.e. exactly 56 characters, starts with "G", base32 alphabet only.
+ * - `totalValue`: required and must parse as a finite number greater than zero.
+ * - `currency`: required (non-empty after trim).
+ *
+ * The function is intentionally pure and side-effect-free so it can be
+ * called from both the form component and unit tests without any React context.
+ *
+ * Time complexity:  O(1) — the field count is fixed at 4; `isValidStellarAddress`
+ *                   runs a single regex test on a max-56-char string.
+ * Space complexity: O(1) — the returned errors array is bounded by the fixed
+ *                   number of fields.
+ *
+ * @param values - The raw string values from the form inputs.
+ * @returns An array of `ValidationError` objects. An empty array means the
+ *          form is valid and can be submitted.
+ */
+export function validateContract(values: ContractFormValues): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (!values.contractName.trim()) {
+    errors.push({ fieldId: 'contractName', message: 'Contract name is required' });
+  }
+
+  if (!values.freelancerAddress.trim()) {
+    errors.push({ fieldId: 'freelancerAddress', message: 'Freelancer address is required' });
+  } else if (!isValidStellarAddress(values.freelancerAddress)) {
+    errors.push({
+      fieldId: 'freelancerAddress',
+      message: 'Freelancer address must be a valid Stellar G... address',
+    });
+  }
+
+  const parsed = parseFloat(values.totalValue);
+  if (!values.totalValue.trim() || isNaN(parsed) || !isFinite(parsed) || parsed <= 0) {
+    errors.push({ fieldId: 'totalValue', message: 'Total value must be a positive number' });
+  }
+
+  if (!values.currency.trim()) {
+    errors.push({ fieldId: 'currency', message: 'Currency is required' });
+  }
+
+  return errors;
+}

--- a/src/test-utils/a11y.tsx
+++ b/src/test-utils/a11y.tsx
@@ -1,12 +1,13 @@
 import { render, RenderOptions } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import React from 'react';
+import { expect } from '@jest/globals';
 
 export { axe };
 
 export async function assertNoA11yViolations(container: HTMLElement) {
   const results = await axe(container);
-  expect(results).toHaveNoViolations();
+  expect(results.violations).toHaveLength(0);
 }
 
 export function renderWithA11y(ui: React.ReactElement, options?: RenderOptions) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,10 +27,7 @@
         "./src/*"
       ]
     },
-    "types": [
-      "jest",
-      "@testing-library/jest-dom"
-    ]
+    "types": []
   },
   "include": [
     "next-env.d.ts",
@@ -45,5 +42,8 @@
     "jest.setup.js",
     "**/*.test.ts",
     "**/*.test.tsx"
+  ],
+  "references": [
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "types": ["jest", "@testing-library/jest-dom"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "jest.setup.ts",
+    "jest.setup.js"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
closes #80 

SUMMARY OF CHANGES

This PR implements the Create Contract Form feature (Issue #80),
delivering a fully accessible, client-side-validated inline form
for creating TalentTrust escrow contracts.

##REASON FOR CHANGES
Issue #80 required a contract creation form that meets WCAG 2.1 AA
accessibility standards. Native browser validation (e.g. required,
type="number" popups) is inconsistent across assistive technologies,
so all validation is handled client-side with explicit ARIA wiring
to ensure a reliable screen reader experience.