### PR TITLE
feat: announce per-party copied state in ContractSummary

### DIFF
--- a/docs/components/ContractSummary.md
+++ b/docs/components/ContractSummary.md
@@ -26,4 +26,5 @@ The component supports copying the full address of any party to the system clipb
 - **Toast Notifications**:
   - Displays a success toast upon successful copy.
   - Displays an error toast if browser clipboard API access fails or is rejected.
-- **Accessibility**: The copy control is a standard `<button>` with an explicit `aria-label` identifying the target party (e.g., `Copy Client address to clipboard`), ensuring compatibility with screen readers.
+- **Accessibility**: The copy control is a standard `<button>` with an explicit `aria-label` identifying the target party (e.g., `Copy Client address to clipboard`).
+  When a copy succeeds, the control updates its accessible name to reflect the copied state (e.g., `Client address copied`) for direct screen reader confirmation.

--- a/src/components/ContractSummary.tsx
+++ b/src/components/ContractSummary.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import StatusBadge, { StatusType } from './StatusBadge';
 import { truncateAddress } from '@/lib/truncateAddress';
 import { usePreferences } from '@/lib/preferences';
@@ -33,6 +33,7 @@ const ContractSummary = ({
   const { formatAmount } = usePreferences();
   const { showSuccess, showError } = useToast();
   const [copiedAddress, setCopiedAddress] = useState<string | null>(null);
+  const copyResetTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const formattedValue = formatAmount(totalValue, currency);
 
@@ -48,6 +49,10 @@ const ContractSummary = ({
    *   reverting it back to null after 2 seconds.
    * - Triggers a success toast on successful clipboard write.
    * - Triggers an error toast on any clipboard write failures.
+   *
+   * This function also ensures the button's accessible name reflects the
+   * temporary copied state so that assistive technology users perceive the
+   * per-party confirmation directly on the control.
    *
    * @param address - The full, non-truncated wallet address to copy.
    */
@@ -67,8 +72,14 @@ const ContractSummary = ({
         title: 'Address copied',
         description: 'The address has been successfully copied to your clipboard.',
       });
-      setTimeout(() => {
+
+      if (copyResetTimeout.current) {
+        clearTimeout(copyResetTimeout.current);
+      }
+
+      copyResetTimeout.current = setTimeout(() => {
         setCopiedAddress(null);
+        copyResetTimeout.current = null;
       }, 2000);
     } catch {
       showError({
@@ -77,6 +88,14 @@ const ContractSummary = ({
       });
     }
   };
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimeout.current) {
+        clearTimeout(copyResetTimeout.current);
+      }
+    };
+  }, []);
 
   return (
     <section
@@ -121,8 +140,12 @@ const ContractSummary = ({
                   <button
                     onClick={() => handleCopy(party.address)}
                     className="flex-shrink-0 rounded-lg p-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    aria-label={`Copy ${party.label} address to clipboard`}
-                    title="Copy address"
+                    aria-label={
+                      isCopied
+                        ? `${party.label} address copied`
+                        : `Copy ${party.label} address to clipboard`
+                    }
+                    title={isCopied ? `${party.label} address copied` : 'Copy address'}
                   >
                     {isCopied ? (
                       <svg className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/components/__tests__/ContractSummary.test.tsx
+++ b/src/components/__tests__/ContractSummary.test.tsx
@@ -191,7 +191,9 @@ describe('ContractSummary', () => {
       const writeText = mockClipboard();
       renderWithPrefs(<ContractSummary {...defaultProps} />);
 
-      const copyBtn = screen.getByRole('button', { name: /copy client address to clipboard/i });
+      const copyBtn = screen.getByRole('button', {
+        name: /copy client address to clipboard/i,
+      });
       expect(copyBtn).toBeInTheDocument();
       expect(copyBtn).toHaveAttribute('title', 'Copy address');
 
@@ -207,26 +209,91 @@ describe('ContractSummary', () => {
       );
     });
 
-    it('shows checkmark icon and reverts after 2 seconds', async () => {
+    it('updates the accessible button name when copied and reverts after 2 seconds', async () => {
       mockClipboard();
       renderWithPrefs(<ContractSummary {...defaultProps} />);
 
-      const copyBtn = screen.getByRole('button', { name: /copy client address to clipboard/i });
-      const copyIconPathBefore = copyBtn.querySelector('path')?.getAttribute('d');
+      const copyBtn = screen.getByRole('button', {
+        name: /copy client address to clipboard/i,
+      });
+      expect(copyBtn).toBeInTheDocument();
 
       await act(async () => {
         fireEvent.click(copyBtn);
       });
 
-      const checkPath = copyBtn.querySelector('path[d="M5 13l4 4L19 7"]');
-      expect(checkPath).toBeInTheDocument();
+      const copiedButton = screen.getByRole('button', {
+        name: /client address copied/i,
+      });
+      expect(copiedButton).toBeInTheDocument();
+      expect(copiedButton).toHaveAttribute('title', 'Client address copied');
 
       await act(async () => {
         jest.advanceTimersByTime(2000);
       });
 
-      const copyIconPathAfter = copyBtn.querySelector('path')?.getAttribute('d');
-      expect(copyIconPathAfter).toEqual(copyIconPathBefore);
+      expect(
+        screen.getByRole('button', {
+          name: /copy client address to clipboard/i,
+        })
+      ).toBeInTheDocument();
+    });
+
+    it('clears the pending timeout when the same address is copied again before revert', async () => {
+      const writeText = mockClipboard();
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      renderWithPrefs(<ContractSummary {...defaultProps} />);
+
+      const copyBtn = screen.getByRole('button', {
+        name: /copy client address to clipboard/i,
+      });
+
+      await act(async () => {
+        fireEvent.click(copyBtn);
+      });
+
+      await act(async () => {
+        fireEvent.click(copyBtn);
+      });
+
+      expect(writeText).toHaveBeenCalledTimes(2);
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+      expect(
+        screen.getByRole('button', {
+          name: /client address copied/i,
+        })
+      ).toBeInTheDocument();
+
+      await act(async () => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      expect(
+        screen.getByRole('button', {
+          name: /copy client address to clipboard/i,
+        })
+      ).toBeInTheDocument();
+
+      clearTimeoutSpy.mockRestore();
+    });
+
+    it('clears the pending timeout when the component unmounts', async () => {
+      mockClipboard();
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      const { unmount } = renderWithPrefs(<ContractSummary {...defaultProps} />);
+
+      const copyBtn = screen.getByRole('button', {
+        name: /copy client address to clipboard/i,
+      });
+
+      await act(async () => {
+        fireEvent.click(copyBtn);
+      });
+
+      unmount();
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+      clearTimeoutSpy.mockRestore();
     });
 
     it('shows error toast when copying to clipboard fails', async () => {


### PR DESCRIPTION
## Description

<!-- Summarize the changes in this PR and the motivation behind them. -->

Closes #247 

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [x] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage

- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [x] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

<!-- Briefly describe the test cases you added or updated, and any manual testing performed. -->
copy success and toast display
button accessible name updates to ["{label} address copied"](https://didactic-adventure-5rjwp59jjj9f49w6.github.dev/)
state reverts after 2 seconds
unsupported clipboard error path
repeated copy resets pending timeout
timeout cleanup on unmountcopy success and toast display
button accessible name updates to ["{label} address copied"](https://didactic-adventure-5rjwp59jjj9f49w6.github.dev/)
state reverts after 2 seconds
unsupported clipboard error path
repeated copy resets pending timeout
timeout cleanup on unmount
---

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->
Automated jest-axe audit run via [testA11y(...)](https://didactic-adventure-5rjwp59jjj9f49w6.github.dev/)
Added per-button accessible state so screen readers receive direct confirmation on the controAutomated jest-axe audit run via [testA11y(...)](https://didactic-adventure-5rjwp59jjj9f49w6.github.dev/)
Added per-button accessible state so screen readers receive direct confirmation on the contro

### Security

<!-- Does this PR touch authentication, authorization, wallet logic, API calls, or
     user-supplied input? Describe any security considerations or "N/A" if not applicable. -->
N/A