### PR TITLE
test(utils): add boundary and custom-length tests for truncateAddress

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The shared utility layer now includes lightweight Stellar address helpers in [sr
 
 - `isValidStellarAddress(value)` returns `true` only for a trimmed, uppercased value that looks like a Stellar public key: it starts with `G`, is exactly 56 characters long, and uses the base32 alphabet `A-Z` and `2-7`.
 - `normalizeStellarAddress(value)` trims whitespace and uppercases the value without throwing on invalid input.
+- `truncateAddress(value, prefixLength?, suffixLength?)` in [src/lib/truncateAddress.ts](src/lib/truncateAddress.ts) securely shortens addresses (or any string) by preserving the start and end, and inserting an ellipsis. Strings shorter than or equal to `prefixLength + suffixLength + 3` are returned untouched.
 - The display truncation path uses these helpers so clearly malformed addresses are treated as ordinary strings rather than being shortened as if they were valid keys.
 
 ## Authentication form validation and accessibility

--- a/src/lib/__tests__/truncateAddress.test.ts
+++ b/src/lib/__tests__/truncateAddress.test.ts
@@ -23,4 +23,42 @@ describe('truncateAddress', () => {
 
     expect(truncateAddress(validAddress)).toBe('GAAAAA...AAAA');
   });
+
+  describe('boundary conditions (prefixLength=6, suffixLength=4, threshold=13)', () => {
+    it('returns the unchanged string when length is exactly at the threshold (13 characters)', () => {
+      const atThreshold = '1234567890123';
+      expect(atThreshold).toHaveLength(13);
+      expect(truncateAddress(atThreshold)).toBe(atThreshold);
+    });
+
+    it('returns the unchanged string when length is just below the threshold (12 characters)', () => {
+      const belowThreshold = '123456789012';
+      expect(belowThreshold).toHaveLength(12);
+      expect(truncateAddress(belowThreshold)).toBe(belowThreshold);
+    });
+
+    it('truncates the string when length is exactly one over the threshold (14 characters)', () => {
+      const overThreshold = '12345678901234';
+      expect(overThreshold).toHaveLength(14);
+      expect(truncateAddress(overThreshold)).toBe('123456...1234');
+    });
+  });
+
+  describe('custom prefix and suffix lengths', () => {
+    it('uses custom prefix and suffix lengths correctly', () => {
+      // String length 20, prefix 2, suffix 2. Threshold = 2 + 2 + 3 = 7. Length > 7, so truncated.
+      expect(truncateAddress('ABCDEFGHIJKLMNOPQRST', 2, 2)).toBe('AB...ST');
+    });
+
+    it('respects the threshold dynamically based on custom arguments', () => {
+      // prefix 3, suffix 3. Threshold = 3 + 3 + 3 = 9.
+      const atCustomThreshold = '123456789';
+      expect(atCustomThreshold).toHaveLength(9);
+      expect(truncateAddress(atCustomThreshold, 3, 3)).toBe(atCustomThreshold);
+
+      const overCustomThreshold = '1234567890';
+      expect(overCustomThreshold).toHaveLength(10);
+      expect(truncateAddress(overCustomThreshold, 3, 3)).toBe('123...890');
+    });
+  });
 });

--- a/src/lib/truncateAddress.ts
+++ b/src/lib/truncateAddress.ts
@@ -1,5 +1,10 @@
 import { isValidStellarAddress, normalizeStellarAddress } from './stellarAddress';
 
+/**
+ * Truncates a Stellar address (or any string) by keeping the start and end, and inserting an ellipsis.
+ * The string is left untouched if its total length is at or below the threshold: `prefixLength + suffixLength + 3`.
+ * This prevents truncating strings that wouldn't actually be shortened.
+ */
 export function truncateAddress(value: string, prefixLength = 6, suffixLength = 4): string {
   if (!value) {
     return '';


### PR DESCRIPTION
What was done:

Extended the test suite in src/lib/__tests__/truncateAddress.test.ts to exhaustively cover the boundary cases of the address truncation logic.
Implemented edge-case assertions testing strings that hit the exact prefixLength + suffixLength + 3 threshold limit (which return unchanged), strings that are exactly one character over the threshold (which return truncated), and inputs utilizing custom prefix/suffix arguments.
Documented src/lib/truncateAddress.ts with JSDoc comments to clearly explain the threshold mechanism, avoiding any confusion about why short values do not get truncated.
Added a usage note in the README.md under the "Stellar address helpers" section to describe the signature, threshold fallback behavior, and usage context for truncateAddress.
Why it was done: To solidify the guarantees of the truncateAddress helper and ensure deterministic performance. The tests now definitively prevent regressions for boundary inputs and custom-sized parameters, guaranteeing that strings are never maliciously truncated into unhelpful sequences.

Verification / Test Output: npm run lint, npm run build, and npm test were all successfully verified.

text
> talenttrust-frontend@0.1.0 test
> jest
PASS src/lib/__tests__/truncateAddress.test.ts
PASS src/components/__tests__/WalletConnectButton.test.tsx
PASS src/app/__tests__/layout.test.tsx
PASS src/components/__tests__/a11y.test.tsx
PASS src/app/global-error.test.tsx
PASS src/components/__tests__/ContractSummary.test.tsx
...
Test Suites: 40 passed, 40 total
Tests:       5 skipped, 471 passed, 476 total
Snapshots:   7 passed, 7 total
Time:        70.927 s
Ran all test suites.
closes #94 