### PR TITLE
Security/headers referrer coop corp

### DIFF
--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -11,9 +11,37 @@ This project sets HTTP response headers via the `headers()` function in
 | `X-Frame-Options` | `DENY` | Prevents clickjacking (legacy; also covered by CSP `frame-ancestors`) |
 | `X-Content-Type-Options` | `nosniff` | Stops MIME-type sniffing |
 | `Referrer-Policy` | `strict-origin-when-cross-origin` | Sends only the origin (not full URL) on cross-origin nav |
+| `Cross-Origin-Opener-Policy` | `same-origin` | Isolates the top-level browsing context from cross-origin windows and popups |
+| `Cross-Origin-Resource-Policy` | `same-origin` | Stops other origins from embedding or hotlinking app-served resources |
 | `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Enforces HTTPS for 1 year (ignored by browsers on localhost per RFC 6797) |
 | `X-Permitted-Cross-Domain-Policies` | `none` | Blocks Adobe Flash/PDF cross-domain requests (bonus hardening) |
 | `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disables sensitive browser features app-wide (bonus hardening) |
+
+## Cross-origin hardening notes
+
+`Referrer-Policy: strict-origin-when-cross-origin` is intentionally retained.
+It preserves same-origin analytics/debuggability while reducing cross-origin
+URL leakage to the origin only.
+
+`Cross-Origin-Opener-Policy: same-origin` narrows the browsing-context group to
+same-origin documents. That reduces the cross-origin window surface area and is
+safe for the current app because the repo does not show popup-based auth or
+cross-origin window messaging requirements.
+
+`Cross-Origin-Resource-Policy: same-origin` is the strongest safe default for
+this app today. The project serves its own icons, manifest, and social preview
+assets from the same origin, and the repo does not indicate any intentional
+cross-site embedding or third-party hotlinking requirement.
+
+If the app later adds popup auth, same-site asset sharing, or third-party
+embeds, revisit COOP/CORP together rather than weakening only one header.
+
+## About Subresource Integrity
+
+This hardening pass is limited to response headers in `next.config.js`. It does
+not add HTML `integrity` attributes or asset-pipeline Subresource Integrity
+(SRI) generation for scripts/styles. That would be a separate change with
+different build and rendering implications.
 
 ## Content-Security-Policy
 

--- a/next.config.js
+++ b/next.config.js
@@ -42,16 +42,30 @@ const nextConfig = {
     root: __dirname,
   },
 
+  /**
+   * Apply baseline security headers to every response.
+   * Revisit COOP/CORP if the app later adds popup auth flows,
+   * cross-site asset sharing, or third-party embeds.
+   */
   async headers() {
     return [
       {
         // Apply security headers to every route
         source: '/(.*)',
         headers: [
+          // Restrict resource origins without changing the existing dev/prod CSP behavior.
           { key: 'Content-Security-Policy', value: cspHeader },
+          // Legacy clickjacking protection for browsers that do not enforce frame-ancestors.
           { key: 'X-Frame-Options', value: 'DENY' },
+          // Prevent MIME sniffing so assets are interpreted as declared.
           { key: 'X-Content-Type-Options', value: 'nosniff' },
+          // Keep full referrers on same-origin navigation and trim cross-origin referrers to origin only.
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          // Isolate the top-level browsing context from cross-origin windows and popups.
+          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+          // Prevent other origins from embedding or hotlinking app-served assets.
+          { key: 'Cross-Origin-Resource-Policy', value: 'same-origin' },
+          // Enforce HTTPS in supported browsers once the site is loaded over TLS.
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
 
           // Bonus hardening headers (not part of the original spec but

--- a/src/app/__tests__/csp.test.ts
+++ b/src/app/__tests__/csp.test.ts
@@ -7,7 +7,7 @@ async function loadHeadersForEnv(nodeEnv: string) {
   process.env.NODE_ENV = nodeEnv;
   jest.resetModules();
 
-  const nextConfig = require('../../../../next.config');
+  const nextConfig = require('../../../next.config');
   return nextConfig.headers();
 }
 

--- a/src/app/__tests__/csp.test.ts
+++ b/src/app/__tests__/csp.test.ts
@@ -1,5 +1,19 @@
-// src/app/__tests__/csp.test.ts
-import { headers as getHeaders } from "../../../../next.config";
+type HeaderEntry = {
+  key: string;
+  value: string;
+};
+
+async function loadHeadersForEnv(nodeEnv: string) {
+  process.env.NODE_ENV = nodeEnv;
+  jest.resetModules();
+
+  const nextConfig = require('../../../../next.config');
+  return nextConfig.headers();
+}
+
+function getHeaderMap(headers: HeaderEntry[]) {
+  return new Map(headers.map(header => [header.key, header.value]));
+}
 
 describe('Content Security Policy', () => {
   const originalEnv = process.env.NODE_ENV;
@@ -9,25 +23,38 @@ describe('Content Security Policy', () => {
   });
 
   test('development includes unsafe-eval and unsafe-inline', async () => {
-    process.env.NODE_ENV = 'development';
-    // Re-import to pick up new env
-    const result = await (await import('../../../../next.config')).default.headers();
-    const cspHeader = result[0].headers.find((h: any) => h.key === 'Content-Security-Policy');
+    const result = await loadHeadersForEnv('development');
+    const headerMap = getHeaderMap(result[0].headers);
+    const cspHeader = headerMap.get('Content-Security-Policy');
+
     expect(cspHeader).toBeDefined();
-    const value: string = cspHeader.value;
+    const value = cspHeader as string;
     expect(value).toContain("script-src 'self' 'unsafe-eval'");
     expect(value).toContain("style-src 'self' 'unsafe-inline'");
   });
 
   test('production omits unsafe-eval and unsafe-inline', async () => {
-    process.env.NODE_ENV = 'production';
-    const result = await (await import('../../../../next.config')).default.headers();
-    const cspHeader = result[0].headers.find((h: any) => h.key === 'Content-Security-Policy');
+    const result = await loadHeadersForEnv('production');
+    const headerMap = getHeaderMap(result[0].headers);
+    const cspHeader = headerMap.get('Content-Security-Policy');
+
     expect(cspHeader).toBeDefined();
-    const value: string = cspHeader.value;
+    const value = cspHeader as string;
     expect(value).toContain("script-src 'self'");
     expect(value).not.toContain("unsafe-eval");
     expect(value).toContain("style-src 'self'");
     expect(value).not.toContain("unsafe-inline");
+  });
+
+  test('global security headers include referrer and cross-origin hardening', async () => {
+    const result = await loadHeadersForEnv('production');
+
+    expect(result[0].source).toBe('/(.*)');
+
+    const headerMap = getHeaderMap(result[0].headers);
+    expect(headerMap.get('Content-Security-Policy')).toBeDefined();
+    expect(headerMap.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    expect(headerMap.get('Cross-Origin-Opener-Policy')).toBe('same-origin');
+    expect(headerMap.get('Cross-Origin-Resource-Policy')).toBe('same-origin');
   });
 });


### PR DESCRIPTION
## Description

Hardens the app-wide security headers configured in `next.config.js` without changing the existing CSP behavior.

This PR:
- adds `Cross-Origin-Opener-Policy: same-origin`
- adds `Cross-Origin-Resource-Policy: same-origin`
- preserves `Referrer-Policy: strict-origin-when-cross-origin`
- expands automated tests to assert the header contract by name
- documents the new headers and rationale in `docs/security-headers.md`
- adds inline comments in `next.config.js` for future maintainers

Closes #235

## Type of Change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [x] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

Updated `src/app/__tests__/csp.test.ts` to cover:
- development CSP still includes `unsafe-eval` and `unsafe-inline`
- production CSP still omits `unsafe-eval` and `unsafe-inline`
- global headers include:
  - `Content-Security-Policy`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `Cross-Origin-Opener-Policy: same-origin`
  - `Cross-Origin-Resource-Policy: same-origin`

Also ran:
- `npm run lint` ✅
- `npm test` ✅
- `npm run build`  ✅

---

## Accessibility & Security Notes

### Accessibility

N/A - no UI changes.

### Security

This PR directly hardens response headers for all routes. It reduces cross-origin attack surface by isolating the browsing context with COOP and preventing cross-origin embedding/hotlinking of app-served resources with CORP. It preserves the existing CSP behavior and keeps the current referrer policy in place to reduce cross-origin URL leakage.