### PR TITLE
refactor: report repository storage failures via the central reporter

### DIFF
--- a/src/lib/__tests__/repository.test.ts
+++ b/src/lib/__tests__/repository.test.ts
@@ -9,7 +9,7 @@
  * 4. SSR context isolation — functions return [] safely when window is absent.
  * 5. Empty-store defaults — first read on a fresh store returns [].
  * 6. Multiple writes — each save is additive, not a full replacement.
- * 7. writeStore failure — localStorage.setItem throws; warn logged, no crash.
+ * 7. writeStore failure — localStorage.setItem throws; error reported, no crash.
  */
 
 import {
@@ -19,6 +19,7 @@ import {
   saveMilestone,
   STORAGE_KEY,
 } from '../repository';
+import { setErrorReporter } from '../errorReporter';
 import type { Contract } from '@/components/ContractSummary';
 import type { Milestone } from '@/components/MilestonesList';
 
@@ -207,24 +208,32 @@ describe('data isolation', () => {
 // ===========================================================================
 
 describe('corrupt data handling', () => {
+  let mockReporter: jest.Mock;
+
+  beforeEach(() => {
+    mockReporter = jest.fn();
+    setErrorReporter(mockReporter);
+  });
+
+  afterEach(() => {
+    setErrorReporter(null);
+  });
+
   it('returns [] for contracts when localStorage contains invalid JSON', () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
     seedRaw('%%%not-json%%%');
     expect(listContracts()).toEqual([]);
   });
 
   it('returns [] for milestones when localStorage contains invalid JSON', () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
     seedRaw('%%%not-json%%%');
     expect(listMilestones()).toEqual([]);
   });
 
-  it('logs a console.warn (not error) on parse failure', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  it('calls the error reporter on parse failure', () => {
     seedRaw('{invalid}');
     listContracts();
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0][0]).toMatch(/\[repository\]/);
+    expect(mockReporter).toHaveBeenCalledTimes(1);
+    expect(mockReporter.mock.calls[0][1]).toMatch(/\[repository\]/);
   });
 
   it('returns [] when stored value is a JSON string (not an object)', () => {
@@ -266,12 +275,21 @@ describe('corrupt data handling', () => {
   });
 
   it('does not throw even when localStorage.getItem throws', () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
     jest.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
       throw new Error('storage quota exceeded');
     });
     expect(() => listContracts()).not.toThrow();
     expect(listContracts()).toEqual([]);
+  });
+
+  it('reports the error via the central reporter when getItem throws', () => {
+    jest.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('storage quota exceeded');
+    });
+    listContracts();
+    expect(mockReporter).toHaveBeenCalledTimes(1);
+    expect(mockReporter.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(mockReporter.mock.calls[0][1]).toMatch(/\[repository\]/);
   });
 });
 
@@ -338,21 +356,30 @@ describe('SSR context isolation', () => {
 // ===========================================================================
 
 describe('write failure resilience', () => {
+  let mockReporter: jest.Mock;
+
+  beforeEach(() => {
+    mockReporter = jest.fn();
+    setErrorReporter(mockReporter);
+  });
+
+  afterEach(() => {
+    setErrorReporter(null);
+  });
+
   it('does not throw when localStorage.setItem throws', () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
     jest.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
       throw new DOMException('QuotaExceededError');
     });
     expect(() => saveContract(contractA)).not.toThrow();
   });
 
-  it('logs a console.warn when setItem throws', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  it('calls the error reporter when setItem throws', () => {
     jest.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
       throw new DOMException('QuotaExceededError');
     });
     saveContract(contractA);
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0][0]).toMatch(/\[repository\]/);
+    expect(mockReporter).toHaveBeenCalledTimes(1);
+    expect(mockReporter.mock.calls[0][1]).toMatch(/\[repository\]/);
   });
 });

--- a/src/lib/repository.ts
+++ b/src/lib/repository.ts
@@ -11,13 +11,14 @@
  * - **SSR-safe** — guards every storage access with a `typeof window` check so
  *   Next.js server-side builds never throw.
  * - **Resilient** — all reads are wrapped in try/catch; corrupt or missing data
- *   falls back to `[]` with a console warning rather than crashing.
+ *   falls back to `[]` with a report via the central error reporter rather than crashing.
  * - **Non-mutating** — callers own their data; this module never mutates the
  *   objects it receives or returns.
  */
 
 import type { Contract } from '@/types/domain';
 import type { Milestone } from '@/components/MilestonesList';
+import { reportError } from './errorReporter';
 
 // ---------------------------------------------------------------------------
 // Storage key & data shape
@@ -48,6 +49,9 @@ function isBrowser(): boolean {
 /**
  * Reads and parses the full persisted data object from localStorage.
  *
+ * On failure the error is forwarded to the central `reportError` reporter
+ * before falling back to the empty state.
+ *
  * @returns The parsed `AppData` object, or `EMPTY_DATA` on any failure
  *          (missing key, unparseable JSON, unexpected shape).
  */
@@ -65,16 +69,16 @@ function readStore(): AppData {
       milestones: Array.isArray(parsed.milestones) ? parsed.milestones : [],
     };
   } catch (err) {
-    console.warn(
-      '[repository] Failed to read from localStorage. Falling back to empty state.',
-      err,
-    );
+    reportError(err, '[repository] Failed to read from localStorage. Falling back to empty state.');
     return { ...EMPTY_DATA };
   }
 }
 
 /**
  * Serialises and writes the full data object back to localStorage.
+ *
+ * On failure the error is forwarded to the central `reportError` reporter.
+ * The call is a no-op in SSR contexts (no `window`).
  *
  * @param data - The complete `AppData` object to persist.
  */
@@ -84,7 +88,7 @@ function writeStore(data: AppData): void {
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
   } catch (err) {
-    console.warn('[repository] Failed to write to localStorage.', err);
+    reportError(err, '[repository] Failed to write to localStorage.');
   }
 }
 
@@ -97,7 +101,7 @@ function writeStore(data: AppData): void {
  *
  * Reads from localStorage and returns the stored array. If localStorage is
  * unavailable (SSR) or the stored value is corrupt, returns an empty array
- * `[]` and logs a console warning — it never throws.
+ * `[]` and reports the failure via the central error reporter — it never throws.
  *
  * @returns A new array of `Contract` objects (may be empty).
  *
@@ -147,7 +151,7 @@ export function saveContract(contract: Contract): void {
  *
  * Reads from localStorage and returns the stored array. If localStorage is
  * unavailable (SSR) or the stored value is corrupt, returns an empty array
- * `[]` and logs a console warning — it never throws.
+ * `[]` and reports the failure via the central error reporter — it never throws.
  *
  * @returns A new array of `Milestone` objects (may be empty).
  *


### PR DESCRIPTION
Closes #232 

# PR Summary

**Branch:** `refactor/repository-use-error-reporter`

##  Changes

### `src/lib/repository.ts`
* **Centralized Error Reporting:** Imported `{ reportError }` from `./errorReporter` (no circular dependency risk detected, as `errorReporter.ts` does not import from `repository.ts`).
* **Refactored Logging:** Replaced `console.warn(...)` instances with `reportError` inside:
  * `readStore`: `reportError(err, '[repository] Failed to read from localStorage. Falling back to empty state.')`
  * `writeStore`: `reportError(err, '[repository] Failed to write to localStorage.')`
* **Preserved Guardrails:** Maintained all existing SSR guards (`isBrowser()` checks) and empty-state fallbacks exactly as they were.
* **Documentation:** Updated JSDoc strings for `readStore`, `writeStore`, `listContracts`, and `listMilestones` to document the new centralized error reporting behavior.

### `src/lib/__tests__/repository.test.ts`
* **Test Refactoring:** Replaced old `console.warn` spy assertions with the `setErrorReporter(jest.fn())` pattern to verify the central reporter is correctly invoked on failures.
* **New Coverage:** Added a new unit test: `"reports the error via the central reporter when getItem throws"` (verifies the read failure path).
* **Descriptions:** Updated existing test descriptions to explicitly reference `reportError` instead of `console.warn`.
* **Status:** All 28 tests pass successfully.

---

##  Verification

* **`npm test`**: The repository suite passes completely (**28/28 tests passed**).
* **`npm run lint`**: No new lint errors introduced (14 pre-existing errors remain, unrelated to these changes).
* **`npm run build`**: Build passes outside of a pre-existing error in `WalletContext.tsx` (`missing safeStorage export`), which is completely unrelated to the repository logic.

---

##  Security

* **Production Safety:** No sensitive data is logged in production. The `reportError` mechanism defaults to a no-op when `NODE_ENV === 'production'`, matching the established security posture of the application's error reporter module.
