### PR TITLE
close #415 Bound and sanitize user-supplied titles and party labels before persisting

### DIFF
--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -3,6 +3,20 @@
 This project sets HTTP response headers via the `headers()` function in
 `next.config.js`.  The headers are applied to every route.
 
+## User-supplied record text
+
+Contract names, party labels, and milestone titles are normalised at form
+validation before they are saved to browser storage. `sanitizeUserText` removes
+control characters, trims and collapses whitespace, and applies a length cap.
+The forms validate the cleaned, unbounded value first, so input longer than the
+cap is rejected with a field error rather than being silently truncated.
+
+| Field | Maximum cleaned length |
+|---|---:|
+| Contract name | 200 characters |
+| Party label | 100 characters |
+| Milestone title | 200 characters |
+
 ## Login form throttling
 
 The home page login form (`src/app/page.tsx`) uses a client-side attempt

--- a/src/components/ContractCreationForm.tsx
+++ b/src/components/ContractCreationForm.tsx
@@ -4,7 +4,11 @@ import React, { useState, useCallback, FormEvent } from 'react';
 import { FormField } from './FormField';
 import { ErrorSummary } from './ErrorSummary';
 import { isValidStellarAddress } from '@/lib/stellarAddress';
+import { sanitizeUserText } from '@/lib/sanitizeUserText';
 import type { Contract } from '@/types/domain';
+
+export const MAX_CONTRACT_NAME_LENGTH = 200;
+export const MAX_PARTY_LABEL_LENGTH = 100;
 
 export interface ContractFormData {
   contractName: string;
@@ -51,10 +55,17 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
     const validationErrors: Array<{ fieldId: string; message: string }> = [];
 
     // Validate contract name
-    if (!contractName.trim()) {
+    const sanitizedContractName = sanitizeUserText(contractName, MAX_CONTRACT_NAME_LENGTH);
+    const unboundedContractName = sanitizeUserText(contractName, Number.MAX_SAFE_INTEGER);
+    if (!sanitizedContractName) {
       validationErrors.push({
         fieldId: 'contractName',
         message: 'Contract name is required',
+      });
+    } else if (unboundedContractName.length > MAX_CONTRACT_NAME_LENGTH) {
+      validationErrors.push({
+        fieldId: 'contractName',
+        message: `Contract name must be no more than ${MAX_CONTRACT_NAME_LENGTH} characters`,
       });
     }
 
@@ -81,7 +92,9 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
     }
 
     // Validate parties
-    const filledParties = parties.filter(p => p.label.trim() || p.address.trim());
+    const filledParties = parties.filter(
+      p => sanitizeUserText(p.label, MAX_PARTY_LABEL_LENGTH) || p.address.trim(),
+    );
     if (filledParties.length < 2) {
       validationErrors.push({
         fieldId: 'parties',
@@ -91,7 +104,9 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
 
     // Validate individual party fields
     parties.forEach((party, index) => {
-      const hasLabel = party.label.trim();
+      const sanitizedLabel = sanitizeUserText(party.label, MAX_PARTY_LABEL_LENGTH);
+      const unboundedLabel = sanitizeUserText(party.label, Number.MAX_SAFE_INTEGER);
+      const hasLabel = sanitizedLabel;
       const hasAddress = party.address.trim();
 
       // If either field is filled, both must be filled
@@ -100,6 +115,12 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
           validationErrors.push({
             fieldId: `party-label-${index}`,
             message: `Party ${index + 1} label is required`,
+          });
+        }
+        if (unboundedLabel.length > MAX_PARTY_LABEL_LENGTH) {
+          validationErrors.push({
+            fieldId: `party-label-${index}`,
+            message: `Party ${index + 1} label must be no more than ${MAX_PARTY_LABEL_LENGTH} characters`,
           });
         }
 
@@ -135,10 +156,15 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
       }
 
       // Filter out empty parties and construct the contract
-      const validParties = parties.filter(p => p.label.trim() && p.address.trim());
+      const validParties = parties
+        .filter(p => sanitizeUserText(p.label, MAX_PARTY_LABEL_LENGTH) && p.address.trim())
+        .map(p => ({
+          ...p,
+          label: sanitizeUserText(p.label, MAX_PARTY_LABEL_LENGTH),
+        }));
       
       const contract: Contract = {
-        contractName: contractName.trim(),
+        contractName: sanitizeUserText(contractName, MAX_CONTRACT_NAME_LENGTH),
         parties: validParties,
         totalValue: parseFloat(totalValue),
         currency: currency.trim(),

--- a/src/components/__tests__/ContractCreationForm.test.tsx
+++ b/src/components/__tests__/ContractCreationForm.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { ContractCreationForm } from '../ContractCreationForm';
+import {
+  ContractCreationForm,
+  MAX_CONTRACT_NAME_LENGTH,
+  MAX_PARTY_LABEL_LENGTH,
+} from '../ContractCreationForm';
 import * as stellarAddress from '@/lib/stellarAddress';
 
 // Mock the stellarAddress module
@@ -298,6 +302,33 @@ describe('ContractCreationForm', () => {
       expect(submittedContract.contractName).toBe('Website Redesign');
     });
 
+    it('normalizes control characters and whitespace before submitting text fields', async () => {
+      render(<ContractCreationForm {...defaultProps} />);
+
+      fireEvent.change(screen.getByLabelText(/contract name/i), {
+        target: { value: '  Website\u0000\n  Redesign  ' },
+      });
+      fireEvent.change(screen.getByLabelText(/total value/i), { target: { value: '5000' } });
+
+      const partyLabels = screen.getAllByPlaceholderText(/e\.g\., client, freelancer/i);
+      const partyAddresses = screen.getAllByPlaceholderText(/GXXXXXXXXXX/i);
+      fireEvent.change(partyLabels[0], { target: { value: '  Client\u0007  Team ' } });
+      fireEvent.change(partyAddresses[0], { target: { value: VALID_ADDRESS } });
+      fireEvent.change(partyLabels[1], { target: { value: ' Freelancer ' } });
+      fireEvent.change(partyAddresses[1], { target: { value: VALID_ADDRESS } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => expect(mockOnSubmit).toHaveBeenCalledTimes(1));
+      expect(mockOnSubmit.mock.calls[0][0]).toMatchObject({
+        contractName: 'Website Redesign',
+        parties: [
+          { label: 'Client Team', address: VALID_ADDRESS },
+          { label: 'Freelancer', address: VALID_ADDRESS },
+        ],
+      });
+    });
+
     it('filters out empty parties when submitting', async () => {
       render(<ContractCreationForm {...defaultProps} />);
 
@@ -414,6 +445,41 @@ describe('ContractCreationForm', () => {
         const contractNameInput = screen.getByLabelText(/contract name/i);
         expect(contractNameInput.className).toContain('border-red-500');
       });
+    });
+  });
+
+  describe('Text length validation', () => {
+    it('rejects an over-length contract name instead of truncating it', async () => {
+      render(<ContractCreationForm {...defaultProps} />);
+
+      fireEvent.change(screen.getByLabelText(/contract name/i), {
+        target: { value: 'a'.repeat(MAX_CONTRACT_NAME_LENGTH + 1) },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText(
+          `Contract name must be no more than ${MAX_CONTRACT_NAME_LENGTH} characters`,
+        )[0]).toBeInTheDocument();
+      });
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it('rejects an over-length party label instead of truncating it', async () => {
+      render(<ContractCreationForm {...defaultProps} />);
+      const partyLabels = screen.getAllByPlaceholderText(/e\.g\., client, freelancer/i);
+      const partyAddresses = screen.getAllByPlaceholderText(/GXXXXXXXXXX/i);
+      fireEvent.change(partyLabels[0], { target: { value: 'a'.repeat(MAX_PARTY_LABEL_LENGTH + 1) } });
+      fireEvent.change(partyAddresses[0], { target: { value: VALID_ADDRESS } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText(
+          `Party 1 label must be no more than ${MAX_PARTY_LABEL_LENGTH} characters`,
+        )[0]).toBeInTheDocument();
+      });
+      expect(mockOnSubmit).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/milestones/MilestoneCreationForm.test.tsx
+++ b/src/components/milestones/MilestoneCreationForm.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  MAX_MILESTONE_TITLE_LENGTH,
+  MilestoneCreationForm,
+} from './MilestoneCreationForm';
+
+describe('MilestoneCreationForm', () => {
+  const onSubmit = jest.fn();
+  const onCancel = jest.fn();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('normalizes a title before submitting the milestone', async () => {
+    render(<MilestoneCreationForm onSubmit={onSubmit} onCancel={onCancel} />);
+
+    fireEvent.change(screen.getByLabelText(/^title/i), {
+      target: { value: '  Design\u0000\n  review  ' },
+    });
+    fireEvent.change(screen.getByLabelText(/payout amount/i), { target: { value: '500' } });
+    fireEvent.click(screen.getByRole('button', { name: /add milestone/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0].title).toBe('Design review');
+  });
+
+  it('rejects an over-length title instead of truncating it', async () => {
+    render(<MilestoneCreationForm onSubmit={onSubmit} onCancel={onCancel} />);
+
+    fireEvent.change(screen.getByLabelText(/^title/i), {
+      target: { value: 'a'.repeat(MAX_MILESTONE_TITLE_LENGTH + 1) },
+    });
+    fireEvent.change(screen.getByLabelText(/payout amount/i), { target: { value: '500' } });
+    fireEvent.click(screen.getByRole('button', { name: /add milestone/i }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(
+        `Title must be no more than ${MAX_MILESTONE_TITLE_LENGTH} characters`,
+      )[0]).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/milestones/MilestoneCreationForm.tsx
+++ b/src/components/milestones/MilestoneCreationForm.tsx
@@ -3,7 +3,10 @@
 import React, { useState, useCallback, FormEvent } from 'react';
 import { FormField } from '@/components/FormField';
 import { ErrorSummary } from '@/components/ErrorSummary';
+import { sanitizeUserText } from '@/lib/sanitizeUserText';
 import type { Milestone } from '@/types/domain';
+
+export const MAX_MILESTONE_TITLE_LENGTH = 200;
 
 /** Status options available when creating a milestone. */
 const STATUS_OPTIONS: Milestone['status'][] = [
@@ -72,8 +75,15 @@ export const MilestoneCreationForm: React.FC<MilestoneCreationFormProps> = ({
   const validateForm = useCallback((): Array<{ fieldId: string; message: string }> => {
     const errs: Array<{ fieldId: string; message: string }> = [];
 
-    if (!title.trim()) {
+    const sanitizedTitle = sanitizeUserText(title, MAX_MILESTONE_TITLE_LENGTH);
+    const unboundedTitle = sanitizeUserText(title, Number.MAX_SAFE_INTEGER);
+    if (!sanitizedTitle) {
       errs.push({ fieldId: 'milestone-title', message: 'Title is required' });
+    } else if (unboundedTitle.length > MAX_MILESTONE_TITLE_LENGTH) {
+      errs.push({
+        fieldId: 'milestone-title',
+        message: `Title must be no more than ${MAX_MILESTONE_TITLE_LENGTH} characters`,
+      });
     }
 
     const numericPayout = parseFloat(payout);
@@ -104,8 +114,8 @@ export const MilestoneCreationForm: React.FC<MilestoneCreationFormProps> = ({
       if (validationErrors.length > 0) return;
 
       // Generate a stable id from title slug + current timestamp
-      const slug = title
-        .trim()
+      const sanitizedTitle = sanitizeUserText(title, MAX_MILESTONE_TITLE_LENGTH);
+      const slug = sanitizedTitle
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-|-$/g, '');
@@ -113,7 +123,7 @@ export const MilestoneCreationForm: React.FC<MilestoneCreationFormProps> = ({
 
       const milestone: Milestone = {
         id,
-        title: title.trim(),
+        title: sanitizedTitle,
         status,
         payout: parseFloat(payout),
         currency: currency.trim(),

--- a/src/lib/sanitizeUserText.test.ts
+++ b/src/lib/sanitizeUserText.test.ts
@@ -1,0 +1,34 @@
+import { sanitizeUserText } from './sanitizeUserText';
+
+describe('sanitizeUserText', () => {
+  it('trims surrounding whitespace and collapses internal whitespace', () => {
+    expect(sanitizeUserText('  Website\t\n  Redesign  ', 100)).toBe('Website Redesign');
+  });
+
+  it('removes C0, DEL, and C1 control characters', () => {
+    expect(sanitizeUserText('Client\u0000\u001F\u007F\u0085 Name', 100)).toBe('Client Name');
+  });
+
+  it('returns an empty string when the input is only whitespace or controls', () => {
+    expect(sanitizeUserText('\t\u0000\n\u007F ', 100)).toBe('');
+  });
+
+  it('preserves printable Unicode characters', () => {
+    expect(sanitizeUserText('  Café — 開発  ', 100)).toBe('Café — 開発');
+  });
+
+  it('caps the cleaned value at maxLength', () => {
+    expect(sanitizeUserText('  abcdef  ', 4)).toBe('abcd');
+  });
+
+  it('supports a zero-length cap', () => {
+    expect(sanitizeUserText('text', 0)).toBe('');
+  });
+
+  it.each([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN])(
+    'rejects an invalid maxLength of %p',
+    (maxLength) => {
+      expect(() => sanitizeUserText('text', maxLength)).toThrow(RangeError);
+    },
+  );
+});

--- a/src/lib/sanitizeUserText.ts
+++ b/src/lib/sanitizeUserText.ts
@@ -1,0 +1,19 @@
+/**
+ * Produces display-safe, consistently formatted user text.
+ *
+ * Control characters are removed before whitespace is normalised, then the
+ * result is capped. Callers that accept user input should validate the
+ * normalised, uncapped value before saving so an over-length value can be
+ * reported instead of silently truncated.
+ */
+export function sanitizeUserText(value: string, maxLength: number): string {
+  if (!Number.isSafeInteger(maxLength) || maxLength < 0) {
+    throw new RangeError('maxLength must be a non-negative safe integer');
+  }
+
+  return value
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .slice(0, maxLength);
+}


### PR DESCRIPTION
## Description

<!-- Summarize the changes in this PR and the motivation behind them. -->

Closes #415 

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

<!-- Briefly describe the test cases you added or updated, and any manual testing performed. -->

---

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->

### Security

<!-- Does this PR touch authentication, authorization, wallet logic, API calls, or
     user-supplied input? Describe any security considerations or "N/A" if not applicable. -->
