### PR TITLE
a11y(contracts): announce status changes

### DIFF
--- a/src/app/contracts/[id]/__tests__/page.test.tsx
+++ b/src/app/contracts/[id]/__tests__/page.test.tsx
@@ -408,6 +408,10 @@ describe('existing contract detail page behaviour', () => {
         screen.getByRole('complementary', { name: /what would you like to do/i }),
       ).toBeInTheDocument();
     });
+
+    expect(
+      screen.getByRole('status', { name: 'Contract status updates' }),
+    ).toBeEmptyDOMElement();
   });
 
   it('persists the confirmed dispute flow and reflects the disputed status in the page', async () => {
@@ -431,6 +435,9 @@ describe('existing contract detail page behaviour', () => {
     });
 
     expect(within(getContractSummarySection()).getByLabelText('Status: Disputed')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Contract status updates' })).toHaveTextContent(
+      'Contract status changed to Disputed.',
+    );
     expect(screen.queryByRole('button', { name: /release funds to the contractor/i })).not.toBeInTheDocument();
     expect(await screen.findByText('Dispute opened')).toBeInTheDocument();
   });

--- a/src/app/contracts/[id]/page.tsx
+++ b/src/app/contracts/[id]/page.tsx
@@ -10,6 +10,7 @@ import ContractProgress from '@/components/ContractProgress';
 import { ContractProgressSkeleton } from '@/components/ContractProgressSkeleton';
 import { ContractSummarySkeleton } from '@/components/ContractSummarySkeleton';
 import { MilestonesListSkeleton } from '@/components/MilestonesListSkeleton';
+import ContractStatusAnnouncer from '@/components/ContractStatusAnnouncer';
 import SafeBoundary from '@/components/SafeBoundary';
 import { resolveContractData, ContractData } from '@/lib/contractResolver';
 import { useToast } from '@/components/toast/toast-provider';
@@ -195,6 +196,7 @@ const ContractDetailPageContent = ({ id }: { id: string }) => {
 
   return (
     <main className="min-h-screen bg-slate-50 px-4 py-8 sm:px-6 lg:px-8">
+      {contractData ? <ContractStatusAnnouncer status={contractData.status} /> : null}
       <div className="mx-auto max-w-screen-2xl space-y-6">
         <div className="flex items-center justify-between gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
           <div>

--- a/src/components/ContractStatusAnnouncer.tsx
+++ b/src/components/ContractStatusAnnouncer.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { StatusType } from './StatusBadge';
+
+export interface ContractStatusAnnouncerProps {
+  status: StatusType;
+}
+
+/**
+ * Announces contract status transitions without repeating the initial status.
+ */
+const ContractStatusAnnouncer = ({ status }: ContractStatusAnnouncerProps) => {
+  const previousStatusRef = useRef(status);
+  const [announcement, setAnnouncement] = useState('');
+
+  useEffect(() => {
+    if (previousStatusRef.current === status) return;
+
+    previousStatusRef.current = status;
+    setAnnouncement(`Contract status changed to ${status}.`);
+  }, [status]);
+
+  return (
+    <span
+      role="status"
+      aria-label="Contract status updates"
+      aria-live="polite"
+      aria-atomic="true"
+      className="sr-only"
+    >
+      {announcement}
+    </span>
+  );
+};
+
+export default ContractStatusAnnouncer;

--- a/src/components/__tests__/ContractStatusAnnouncer.test.tsx
+++ b/src/components/__tests__/ContractStatusAnnouncer.test.tsx
@@ -1,0 +1,57 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import ContractStatusAnnouncer from '../ContractStatusAnnouncer';
+import { assertNoA11yViolations } from '@/test-utils/a11y';
+
+describe('ContractStatusAnnouncer', () => {
+  it('renders an empty polite live region on initial mount', () => {
+    render(<ContractStatusAnnouncer status="Active" />);
+
+    const liveRegion = screen.getByRole('status', { name: 'Contract status updates' });
+    expect(liveRegion).toBeEmptyDOMElement();
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    expect(liveRegion).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('announces a genuine status transition', async () => {
+    const { rerender } = render(<ContractStatusAnnouncer status="Active" />);
+
+    rerender(<ContractStatusAnnouncer status="Completed" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('status', { name: 'Contract status updates' }),
+      ).toHaveTextContent('Contract status changed to Completed.');
+    });
+  });
+
+  it('does not announce a same-status rerender', () => {
+    const { rerender } = render(<ContractStatusAnnouncer status="Pending" />);
+
+    rerender(<ContractStatusAnnouncer status="Pending" />);
+
+    expect(
+      screen.getByRole('status', { name: 'Contract status updates' }),
+    ).toBeEmptyDOMElement();
+  });
+
+  it('settles on the latest status during rapid transitions', async () => {
+    const { rerender } = render(<ContractStatusAnnouncer status="Active" />);
+
+    act(() => {
+      rerender(<ContractStatusAnnouncer status="Pending" />);
+      rerender(<ContractStatusAnnouncer status="Disputed" />);
+    });
+
+    await waitFor(() => {
+      const liveRegion = screen.getByRole('status', { name: 'Contract status updates' });
+      expect(liveRegion).toHaveTextContent('Contract status changed to Disputed.');
+      expect(liveRegion).not.toHaveTextContent('Pending');
+    });
+  });
+
+  it('has no automated accessibility violations', async () => {
+    const { container } = render(<ContractStatusAnnouncer status="Active" />);
+
+    await assertNoA11yViolations(container);
+  });
+});


### PR DESCRIPTION
## Description

Add an atomic polite live region to the contract detail page. It remains empty when the loaded contract first mounts, announces genuine status transitions, ignores same-status rerenders, and settles on the latest value during rapid transitions.

Closes #463

## Type of Change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage

- [x] Module test coverage for impacted files meets or exceeds the 95% minimum threshold
- [x] Accessibility tests use the shared `assertNoA11yViolations` helper

### What was tested?

- 5 focused announcer tests cover initial mount, genuine transition, same-status rerender, rapid transitions, and automated accessibility
- new component coverage: 100% statements, branches, functions, and lines
- contract detail integration: 30 tests passed
- full suite: 70 suites and 1,125 tests passed
- production build and lint passed

---

## Accessibility & Security Notes

### Accessibility

The live region uses `role="status"`, `aria-live="polite"`, and `aria-atomic="true"`. It has an accessible label and visually hidden presentation. The shared jest-axe audit passes. No manual screen-reader session was performed.

### Security

No authentication, authorization, wallet, API, or user-input behavior changes. `npm install` reports three existing dependency audit findings, one moderate and two high; this PR changes no dependencies.
