### PR TITLE
test(stellar): cover normalizeStellarAddress edge cases

### DIFF
--- a/src/lib/__tests__/stellarAddress.test.ts
+++ b/src/lib/__tests__/stellarAddress.test.ts
@@ -9,6 +9,10 @@ describe('stellarAddress helpers', () => {
     expect(normalizeStellarAddress(VALID_KEY.toLowerCase())).toBe(VALID_KEY);
   });
 
+  it('normalizes surrounding whitespace and casing before validation', () => {
+    expect(isValidStellarAddress(`  ${VALID_KEY.toLowerCase()}  `)).toBe(true);
+  });
+
   it('rejects keys with an invalid StrKey checksum', () => {
     expect(isValidStellarAddress('GABQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQDZ7H')).toBe(false);
     expect(isValidStellarAddress('GAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQDZ7I')).toBe(false);
@@ -29,11 +33,18 @@ describe('stellarAddress helpers', () => {
     expect(isValidStellarAddress(VALID_KEY + 'A')).toBe(false);
   });
 
-  it('normalizes whitespace and case without throwing for invalid input', () => {
-    const normalized = `GAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQDZ7H`;
-    expect(normalizeStellarAddress(`  ${normalized.toLowerCase()}  `)).toBe(normalized);
+  it('normalizes whitespace and case without touching already-normalized values', () => {
+    expect(normalizeStellarAddress(`  ${VALID_KEY.toLowerCase()}  `)).toBe(VALID_KEY);
+    expect(normalizeStellarAddress(`\n\t${VALID_KEY}\r\n`)).toBe(VALID_KEY);
+    expect(normalizeStellarAddress(VALID_KEY)).toBe(VALID_KEY);
+  });
+
+  it('returns an empty string for blank and non-string input', () => {
     expect(normalizeStellarAddress('')).toBe('');
-    expect(normalizeStellarAddress(undefined as unknown as string)).toBe('');
+    expect(normalizeStellarAddress('   ')).toBe('');
+    expect(normalizeStellarAddress(null)).toBe('');
+    expect(normalizeStellarAddress(undefined)).toBe('');
+    expect(normalizeStellarAddress(12345 as unknown as string)).toBe('');
     expect(isValidStellarAddress('   ')).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- add dedicated normalization coverage for whitespace trimming, case conversion, blank values, and non-string inputs
- assert that `isValidStellarAddress` accepts a lowercase, whitespace-padded valid G-address via normalization
- keep the change scoped to tests only

Closes Talenttrust/Talenttrust-Frontend#309.

## Validation
- `pnpm exec jest src/lib/__tests__/stellarAddress.test.ts --runInBand`
- `pnpm run lint`
- `pnpm test --runInBand`
- `./node_modules/.bin/next build`

Notes:
- Full Jest passed: 55 suites, 925 tests passing, 5 skipped.
- Build passed after using a pnpm hoist layout for the existing `@jest/globals` test-utils dependency in this local Codex environment.
