### PR TITLE
feat(a11y): breadcrumb nav landmark, aria-current, and focus ring

### DIFF
--- a/docs/components/Accessibility.md
+++ b/docs/components/Accessibility.md
@@ -558,3 +558,77 @@ To verify reduced-motion behavior:
 5. Hover over interactive elements — state changes should be instant, not gradual
 
 All automated tests pass with zero axe violations under reduced-motion conditions.
+
+---
+
+## Breadcrumbs — Nav Landmark, aria-current, and Focus Ring (issue #440)
+
+**Component:** `src/components/Breadcrumbs.tsx`
+**Test file:** `src/components/__tests__/Breadcrumbs.test.tsx`, plus two `jest-axe` states in `src/components/__tests__/a11y.test.tsx`
+
+### What was already correct
+
+Most of this issue's requirements were already implemented when the issue was
+filed: the trail is wrapped in `<nav aria-label="Breadcrumb">` containing an
+`<ol>`, the final crumb renders as non-interactive text with
+`aria-current="page"` instead of a link, and the `/` separators between
+crumbs are marked `aria-hidden="true"`. The one gap was the focus ring on
+the ancestor `<Link>` crumbs.
+
+### Problem found
+
+The ancestor links used a hardcoded `focus-visible:outline-blue-500`
+(Tailwind's fixed `blue-500`, `#3b82f6`) rather than the app's `--ring`
+theme token. Two issues with that:
+
+1. **Wrong color in light mode.** Light mode's own `--ring` token is
+   `#2563eb`, not `blue-500`. The hardcoded class happened to render the
+   *dark*-mode ring color even when the theme was light.
+2. **Not theme-aware.** Every other focus-visible ring in this codebase that
+   follows the current convention (`MilestonesList.tsx`,
+   `toast-provider.tsx`, `SettingsPanel.tsx`) uses
+   `focus-visible:ring-[var(--ring)]` so the color swaps with
+   `[data-theme='dark']`. The hardcoded class didn't, so it was already
+   inconsistent with the rest of the app even before considering contrast.
+
+### Fix
+
+Replaced the hardcoded outline with the same pattern used elsewhere:
+
+```tsx
+className="... rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2"
+```
+
+### Contrast verification
+
+Breadcrumbs are only mounted on the contract detail page
+(`src/app/contracts/[id]/page.tsx`), inside a card with a **hardcoded
+`bg-white`** container that does not vary with `[data-theme]`. That matters
+for this specific check: the ring's *color* is theme-aware (`--ring` swaps
+value), but the *background it's drawn against* does not swap, so both
+themes' ring colors were checked against the same white card rather than
+against `--background`.
+
+| Theme | `--ring` value | Rendered against | Ratio |
+|---|---|---|---|
+| Light | `#2563eb` | white card (`#ffffff`) | 5.17:1 ✅ |
+| Dark | `#3b82f6` | white card (`#ffffff`) — card itself isn't theme-aware | 3.68:1 ✅ |
+
+Both clear the WCAG 2.1 non-text contrast minimum of 3:1 (SC 1.4.11), computed
+with the same relative-luminance method used elsewhere in this document.
+Dark mode has noticeably less headroom (3.68:1 vs. a 3:1 floor) than light
+mode, entirely because the card background doesn't adapt to the theme —
+flagging this since it's the kind of narrow-margin pairing this document
+has previously called out as worth tracking. Making the contract-detail
+card itself theme-aware is a separate, larger change (it touches the whole
+page, not just this component) and is out of scope for this issue.
+
+### Testing
+
+- `Breadcrumbs.test.tsx` — structure/ARIA (nav landmark, `<ol>`, one `<li>`
+  per crumb), link generation, `aria-current` placement, separator
+  `aria-hidden`, dynamic labels, and three new focus-ring assertions: the
+  token classes are present on every ancestor link, and the old
+  `outline-blue-500` class is confirmed absent (regression guard).
+- `a11y.test.tsx` — `jest-axe` audit for a single-crumb trail and a
+  three-crumb trail with a current page, both zero violations.

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -66,7 +66,7 @@ const Breadcrumbs = ({ items }: BreadcrumbsProps) => {
                 // Ancestor: linked crumb
                 <Link
                   href={item.href ?? '/'}
-                  className="truncate max-w-[16rem] transition hover:text-slate-900 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 rounded-sm"
+                  className="truncate max-w-[16rem] transition hover:text-slate-900 hover:underline rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2"
                 >
                   {item.label}
                 </Link>

--- a/src/components/__tests__/Breadcrumbs.test.tsx
+++ b/src/components/__tests__/Breadcrumbs.test.tsx
@@ -140,6 +140,37 @@ describe('Breadcrumbs — separators', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Focus ring
+// ---------------------------------------------------------------------------
+
+describe('Breadcrumbs — focus ring', () => {
+  it('applies the theme-token focus ring to ancestor links', () => {
+    render(<Breadcrumbs items={THREE_CRUMBS} />);
+    const dashboardLink = screen.getByRole('link', { name: 'Dashboard' });
+
+    expect(dashboardLink.className).toContain('focus-visible:ring-2');
+    expect(dashboardLink.className).toContain('focus-visible:ring-[var(--ring)]');
+    expect(dashboardLink.className).toContain('focus-visible:ring-offset-2');
+  });
+
+  it('does not use a hardcoded outline color for the focus ring', () => {
+    // Regression guard: outline-blue-500 doesn't match --ring in light mode
+    // (#2563eb) and was never theme-aware for dark mode either.
+    render(<Breadcrumbs items={THREE_CRUMBS} />);
+    const dashboardLink = screen.getByRole('link', { name: 'Dashboard' });
+
+    expect(dashboardLink.className).not.toContain('outline-blue-500');
+  });
+
+  it('applies the focus ring to every ancestor link, not just the first', () => {
+    render(<Breadcrumbs items={THREE_CRUMBS} />);
+    const contractsLink = screen.getByRole('link', { name: 'Contracts' });
+
+    expect(contractsLink.className).toContain('focus-visible:ring-[var(--ring)]');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Dynamic label (contract id interpolation)
 // ---------------------------------------------------------------------------
 
@@ -176,5 +207,18 @@ describe('Breadcrumbs — dynamic labels', () => {
     expect(within(nav).getByRole('link', { name: 'Dashboard' })).toBeInTheDocument();
     expect(within(nav).getByRole('link', { name: 'Contracts' })).toBeInTheDocument();
     expect(within(nav).getByText('Contract #99')).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('falls back to "/" for an ancestor crumb with no href', () => {
+    render(
+      <Breadcrumbs
+        items={[
+          { label: 'Untitled' },
+          { label: 'Current' },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Untitled' })).toHaveAttribute('href', '/');
   });
 });

--- a/src/components/__tests__/a11y.test.tsx
+++ b/src/components/__tests__/a11y.test.tsx
@@ -7,6 +7,7 @@ import ReputationProfile from '@/components/ReputationProfile';
 import EmptyState from '@/components/EmptyState';
 import StatusBadge from '@/components/StatusBadge';
 import { ToastProvider, useToast } from '@/components/toast/toast-provider';
+import Breadcrumbs from '@/components/Breadcrumbs';
 
 describe('a11y: MilestonesList', () => {
   it('empty list has no violations', async () => {
@@ -576,5 +577,23 @@ describe('a11y: prefers-reduced-motion — toast panels', () => {
     // not deferred behind an animation frame, so it snaps into view.
     const toastPanel = container.querySelector('[role="alert"]');
     expect(toastPanel).toBeInTheDocument();
+  });
+});
+
+describe('a11y: Breadcrumbs', () => {
+  it('single crumb has no violations', async () => {
+    await testA11y(<Breadcrumbs items={[{ label: 'Dashboard', href: '/' }]} />);
+  });
+
+  it('multi-crumb trail with a current page has no violations', async () => {
+    await testA11y(
+      <Breadcrumbs
+        items={[
+          { label: 'Dashboard', href: '/' },
+          { label: 'Contracts', href: '/contracts' },
+          { label: 'Contract #42' },
+        ]}
+      />,
+    );
   });
 });


### PR DESCRIPTION
## Description

Most of this was already correct when the issue was filed: the nav landmark, ordered list, aria-current on the final crumb, and aria-hidden separators were all already in place. The one real gap was the focus ring on the ancestor links, which used a hardcoded outline-blue-500 instead of the app's --ring theme token. That was wrong even in light mode (light's own --ring is #2563eb, not blue-500) and inconsistent with the focus-visible:ring-[var(--ring)] pattern used everywhere else in this codebase.

Checked where Breadcrumbs actually renders (the contract detail page) rather than assuming: it sits inside a hardcoded bg-white card that doesn't respond to [data-theme], so both themes' ring colors were verified against that same white card, not against --background. Light clears comfortably (5.17:1); dark has much less headroom (3.68:1) purely because the card itself isn't theme-aware, which is documented as a known constraint rather than silently assumed fine.

Added three focus-ring tests (token classes present, old hardcoded class confirmed absent as a regression guard, ring applied to every ancestor link not just the first) and two jest-axe states in the shared a11y test file, following this repo's existing per-component testing pattern.

Closes #440

## Type of Change

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage

- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [x] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

`Breadcrumbs.tsx` is at 100% statements/branches/functions/lines after this PR (added one test for the `href ?? '/'` fallback branch, which nothing previously exercised).

- **`Breadcrumbs.test.tsx`**: existing structure/ARIA/link/aria-current/separator coverage, plus three new focus-ring tests (token classes present on every ancestor link, old `outline-blue-500` confirmed absent, ring applied consistently across all ancestor links) and one new href-fallback test.
- **`a11y.test.tsx`**: two new `jest-axe` states — a single-crumb trail and a three-crumb trail with a current page — both zero violations, using `testA11y` per the shared helper convention.
- Full suite: 60/60 relevant tests pass. Repo-wide, only 2 pre-existing failing suites remain (`milestones-sample-banner.test.tsx`, `milestones/page.test.tsx`), confirmed identical on `main` without this branch applied.

---
## CI Note

`npm ci` currently fails on `main` itself — `package-lock.json` is out of sync with `package.json` (missing packages like `@typescript-eslint/type-utils@8.65.0`, and version mismatches like `@typescript-eslint/parser@8.64.0` in the lockfile vs. `8.65.0` required). Reproduced on unmodified `main` with none of this PR's changes applied, so the failing `build-and-test` check is expected and unrelated to this PR — it would fail identically on any branch right now. Not fixed here to keep this PR scoped to #440; happy to open a separate `chore: sync package-lock.json` PR if useful.

## Accessibility & Security Notes

### Accessibility

Ran `jest-axe` via the shared `testA11y` helper for both a single-crumb and a multi-crumb-with-current-page state — zero violations in both. Manually verified via the DOM that the nav landmark (`aria-label="Breadcrumb"`), `aria-current="page"` placement, and `aria-hidden` separators were already correct pre-PR; this change is scoped to the focus-visible ring only. No manual screen-reader pass performed beyond the automated axe checks and the existing structural test coverage.

### Security

N/A — no auth, wallet, API, or user-input handling touched. This is a presentational focus-ring fix on a client-rendered breadcrumb trail.