### PR TITLE
refactor(hooks): add SSR-safe useMediaQuery and reuse it in PreferencesProvider

### DIFF
--- a/docs/hooks/useMediaQuery.md
+++ b/docs/hooks/useMediaQuery.md
@@ -1,0 +1,56 @@
+# useMediaQuery
+
+A small, SSR-safe React hook for checking whether a CSS media query currently matches. It starts with a stable `false` value on the server and updates on the client after the component mounts.
+
+## Location
+
+`src/hooks/useMediaQuery.ts`
+
+## Usage
+
+```tsx
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+export function ThemeBadge() {
+  const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');
+  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+
+  return (
+    <p>
+      {prefersDark ? 'Dark mode' : 'Light mode'}
+      {prefersReducedMotion ? ' with reduced motion' : ''}
+    </p>
+  );
+}
+```
+
+## API Reference
+
+### `useMediaQuery(query)`
+
+#### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | A valid CSS media query string, such as `'(prefers-color-scheme: dark)'` or `'(min-width: 1024px)'`. |
+
+#### Returns
+
+| Return value | Type | Description |
+|---|---|---|
+| `matches` | `boolean` | `true` when the media query currently matches, `false` otherwise. |
+
+## SSR Notes
+
+1. The hook returns `false` on the server and in environments where `window.matchMedia` is unavailable.
+2. The real media-query value is read in a client `useEffect`, which keeps the initial server render and first client render aligned.
+3. The `change` listener is removed during cleanup so the hook does not leak subscriptions when components unmount.
+
+## Testing
+
+Unit tests are defined in `src/hooks/__tests__/useMediaQuery.test.ts`.
+
+To run the unit tests:
+```bash
+npm test src/hooks/__tests__/useMediaQuery.test.ts
+```

--- a/src/hooks/__tests__/useMediaQuery.test.ts
+++ b/src/hooks/__tests__/useMediaQuery.test.ts
@@ -1,0 +1,93 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useMediaQuery } from '../useMediaQuery';
+
+function createMatchMedia(matches: boolean) {
+  const addEventListener = jest.fn();
+  const removeEventListener = jest.fn();
+
+  const mediaQueryList = {
+    matches,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener,
+    removeEventListener,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  } as unknown as MediaQueryList;
+
+  return {
+    mediaQueryList,
+    addEventListener,
+    removeEventListener,
+  };
+}
+
+describe('useMediaQuery', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns false before hydration and updates to the current match state', () => {
+    const { mediaQueryList, addEventListener, removeEventListener } = createMatchMedia(true);
+    const matchMedia = jest.fn(() => mediaQueryList);
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: matchMedia,
+    });
+
+    const { result, unmount } = renderHook(() => useMediaQuery('(prefers-color-scheme: dark)'));
+
+    expect(result.current).toBe(true);
+    expect(matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: dark)');
+    expect(addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+
+    act(() => {
+      const listener = addEventListener.mock.calls[0][1] as (event: MediaQueryListEvent) => void;
+      listener({ matches: true } as MediaQueryListEvent);
+    });
+
+    expect(result.current).toBe(true);
+
+    unmount();
+    expect(removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('falls back to false when matchMedia is unavailable', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: undefined,
+    });
+
+    const { result } = renderHook(() => useMediaQuery('(min-width: 1024px)'));
+
+    expect(result.current).toBe(false);
+  });
+
+  it('uses the latest query when the query string changes', async () => {
+    const first = createMatchMedia(false);
+    const second = createMatchMedia(true);
+    const matchMedia = jest.fn((query: string) =>
+      query === '(min-width: 1024px)' ? first.mediaQueryList : second.mediaQueryList,
+    );
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: matchMedia,
+    });
+
+    const { result, rerender } = renderHook(({ query }) => useMediaQuery(query), {
+      initialProps: { query: '(min-width: 1024px)' },
+    });
+
+    expect(result.current).toBe(false);
+
+    rerender({ query: '(prefers-reduced-motion: reduce)' });
+
+    expect(matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+});

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns true when the given CSS media query matches, false otherwise.
+ *
+ * SSR-safe: on the server (or any environment where `window.matchMedia` is
+ * absent) the hook returns `false` — a stable, predictable default that avoids
+ * hydration mismatches on first client render.
+ *
+ * The listener is removed on unmount so there are no memory leaks even if the
+ * consuming component is mounted and unmounted rapidly.
+ *
+ * @param query - A valid CSS media query string, e.g. `'(prefers-color-scheme: dark)'`.
+ * @returns `true` if the query currently matches, `false` otherwise.
+ *
+ * @example
+ * const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');
+ * const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+ * const isWide = useMediaQuery('(min-width: 1024px)');
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState<boolean>(false);
+
+  useEffect(() => {
+    // Guard: environments like Node/jsdom without matchMedia get a stable false.
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(query);
+
+    // Sync state immediately so the component reflects the real value after
+    // the first paint (after hydration).
+    setMatches(mediaQueryList.matches);
+
+    const listener = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    mediaQueryList.addEventListener('change', listener);
+
+    return () => {
+      mediaQueryList.removeEventListener('change', listener);
+    };
+  }, [query]);
+
+  return matches;
+}

--- a/src/lib/__tests__/preferences.test.tsx
+++ b/src/lib/__tests__/preferences.test.tsx
@@ -536,3 +536,47 @@ describe('formatAmount invalid currency codes', () => {
   });
 });
 
+describe('theme application', () => {
+  function mockMatchMedia(matches: boolean) {
+    const addEventListener = jest.fn();
+    const removeEventListener = jest.fn();
+    const mediaQueryList = {
+      matches,
+      media: '(prefers-color-scheme: dark)',
+      onchange: null,
+      addEventListener,
+      removeEventListener,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    } as unknown as MediaQueryList;
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn(() => mediaQueryList),
+    });
+
+    return { addEventListener, removeEventListener };
+  }
+
+  it('applies the system theme using the media query result', () => {
+    mockMatchMedia(true);
+    render(<PreferencesProvider><div /></PreferencesProvider>);
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains('light')).toBe(false);
+  });
+
+  it('registers and cleans up the system theme listener while theme is set to system', () => {
+    const { addEventListener, removeEventListener } = mockMatchMedia(false);
+
+    const { unmount } = render(<PreferencesProvider><div /></PreferencesProvider>);
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+
+    unmount();
+    expect(removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+});

--- a/src/lib/preferences.tsx
+++ b/src/lib/preferences.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { getItem, setItem } from './safeStorage';
 
 export type Theme = 'light' | 'dark' | 'system';
@@ -171,6 +172,7 @@ export function sanitizePreferences(raw: unknown): UserPreferences {
 export function PreferencesProvider({ children }: { children: React.ReactNode }) {
   const [preferences, setPreferences] = useState<UserPreferences>(DEFAULT_PREFERENCES);
   const [isHydrated, setIsHydrated] = useState(false);
+  const systemPrefersDark = useMediaQuery('(prefers-color-scheme: dark)');
 
   // Load from localStorage on mount. Every value is routed through
   // `sanitizePreferences` so tampered, corrupted, or prototype-polluting
@@ -202,7 +204,7 @@ export function PreferencesProvider({ children }: { children: React.ReactNode })
       let effectiveTheme = theme;
 
       if (theme === 'system') {
-        effectiveTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        effectiveTheme = systemPrefersDark ? 'dark' : 'light';
       }
 
       root.setAttribute('data-theme', effectiveTheme);
@@ -211,15 +213,7 @@ export function PreferencesProvider({ children }: { children: React.ReactNode })
     };
 
     applyTheme(preferences.theme);
-
-    // Listener for system theme changes
-    if (preferences.theme === 'system') {
-      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      const listener = () => applyTheme('system');
-      mediaQuery.addEventListener('change', listener);
-      return () => mediaQuery.removeEventListener('change', listener);
-    }
-  }, [preferences.theme]);
+  }, [preferences.theme, systemPrefersDark]);
 
   const updatePreference = <K extends keyof UserPreferences>(key: K, value: UserPreferences[K]) => {
     setPreferences(prev => ({ ...prev, [key]: value }));


### PR DESCRIPTION
Closes #306

## Summary
Adds a reusable, SSR-safe `useMediaQuery(query: string): boolean` hook and refactors `PreferencesProvider` to use it instead of inlining `window.matchMedia` logic.

- `src/hooks/useMediaQuery.ts` - new hook. Returns `false` as the SSR default to avoid hydration mismatch.
- `src/lib/preferences.tsx` - replaced the inline `matchMedia` block with `const systemPrefersDark = useMediaQuery('(prefers-color-scheme: dark)')`. The theme effect now depends on `[preferences.theme, systemPrefersDark]`. `PreferencesProvider` no longer manages its own `addEventListener`/`removeEventListener` lifecycle.
- `src/hooks/__tests__/useMediaQuery.test.ts` - new tests for the hook.
- `src/lib/__tests__/preferences.test.tsx` - added theme-application tests covering the hook-backed path.
- `docs/hooks/useMediaQuery.md` - new docs, following the existing format in `docs/hooks/useCopyToClipboard.md`.

## Testing
Targeted lint and tests pass on the changed files:

npx eslint src/hooks/useMediaQuery.ts src/lib/preferences.tsx src/hooks/__tests__/useMediaQuery.test.ts src/lib/__tests__/preferences.test.tsx

npm test -- --testPathPattern="useMediaQuery|preferences"

## Note for reviewers
Repo-wide `npm run lint` / `npm run build` currently surface a pre-existing syntax error in `src/components/ActionPanel.tsx`. This issue is also present on `main` and is unrelated to this PR. I confirmed `git diff origin/main -- src/components/ActionPanel.tsx` is empty, so a separate issue should track it.

CI is currently failing npm ci with a dependency resolution error that is unrelated to this PR. I verified this branch does not change package.json or package-lock.json, and a clean npm ci on the restored original lockfile succeeds locally. The reported @types/react@19.2.17 conflict does not match the manifests in this branch, which still target React 18 types. This appears to be a separate environment/lockfile issue and should be tracked independently.