### PR TITLE
refactor: extract escrow progress math into a reusable useContractProgress hook

### DIFF
--- a/src/components/ContractProgress.tsx
+++ b/src/components/ContractProgress.tsx
@@ -1,58 +1,11 @@
 'use client';
 
 import { usePreferences } from '@/lib/preferences';
+import { useContractProgress } from '@/hooks/useContractProgress';
 import { Milestone } from './MilestonesList';
 
 export interface ContractProgressProps {
   milestones: Milestone[];
-}
-
-/**
- * Derives escrow progress metrics from a milestone array.
- *
- * Calculates:
- * - `completedCount`: Number of milestones with status "Completed" or "Paid".
- * - `totalCount`: Total number of milestones.
- * - `paidAmount`: Sum of payouts for milestones with status "Completed" or "Paid".
- * - `outstandingAmount`: Sum of payouts for all other milestones.
- *
- * Guards against empty arrays and ensures safe integer arithmetic (no overflow risk
- * within JavaScript's Number.MAX_SAFE_INTEGER bounds for typical contract values).
- *
- * @param milestones - Array of milestone objects.
- * @returns An object containing completedCount, totalCount, paidAmount, and outstandingAmount.
- */
-function calculateProgress(milestones: Milestone[]) {
-  if (!milestones || milestones.length === 0) {
-    return {
-      completedCount: 0,
-      totalCount: 0,
-      paidAmount: 0,
-      outstandingAmount: 0,
-    };
-  }
-
-  let completedCount = 0;
-  let paidAmount = 0;
-  let outstandingAmount = 0;
-
-  for (const milestone of milestones) {
-    const isCompleted = milestone.status === 'Completed' || milestone.status === 'Paid';
-    
-    if (isCompleted) {
-      completedCount += 1;
-      paidAmount += milestone.payout;
-    } else {
-      outstandingAmount += milestone.payout;
-    }
-  }
-
-  return {
-    completedCount,
-    totalCount: milestones.length,
-    paidAmount,
-    outstandingAmount,
-  };
 }
 
 /**
@@ -80,13 +33,8 @@ function calculateProgress(milestones: Milestone[]) {
  */
 const ContractProgress = ({ milestones }: ContractProgressProps) => {
   const { formatAmount } = usePreferences();
-  const { completedCount, totalCount, paidAmount, outstandingAmount } = calculateProgress(milestones);
-
-  // Calculate progress percentage (0–100)
-  const progressPercent = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
-
-  // Determine currency from first milestone, fallback to USD
-  const currency = milestones.length > 0 ? milestones[0].currency : 'USD';
+  const { completedCount, totalCount, paidAmount, outstandingAmount, progressPercent, currency } =
+    useContractProgress(milestones);
 
   return (
     <section

--- a/src/hooks/__tests__/useContractProgress.test.ts
+++ b/src/hooks/__tests__/useContractProgress.test.ts
@@ -1,0 +1,130 @@
+import { renderHook } from '@testing-library/react';
+import { calculateContractProgress, useContractProgress } from '../useContractProgress';
+import { Milestone } from '@/components/MilestonesList';
+
+function makeMilestone(overrides: Partial<Milestone> = {}): Milestone {
+  return {
+    id: 'ms-1',
+    title: 'Milestone',
+    status: 'Pending',
+    payout: 1000,
+    currency: 'USD',
+    ...overrides,
+  };
+}
+
+describe('calculateContractProgress', () => {
+  describe('empty array', () => {
+    it('returns zeroed metrics and a USD currency fallback', () => {
+      expect(calculateContractProgress([])).toEqual({
+        completedCount: 0,
+        totalCount: 0,
+        paidAmount: 0,
+        outstandingAmount: 0,
+        progressPercent: 0,
+        currency: 'USD',
+      });
+    });
+  });
+
+  describe('all paid', () => {
+    it('treats both "Completed" and "Paid" statuses as completed', () => {
+      const milestones = [
+        makeMilestone({ id: 'ms-1', status: 'Completed', payout: 1000 }),
+        makeMilestone({ id: 'ms-2', status: 'Paid', payout: 2000 }),
+      ];
+
+      expect(calculateContractProgress(milestones)).toEqual({
+        completedCount: 2,
+        totalCount: 2,
+        paidAmount: 3000,
+        outstandingAmount: 0,
+        progressPercent: 100,
+        currency: 'USD',
+      });
+    });
+  });
+
+  describe('none paid', () => {
+    it('sums every milestone into outstandingAmount', () => {
+      const milestones = [
+        makeMilestone({ id: 'ms-1', status: 'Pending', payout: 1500 }),
+        makeMilestone({ id: 'ms-2', status: 'Active', payout: 2500 }),
+      ];
+
+      expect(calculateContractProgress(milestones)).toEqual({
+        completedCount: 0,
+        totalCount: 2,
+        paidAmount: 0,
+        outstandingAmount: 4000,
+        progressPercent: 0,
+        currency: 'USD',
+      });
+    });
+  });
+
+  describe('mixed', () => {
+    it('splits paid and outstanding amounts and rounds the percentage', () => {
+      const milestones = [
+        makeMilestone({ id: 'ms-1', status: 'Completed', payout: 1500 }),
+        makeMilestone({ id: 'ms-2', status: 'Pending', payout: 2500 }),
+        makeMilestone({ id: 'ms-3', status: 'Pending', payout: 3000 }),
+      ];
+
+      expect(calculateContractProgress(milestones)).toEqual({
+        completedCount: 1,
+        totalCount: 3,
+        paidAmount: 1500,
+        outstandingAmount: 5500,
+        progressPercent: 33,
+        currency: 'USD',
+      });
+    });
+  });
+
+  describe('currency', () => {
+    it('uses the currency of the first milestone', () => {
+      const milestones = [makeMilestone({ currency: 'NGN' }), makeMilestone({ currency: 'USD' })];
+      expect(calculateContractProgress(milestones).currency).toBe('NGN');
+    });
+  });
+});
+
+describe('useContractProgress', () => {
+  it('returns the same metrics as calculateContractProgress', () => {
+    const milestones = [
+      makeMilestone({ id: 'ms-1', status: 'Paid', payout: 750 }),
+      makeMilestone({ id: 'ms-2', status: 'Pending', payout: 250 }),
+    ];
+
+    const { result } = renderHook(() => useContractProgress(milestones));
+
+    expect(result.current).toEqual(calculateContractProgress(milestones));
+  });
+
+  it('memoizes the result while the milestones array reference is stable', () => {
+    const milestones = [makeMilestone({ status: 'Completed' })];
+
+    const { result, rerender } = renderHook(({ data }) => useContractProgress(data), {
+      initialProps: { data: milestones },
+    });
+
+    const firstResult = result.current;
+    rerender({ data: milestones });
+
+    expect(result.current).toBe(firstResult);
+  });
+
+  it('recomputes when the milestones array reference changes', () => {
+    const { result, rerender } = renderHook(({ data }) => useContractProgress(data), {
+      initialProps: { data: [makeMilestone({ status: 'Pending', payout: 100 })] },
+    });
+
+    expect(result.current.outstandingAmount).toBe(100);
+
+    rerender({ data: [makeMilestone({ status: 'Completed', payout: 100 })] });
+
+    expect(result.current.outstandingAmount).toBe(0);
+    expect(result.current.paidAmount).toBe(100);
+  });
+});

--- a/src/hooks/useContractProgress.ts
+++ b/src/hooks/useContractProgress.ts
@@ -1,0 +1,87 @@
+import { useMemo } from 'react';
+import { Milestone } from '@/components/MilestonesList';
+
+export interface ContractProgressMetrics {
+  /** Number of milestones with status "Completed" or "Paid". */
+  completedCount: number;
+  /** Total number of milestones. */
+  totalCount: number;
+  /** Sum of payouts for milestones with status "Completed" or "Paid". */
+  paidAmount: number;
+  /** Sum of payouts for all other milestones. */
+  outstandingAmount: number;
+  /** Completion percentage (0-100), rounded, derived from completedCount / totalCount. */
+  progressPercent: number;
+  /** Currency taken from the first milestone, falling back to "USD" when there are none. */
+  currency: string;
+}
+
+/**
+ * Derives escrow progress metrics from a milestone array.
+ *
+ * Calculates:
+ * - `completedCount`: Number of milestones with status "Completed" or "Paid".
+ * - `totalCount`: Total number of milestones.
+ * - `paidAmount`: Sum of payouts for milestones with status "Completed" or "Paid".
+ * - `outstandingAmount`: Sum of payouts for all other milestones.
+ * - `progressPercent`: Completion percentage (0-100), rounded.
+ * - `currency`: Currency from the first milestone, falling back to "USD".
+ *
+ * Guards against empty arrays and ensures safe integer arithmetic (no overflow risk
+ * within JavaScript's Number.MAX_SAFE_INTEGER bounds for typical contract values).
+ *
+ * @param milestones - Array of milestone objects.
+ * @returns Escrow progress metrics derived from the milestone array.
+ */
+export function calculateContractProgress(milestones: Milestone[]): ContractProgressMetrics {
+  if (!milestones || milestones.length === 0) {
+    return {
+      completedCount: 0,
+      totalCount: 0,
+      paidAmount: 0,
+      outstandingAmount: 0,
+      progressPercent: 0,
+      currency: 'USD',
+    };
+  }
+
+  let completedCount = 0;
+  let paidAmount = 0;
+  let outstandingAmount = 0;
+
+  for (const milestone of milestones) {
+    const isCompleted = milestone.status === 'Completed' || milestone.status === 'Paid';
+
+    if (isCompleted) {
+      completedCount += 1;
+      paidAmount += milestone.payout;
+    } else {
+      outstandingAmount += milestone.payout;
+    }
+  }
+
+  const totalCount = milestones.length;
+  const progressPercent = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+  const currency = milestones[0].currency;
+
+  return {
+    completedCount,
+    totalCount,
+    paidAmount,
+    outstandingAmount,
+    progressPercent,
+    currency,
+  };
+}
+
+/**
+ * React hook wrapper around {@link calculateContractProgress}, memoized on the
+ * `milestones` array reference so consumers (e.g. `ContractProgress`, a contract
+ * detail header, or a contracts-list summary) can share the same escrow math.
+ *
+ * @param milestones - Array of milestone objects.
+ * @returns Escrow progress metrics derived from the milestone array.
+ */
+export function useContractProgress(milestones: Milestone[]): ContractProgressMetrics {
+  return useMemo(() => calculateContractProgress(milestones), [milestones]);
+}


### PR DESCRIPTION
## Summary
- Extracts the milestone-derived escrow math (`completedCount`, `totalCount`, `paidAmount`, `outstandingAmount`, `progressPercent`, `currency`) out of `ContractProgress.tsx` into a pure `calculateContractProgress` function plus a memoized `useContractProgress` hook in `src/hooks/useContractProgress.ts`.
- `ContractProgress` now consumes the hook instead of computing this inline, so the same math is reusable by other views (e.g. a contract detail header or contracts-list summary) and is independently testable.
- Preserves the "Completed or Paid counts as completed" definition and the empty-array guard (zeroed metrics, USD currency fallback) exactly as before.
- `ContractProgress`'s rendering output, ARIA attributes, and existing `ContractProgress.test.tsx` suite are unchanged and pass as-is, confirming behavioral parity.

Closes #252

## Test plan
- [x] `npm test -- --testPathPattern="ContractProgress|useContractProgress"` — 35/35 passing (existing component tests + new hook tests covering empty/all-paid/none-paid/mixed/currency cases and memoization).
- [x] `npm run lint` — no new errors introduced (verified identical pre-existing errors exist on `main` without this change).
- [x] `npm test` (full suite) — same 572 passing / 27 pre-existing failing as on `main` (failures are in unrelated `WalletContext`/CSP/contracts-page suites, confirmed pre-existing by running the suite against `main` directly).
- [x] `npm run build` — **fails**, but this is pre-existing and unrelated to this change: `WalletContext.tsx` imports a `safeStorage` export that no longer exists in `src/lib/safeStorage.ts` (only `resetCache` is exported). Verified this fails identically on `main` before this change, and confirmed via `gh run list` that upstream's CI has been failing on `main` for the last several merges for the same reason. Flagging here since it will likely fail this PR's CI build step too, but it is out of scope for issue #252.
- [x] New module coverage: 100% statements/functions/lines, 90% branches on `src/hooks/useContractProgress.ts`.