### PR TITLE
test(auth): cover validateLogin boundary ordering

### DIFF
--- a/docs/lib/validate-login.md
+++ b/docs/lib/validate-login.md
@@ -1,0 +1,53 @@
+# Login validation
+
+`validateLogin` is the shared, side-effect-free validator for the login form's
+email and password fields. It returns `ValidationError[]` entries in form-field
+order so `ErrorSummary` can keep stable links to `#email` and `#password`.
+
+## Rules and precedence
+
+Email validation trims surrounding whitespace, then evaluates one rule at a
+time in this order:
+
+1. required;
+2. maximum length of 254 characters;
+3. format (the value must contain `@`).
+
+Password validation preserves whitespace because it can be part of a password,
+then evaluates:
+
+1. required;
+2. maximum length of 128 characters;
+3. minimum length of 8 characters.
+
+Only the first failing rule for each field is returned. For example, a
+255-character email without `@` receives the length error, while a
+whitespace-only email receives the required error. When both fields fail, the
+email error is returned before the password error.
+
+## Boundary contract
+
+| Input | Expected result |
+| --- | --- |
+| 253-character valid email | accepted |
+| 254-character valid email | accepted |
+| 255-character email | maximum-length error |
+| 7-character password | minimum-length error |
+| 8-character password | accepted |
+| 128-character password | accepted |
+| 129-character password | maximum-length error |
+
+The constants `MAX_EMAIL_LENGTH` and `MAX_PASSWORD_LENGTH` are exported from
+`src/lib/validateLogin.ts` so form controls and tests can use the same ceilings
+as the validator.
+
+## Testing
+
+Run the focused suite with:
+
+```bash
+npm test -- --runInBand src/lib/validateLogin.test.ts
+```
+
+The focused tests cover the exact boundary values, whitespace handling,
+required/length/format precedence, and stable cross-field error ordering.

--- a/src/lib/validateLogin.test.ts
+++ b/src/lib/validateLogin.test.ts
@@ -4,6 +4,16 @@ import {
   validateLogin,
 } from './validateLogin';
 
+const EMAIL_SUFFIX = '@example.com';
+
+function validEmailWithLength(length: number): string {
+  if (length < EMAIL_SUFFIX.length + 1) {
+    throw new Error('Email length must leave room for a local part');
+  }
+
+  return `${'a'.repeat(length - EMAIL_SUFFIX.length)}${EMAIL_SUFFIX}`;
+}
+
 describe('validateLogin', () => {
   it('should return no errors for valid inputs', () => {
     const errors = validateLogin('test@example.com', 'password123');
@@ -67,10 +77,21 @@ describe('validateLogin', () => {
       ]);
     });
 
-    it('treats an over-length trimmed email as over-length', () => {
-      const longEmail = `${'a'.repeat(MAX_EMAIL_LENGTH - '@example.com'.length + 5)}@example.com`;
-      expect(longEmail.length).toBeGreaterThan(MAX_EMAIL_LENGTH);
-      const errors = validateLogin(longEmail, 'password123');
+    it.each([MAX_EMAIL_LENGTH - 1, MAX_EMAIL_LENGTH])(
+      'accepts a valid email at %i characters',
+      (length) => {
+        const email = validEmailWithLength(length);
+
+        expect(email).toHaveLength(length);
+        expect(validateLogin(email, 'password123')).toEqual([]);
+      },
+    );
+
+    it('rejects a valid email at 255 characters', () => {
+      const email = validEmailWithLength(MAX_EMAIL_LENGTH + 1);
+
+      expect(email).toHaveLength(255);
+      const errors = validateLogin(email, 'password123');
       expect(errors).toEqual([
         {
           fieldId: 'email',
@@ -80,9 +101,44 @@ describe('validateLogin', () => {
     });
 
     it('counts length against the trimmed email, not the raw input', () => {
-      // Padding only affects what we strip — the inner content is the over-length payload.
-      const paddedLongEmail = `   ${'a'.repeat(MAX_EMAIL_LENGTH - '@example.com'.length + 5)}@example.com   `;
-      const errors = validateLogin(paddedLongEmail, 'password123');
+      const paddedEmail = `   ${validEmailWithLength(MAX_EMAIL_LENGTH)}   `;
+
+      expect(validateLogin(paddedEmail, 'password123')).toEqual([]);
+    });
+
+    it.each([
+      {
+        length: 7,
+        expected: [
+          {
+            fieldId: 'password',
+            message: 'Password must be at least 8 characters',
+          },
+        ],
+      },
+      { length: 8, expected: [] },
+      { length: MAX_PASSWORD_LENGTH, expected: [] },
+      {
+        length: MAX_PASSWORD_LENGTH + 1,
+        expected: [
+          {
+            fieldId: 'password',
+            message: `Password must be no more than ${MAX_PASSWORD_LENGTH} characters`,
+          },
+        ],
+      },
+    ])('validates the $length-character password boundary', ({ length, expected }) => {
+      const password = 'a'.repeat(length);
+
+      expect(password).toHaveLength(length);
+      expect(validateLogin('test@example.com', password)).toEqual(expected);
+    });
+
+    it('returns the over-length email error before checking email format', () => {
+      const malformedEmail = 'a'.repeat(MAX_EMAIL_LENGTH + 1);
+
+      expect(malformedEmail).not.toContain('@');
+      const errors = validateLogin(malformedEmail, 'password123');
       expect(errors).toEqual([
         {
           fieldId: 'email',
@@ -91,47 +147,23 @@ describe('validateLogin', () => {
       ]);
     });
 
-    it('accepts an email whose trimmed length equals the ceiling', () => {
-      const localPart = 'a'.repeat(MAX_EMAIL_LENGTH - '@example.com'.length);
-      const email = `${localPart}@example.com`;
-      expect(email.length).toBe(MAX_EMAIL_LENGTH);
-      const errors = validateLogin(email, 'password123');
-      expect(errors).toEqual([]);
+    it('returns the required email error before length or format errors', () => {
+      const errors = validateLogin('     ', 'password123');
+
+      expect(errors).toEqual([
+        {
+          fieldId: 'email',
+          message: 'Email is required',
+        },
+      ]);
     });
 
-    it('rejects a password whose length exceeds MAX_PASSWORD_LENGTH', () => {
+    it('keeps errors in form-field order when both fields fail', () => {
+      const longEmail = 'a'.repeat(MAX_EMAIL_LENGTH + 1);
       const longPassword = 'a'.repeat(MAX_PASSWORD_LENGTH + 1);
-      const errors = validateLogin('test@example.com', longPassword);
-      expect(errors).toEqual([
-        {
-          fieldId: 'password',
-          message: `Password must be no more than ${MAX_PASSWORD_LENGTH} characters`,
-        },
-      ]);
-    });
-
-    it('accepts a password whose length equals MAX_PASSWORD_LENGTH', () => {
-      const exactPassword = 'a'.repeat(MAX_PASSWORD_LENGTH);
-      const errors = validateLogin('test@example.com', exactPassword);
-      expect(errors).toEqual([]);
-    });
-
-    it('returns the over-length email error in preference to the format error', () => {
-      // Long email that ALSO lacks '@' — length check fires first.
-      const longEmailNoAt = 'a'.repeat(MAX_EMAIL_LENGTH + 10);
-      const errors = validateLogin(longEmailNoAt, 'password123');
-      expect(errors).toEqual([
-        {
-          fieldId: 'email',
-          message: `Email must be no more than ${MAX_EMAIL_LENGTH} characters`,
-        },
-      ]);
-    });
-
-    it('surfaces a per-field error for both fields when both are over-length', () => {
-      const longEmail = `${'a'.repeat(MAX_EMAIL_LENGTH - '@example.com'.length + 5)}@example.com`;
-      const longPassword = 'a'.repeat(MAX_PASSWORD_LENGTH + 5);
       const errors = validateLogin(longEmail, longPassword);
+
+      expect(errors.map(({ fieldId }) => fieldId)).toEqual(['email', 'password']);
       expect(errors).toEqual([
         {
           fieldId: 'email',


### PR DESCRIPTION
## Description

Adds exhaustive boundary and precedence coverage for `validateLogin`, including exact email and password ceilings, trimmed required handling, length-before-format behavior, and stable cross-field error ordering. It also documents the validator contract for future form and test changes.

Closes #433

## Type of Change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [x] Documentation update

---

## Pre-flight Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

Validation used the compatible TypeScript 6/Jest 29 versions already proposed in #442 without including dependency-file changes here. Current `main` otherwise resolves TypeScript 7/Jest 30 combinations that fail before the suite can run.

---

## Testing & Coverage

- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
- [x] If this PR adds or modifies UI components, accessibility tests were written using the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

- Valid emails at 253 and 254 characters, and rejection at 255
- Passwords at 7, 8, 128, and 129 characters
- Email trimming and whitespace-only required handling
- Required-before-length-before-format precedence
- Stable email-then-password `ValidationError[]` ordering
- Full repository suite: 56 suites and 932 tests passed
- Focused validator suite: 21 tests passed with 100% statements, branches, functions, and lines
- Production build completed successfully

---

## Accessibility & Security Notes

### Accessibility

N/A – no UI changes. The stable error order covered here preserves predictable error-summary links.

### Security

No production authentication behavior changed. This PR only tests and documents the existing login validation contract.
