### PR TITLE
feat: enforce length and trim guards on the login form inputs (#234)

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -5,6 +5,10 @@ import { ToastProvider } from '@/components/toast/toast-provider';
 import { PreferencesProvider } from '@/lib/preferences';
 import { testA11y } from '@/test-utils/a11y';
 import userEvent from '@testing-library/user-event';
+import {
+  MAX_EMAIL_LENGTH,
+  MAX_PASSWORD_LENGTH,
+} from '@/lib/validateLogin';
 
 const renderWithProviders = (ui: React.ReactElement) => {
   return render(
@@ -364,6 +368,140 @@ describe('Home', () => {
     expect(
       screen.getByLabelText(/password/i),
     ).toBeVisible();
+  });
+
+  describe('input length & trim guards (issue #234)', () => {
+    it('applies the email maxLength attribute matching the validator ceiling', () => {
+      renderWithProviders(<Home />);
+      const emailInput = screen.getByLabelText(/Email/i);
+
+      expect(emailInput).toHaveAttribute('maxLength', String(MAX_EMAIL_LENGTH));
+      expect(MAX_EMAIL_LENGTH).toBe(254);
+    });
+
+    it('applies the password maxLength attribute matching the validator ceiling', () => {
+      renderWithProviders(<Home />);
+      const passwordInput = screen.getByLabelText(/Password/i);
+
+      expect(passwordInput).toHaveAttribute('maxLength', String(MAX_PASSWORD_LENGTH));
+      expect(MAX_PASSWORD_LENGTH).toBe(128);
+    });
+
+    it('trims whitespace around a valid email on submit and shows the success toast', async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(<Home />);
+
+      await user.type(
+        screen.getByLabelText(/Email/i),
+        '  test@example.com  ',
+      );
+      await user.type(
+        screen.getByLabelText(/Password/i),
+        'password123',
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: /sign in/i }),
+      );
+
+      // No alert role (no error summary rendered)
+      expect(
+        screen.queryByRole('alert', { name: /there is a problem/i }),
+      ).not.toBeInTheDocument();
+
+      const toast = screen.getByRole('status');
+      expect(
+        within(toast).getByText(/submitted successfully/i),
+      ).toBeInTheDocument();
+    });
+
+    it('rejects a whitespace-only email as the "required" error', async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(<Home />);
+
+      await user.type(
+        screen.getByLabelText(/Email/i),
+        '   ',
+      );
+      await user.type(
+        screen.getByLabelText(/Password/i),
+        'password123',
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: /sign in/i }),
+      );
+
+      // ErrorSummary surfaces the required error in the alert region
+      expect(
+        screen.getByRole('alert', { name: /there is a problem/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getAllByText('Email is required').length,
+      ).toBeGreaterThanOrEqual(2);
+    });
+
+    it('surfaces an over-length email error via ErrorSummary when the value exceeds the ceiling', async () => {
+      // We bypass the browser-level maxLength cap by setting the value via
+      // fireEvent.change (which mutates React state directly), then expect
+      // the validator to reject it.
+      const overlongEmail = `${'a'.repeat(MAX_EMAIL_LENGTH + 5)}@example.com`;
+      const user = userEvent.setup();
+
+      renderWithProviders(<Home />);
+
+      const emailInput = screen.getByLabelText(/Email/i);
+      const passwordInput = screen.getByLabelText(/Password/i);
+
+      fireEvent.change(emailInput, { target: { value: overlongEmail } });
+      fireEvent.change(passwordInput, { target: { value: 'password123' } });
+
+      await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+      const alert = screen.getByRole('alert', { name: /there is a problem/i });
+      expect(alert).toBeInTheDocument();
+      expect(
+        within(alert).getByText(/email must be no more than 254 characters/i),
+      ).toBeInTheDocument();
+
+      // The over-length message must also be available to the FormField for
+      // aria-describedby wiring (FormField renders the same error string).
+      expect(
+        screen.getAllByText(/email must be no more than 254 characters/i).length,
+      ).toBeGreaterThanOrEqual(2);
+
+      // The email input should be marked invalid.
+      expect(emailInput).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('surfaces an over-length password error via ErrorSummary when the value exceeds the ceiling', async () => {
+      const overlongPassword = 'a'.repeat(MAX_PASSWORD_LENGTH + 5);
+
+      renderWithProviders(<Home />);
+
+      const emailInput = screen.getByLabelText(/Email/i);
+      const passwordInput = screen.getByLabelText(/Password/i);
+
+      fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+      fireEvent.change(passwordInput, { target: { value: overlongPassword } });
+
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+      const alert = screen.getByRole('alert', { name: /there is a problem/i });
+      expect(alert).toBeInTheDocument();
+      expect(
+        within(alert).getByText(/password must be no more than 128 characters/i),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getAllByText(/password must be no more than 128 characters/i).length,
+      ).toBeGreaterThanOrEqual(2);
+
+      expect(passwordInput).toHaveAttribute('aria-invalid', 'true');
+    });
   });
 
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,11 @@ import { ToastDemo } from '@/components/toast/toast-demo';
 import { FormField } from '@/components/FormField';
 import { ErrorSummary } from '@/components/ErrorSummary';
 import { useToast } from '@/components/toast/toast-provider';
-import { validateLogin } from '@/lib/validateLogin';
+import {
+  MAX_EMAIL_LENGTH,
+  MAX_PASSWORD_LENGTH,
+  validateLogin,
+} from '@/lib/validateLogin';
 
 export default function Home() {
   const [email, setEmail] = useState('');
@@ -15,6 +19,8 @@ export default function Home() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    // `validateLogin` trims email and enforces both length ceilings, so a
+    // pasted value that exceeds the cap is rejected before any auth call.
     const newErrors = validateLogin(email, password);
     setErrors(newErrors);
 
@@ -58,6 +64,10 @@ export default function Home() {
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
+                // Security: cap pasted/typed input at MAX_EMAIL_LENGTH so the
+                // browser and the validator enforce the same ceiling. See
+                // `MAX_EMAIL_LENGTH` in src/lib/validateLogin.ts.
+                maxLength={MAX_EMAIL_LENGTH}
                 className="w-full px-4 py-2.5 rounded-xl border border-slate-200 bg-white text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500 transition-all shadow-sm"
                 placeholder="you@example.com"
               />
@@ -73,6 +83,10 @@ export default function Home() {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
+                // Security: cap pasted/typed input at MAX_PASSWORD_LENGTH. Mirrors
+                // the validator ceiling and prevents denial-of-service from
+                // arbitrarily long pasted secrets.
+                maxLength={MAX_PASSWORD_LENGTH}
                 className="w-full px-4 py-2.5 rounded-xl border border-slate-200 bg-white text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500 transition-all shadow-sm"
                 placeholder="••••••••"
               />

--- a/src/lib/validateLogin.test.ts
+++ b/src/lib/validateLogin.test.ts
@@ -1,4 +1,8 @@
-import { validateLogin } from './validateLogin';
+import {
+  MAX_EMAIL_LENGTH,
+  MAX_PASSWORD_LENGTH,
+  validateLogin,
+} from './validateLogin';
 
 describe('validateLogin', () => {
   it('should return no errors for valid inputs', () => {
@@ -40,5 +44,104 @@ describe('validateLogin', () => {
       { fieldId: 'email', message: 'Email is required' },
       { fieldId: 'password', message: 'Password must be at least 8 characters' },
     ]);
+  });
+
+  describe('length ceilings', () => {
+    it('exports MAX_EMAIL_LENGTH as 254 per RFC 5321', () => {
+      expect(MAX_EMAIL_LENGTH).toBe(254);
+    });
+
+    it('exports MAX_PASSWORD_LENGTH as 128', () => {
+      expect(MAX_PASSWORD_LENGTH).toBe(128);
+    });
+
+    it('trims surrounding whitespace from the email before validating', () => {
+      const errors = validateLogin('  test@example.com  ', 'password123');
+      expect(errors).toEqual([]);
+    });
+
+    it('treats a whitespace-only email as empty after trimming', () => {
+      const errors = validateLogin('     ', 'password123');
+      expect(errors).toEqual([
+        { fieldId: 'email', message: 'Email is required' },
+      ]);
+    });
+
+    it('treats an over-length trimmed email as over-length', () => {
+      const longEmail = `${'a'.repeat(MAX_EMAIL_LENGTH - '@example.com'.length + 5)}@example.com`;
+      expect(longEmail.length).toBeGreaterThan(MAX_EMAIL_LENGTH);
+      const errors = validateLogin(longEmail, 'password123');
+      expect(errors).toEqual([
+        {
+          fieldId: 'email',
+          message: `Email must be no more than ${MAX_EMAIL_LENGTH} characters`,
+        },
+      ]);
+    });
+
+    it('counts length against the trimmed email, not the raw input', () => {
+      // Padding only affects what we strip — the inner content is the over-length payload.
+      const paddedLongEmail = `   ${'a'.repeat(MAX_EMAIL_LENGTH - '@example.com'.length + 5)}@example.com   `;
+      const errors = validateLogin(paddedLongEmail, 'password123');
+      expect(errors).toEqual([
+        {
+          fieldId: 'email',
+          message: `Email must be no more than ${MAX_EMAIL_LENGTH} characters`,
+        },
+      ]);
+    });
+
+    it('accepts an email whose trimmed length equals the ceiling', () => {
+      const localPart = 'a'.repeat(MAX_EMAIL_LENGTH - '@example.com'.length);
+      const email = `${localPart}@example.com`;
+      expect(email.length).toBe(MAX_EMAIL_LENGTH);
+      const errors = validateLogin(email, 'password123');
+      expect(errors).toEqual([]);
+    });
+
+    it('rejects a password whose length exceeds MAX_PASSWORD_LENGTH', () => {
+      const longPassword = 'a'.repeat(MAX_PASSWORD_LENGTH + 1);
+      const errors = validateLogin('test@example.com', longPassword);
+      expect(errors).toEqual([
+        {
+          fieldId: 'password',
+          message: `Password must be no more than ${MAX_PASSWORD_LENGTH} characters`,
+        },
+      ]);
+    });
+
+    it('accepts a password whose length equals MAX_PASSWORD_LENGTH', () => {
+      const exactPassword = 'a'.repeat(MAX_PASSWORD_LENGTH);
+      const errors = validateLogin('test@example.com', exactPassword);
+      expect(errors).toEqual([]);
+    });
+
+    it('returns the over-length email error in preference to the format error', () => {
+      // Long email that ALSO lacks '@' — length check fires first.
+      const longEmailNoAt = 'a'.repeat(MAX_EMAIL_LENGTH + 10);
+      const errors = validateLogin(longEmailNoAt, 'password123');
+      expect(errors).toEqual([
+        {
+          fieldId: 'email',
+          message: `Email must be no more than ${MAX_EMAIL_LENGTH} characters`,
+        },
+      ]);
+    });
+
+    it('surfaces a per-field error for both fields when both are over-length', () => {
+      const longEmail = `${'a'.repeat(MAX_EMAIL_LENGTH - '@example.com'.length + 5)}@example.com`;
+      const longPassword = 'a'.repeat(MAX_PASSWORD_LENGTH + 5);
+      const errors = validateLogin(longEmail, longPassword);
+      expect(errors).toEqual([
+        {
+          fieldId: 'email',
+          message: `Email must be no more than ${MAX_EMAIL_LENGTH} characters`,
+        },
+        {
+          fieldId: 'password',
+          message: `Password must be no more than ${MAX_PASSWORD_LENGTH} characters`,
+        },
+      ]);
+    });
   });
 });

--- a/src/lib/validateLogin.ts
+++ b/src/lib/validateLogin.ts
@@ -1,4 +1,27 @@
 /**
+ * The maximum allowed length for an email address on the login form.
+ *
+ * Set to 254 characters per RFC 5321 §4.5.3.1, which is the longest
+ * legal email address deliverable on the public internet. The browser
+ * input layer (`maxLength`) and the validator both enforce this ceiling
+ * so a pathologically large paste cannot reach downstream
+ * validation, rendering, or auth code.
+ */
+export const MAX_EMAIL_LENGTH = 254;
+
+/**
+ * The maximum allowed length for a password on the login form.
+ *
+ * 128 characters is a defensive upper bound: bcrypt and Argon2 will
+ * silently truncate anything longer, so capping at the UI layer
+ * surfaces the constraint to the user instead of silently dropping
+ * characters. Combined with the existing 8-character minimum this
+ * matches common industry limits and prevents denial-of-service from
+ * arbitrarily large pasted secrets.
+ */
+export const MAX_PASSWORD_LENGTH = 128;
+
+/**
  * Represents a validation error for a specific form field.
  */
 export interface ValidationError {
@@ -10,27 +33,65 @@ export interface ValidationError {
 
 /**
  * Validates the email and password fields for the login form.
- * 
+ *
  * Rules:
- * - Email is required and must contain '@'
- * - Password is required and must be at least 8 characters
- * 
- * @param email - The email address string to validate.
- * @param password - The password string to validate.
- * @returns An array of validation errors, each containing the fieldId and the corresponding error message.
- *          Returns an empty array if all validations pass.
+ * - **Email**: required; trimmed of surrounding whitespace before
+ *   validation; must be no longer than {@link MAX_EMAIL_LENGTH}
+ *   characters after trimming; must contain `@`.
+ * - **Password**: required; must be no longer than
+ *   {@link MAX_PASSWORD_LENGTH} characters; must be at least 8
+ *   characters long.
+ *
+ * Validation order per field is **required → length → format**, so the
+ * most actionable error is surfaced first. A whitespace-only email
+ * (`"   "`) is treated as empty and surfaces `"Email is required"`,
+ * while a 300-character pasted email surfaces the over-length error
+ * before the `must be valid` error so the user is told to shorten the
+ * input rather than fix its shape.
+ *
+ * The function is pure and side-effect-free so it can be safely called
+ * from both the React form component and unit tests.
+ *
+ * @param email - The raw email string from the email input. Surrounding
+ *                whitespace is trimmed before validation.
+ * @param password - The raw password string from the password input.
+ *                  Passwords are **not** trimmed because leading or
+ *                  trailing spaces can be a deliberate part of the
+ *                  secret.
+ * @returns An array of validation errors, each containing the `fieldId`
+ *          and the corresponding error message. Returns an empty
+ *          array when the input passes every rule.
+ *
+ * @example
+ * ```ts
+ * validateLogin('  test@example.com  ', 'password123'); // []
+ * validateLogin('   ', 'password123');                  // [{ email: 'Email is required' }]
+ * validateLogin('a'.repeat(300), 'password123');        // [{ email: 'Email must be no more than 254 characters' }]
+ * ```
  */
 export function validateLogin(email: string, password: string): ValidationError[] {
   const errors: ValidationError[] = [];
 
-  if (!email) {
+  const trimmedEmail = email.trim();
+
+  if (!trimmedEmail) {
     errors.push({ fieldId: 'email', message: 'Email is required' });
-  } else if (!email.includes('@')) {
+  } else if (trimmedEmail.length > MAX_EMAIL_LENGTH) {
+    errors.push({
+      fieldId: 'email',
+      message: `Email must be no more than ${MAX_EMAIL_LENGTH} characters`,
+    });
+  } else if (!trimmedEmail.includes('@')) {
     errors.push({ fieldId: 'email', message: 'Email must be valid' });
   }
 
   if (!password) {
     errors.push({ fieldId: 'password', message: 'Password is required' });
+  } else if (password.length > MAX_PASSWORD_LENGTH) {
+    errors.push({
+      fieldId: 'password',
+      message: `Password must be no more than ${MAX_PASSWORD_LENGTH} characters`,
+    });
   } else if (password.length < 8) {
     errors.push({ fieldId: 'password', message: 'Password must be at least 8 characters' });
   }


### PR DESCRIPTION
Adds MAX_EMAIL_LENGTH=254 (RFC 5321) and MAX_PASSWORD_LENGTH=128 constants to src/lib/validateLogin.ts. The Home page now sets the matching maxLength HTML attribute on both email and password inputs, and validateLogin trims the email before validation while enforcing the same ceiling programmatically.

Validation order per field is required → length → format so the most actionable error is surfaced first. Over-length errors flow through both ErrorSummary and FormField wiring (aria-invalid/aria-describedby). Passwords are intentionally NOT trimmed because leading/trailing spaces can be a deliberate part of the secret.

Tests added in validateLogin.test.ts cover MAX_* constants, trim, whitespace-only, padded long input, exact-length boundaries, over-length, length-fires-before-format, per-field over-length errors.

Tests added in page.test.tsx cover maxLength attrs on inputs, trim success (success toast), whitespace-only treated as required, over-length email triggers ErrorSummary + FormField, over-length password likewise.

The FormField accessibility semantics are preserved exactly: no helperText is added, so the existing aria-describedby strict-equality assertions still hold.

Closes #234.

## Description

<!-- Summarize the changes in this PR and the motivation behind them. -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

<!-- Briefly describe the test cases you added or updated, and any manual testing performed. -->

---

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->

### Security

<!-- Does this PR touch authentication, authorization, wallet logic, API calls, or
     user-supplied input? Describe any security considerations or "N/A" if not applicable. -->

closes #234 