### PR TITLE
fix(css): restore base font-family on body

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,6 +83,8 @@
 body {
   color: var(--foreground);
   background: var(--background);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
   font-feature-settings: "rlig" 1, "calt" 1;
 }
 


### PR DESCRIPTION
## Summary

The `body` rule in `globals.css` sets `color` and `background` from the theme tokens but never declares a `font-family`. Every page falls back to the browser's default serif (Times New Roman) regardless of theme, which is why the app looks visually "unstyled" even though Tailwind itself is compiling and applying every other utility correctly.

## Root cause

Confirmed this isn't a broken build pipeline: the compiled CSS chunk loads with a 200 and contains a full set of correctly generated utilities, including all the app's `--primary`/`--status-*` custom properties resolving fine. The gap is specifically the missing `font-family` declaration on `body`.

## Fix

```css
body {
  color: var(--foreground);
  background: var(--background);
  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",
    Arial, sans-serif;
  font-feature-settings: "rlig" 1, "calt" 1;
}