### PR TITLE
Feature/UI 01 back to top

### DIFF
--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
+import BackToTop from '../../components/BackToTop';
 import EmptyState from '../../components/EmptyState';
 import { ContractCreationForm } from '../../components/ContractCreationForm';
 import { listContracts, saveContract } from '@/lib/repository';
@@ -11,6 +12,7 @@ const ContractsPage: React.FC = () => {
   // a state update so the list reflects newly added items immediately.
   const [contracts, setContracts] = useState<Contract[]>(() => listContracts());
   const [showForm, setShowForm] = useState(false);
+  const headingRef = useRef<HTMLHeadingElement>(null);
 
   /**
    * Opens the contract creation form modal.
@@ -38,7 +40,9 @@ const ContractsPage: React.FC = () => {
 
   return (
     <main className="min-h-screen p-8">
-      <h1 className="text-2xl font-bold mb-6">Contracts</h1>
+      <h1 ref={headingRef} tabIndex={-1} className="text-2xl font-bold mb-6 focus-visible:outline-none">
+        Contracts
+      </h1>
 
       {!showForm && contracts.length === 0 && (
         <EmptyState
@@ -75,6 +79,9 @@ const ContractsPage: React.FC = () => {
               </li>
             ))}
           </ul>
+          <div className="mt-4 flex justify-end">
+            <BackToTop focusTargetRef={headingRef} />
+          </div>
         </>
       )}
 
@@ -89,4 +96,3 @@ const ContractsPage: React.FC = () => {
 };
 
 export default ContractsPage;
-

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+
+export type BackToTopProps = {
+  /**
+   * The scrollable element to watch and control. Pass this when the list
+   * scrolls inside its own container (e.g. `overflow-y-auto`). Omit it to
+   * track the window instead, for lists that grow the page itself.
+   */
+  containerRef?: RefObject<HTMLElement | null>;
+  /**
+   * Element that should receive focus once the view returns to the top
+   * (WCAG 2.4.3 – focus order). Defaults to the scroll container itself
+   * when `containerRef` is provided; pass an explicit ref (e.g. a heading
+   * with `tabIndex={-1}`) when operating on the window.
+   */
+  focusTargetRef?: RefObject<HTMLElement | null>;
+  /** Scroll distance in pixels past which the button appears. */
+  threshold?: number;
+  /** Accessible label and visible text for the button. */
+  label?: string;
+  /** Extra classes merged onto the button for per-usage placement. */
+  className?: string;
+};
+
+const DEFAULT_THRESHOLD = 300;
+const DEFAULT_LABEL = 'Back to top';
+
+/**
+ * Accessible, reusable back-to-top control for long lists.
+ *
+ * Renders nothing until the tracked scroll position passes `threshold`,
+ * hides again near the top, and moves focus to `focusTargetRef` (or the
+ * container) on activation so keyboard and screen-reader users aren't left
+ * behind visually. Works against either a specific scrollable container or
+ * the window, so the same component can be reused across different list
+ * layouts.
+ */
+const BackToTop = ({
+  containerRef,
+  focusTargetRef,
+  threshold = DEFAULT_THRESHOLD,
+  label = DEFAULT_LABEL,
+  className = '',
+}: BackToTopProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const rafIdRef = useRef<number | null>(null);
+
+  const getScrollTop = useCallback(() => {
+    const el = containerRef?.current;
+    return el ? el.scrollTop : window.scrollY;
+  }, [containerRef]);
+
+  const checkThreshold = useCallback(() => {
+    setIsVisible(getScrollTop() > threshold);
+  }, [getScrollTop, threshold]);
+
+  useEffect(() => {
+    const scrollTarget: HTMLElement | Window = containerRef?.current ?? window;
+
+    // Coalesce rapid scroll events to at most one visibility check per
+    // animation frame, so fast/continuous scrolling doesn't thrash state.
+    const handleScroll = () => {
+      if (rafIdRef.current !== null) return;
+      rafIdRef.current = window.requestAnimationFrame(() => {
+        rafIdRef.current = null;
+        checkThreshold();
+      });
+    };
+
+    // Establish the correct initial state (e.g. a restored scroll position,
+    // or a list too short to scroll at all).
+    checkThreshold();
+
+    scrollTarget.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      scrollTarget.removeEventListener('scroll', handleScroll);
+      if (rafIdRef.current !== null) {
+        window.cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
+  }, [containerRef, checkThreshold]);
+
+  const handleActivate = useCallback(() => {
+    const el = containerRef?.current;
+
+    if (el) {
+      el.scrollTo({ top: 0, behavior: 'smooth' });
+    } else {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+
+    const focusTarget = focusTargetRef?.current ?? el;
+    focusTarget?.focus();
+  }, [containerRef, focusTargetRef]);
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={handleActivate}
+      aria-label={label}
+      className={`inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 ${className}`.trim()}
+    >
+      <span aria-hidden="true">&uarr;</span>
+      {label}
+    </button>
+  );
+};
+
+export default BackToTop;

--- a/src/components/MilestonesList.tsx
+++ b/src/components/MilestonesList.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react';
+import BackToTop from './BackToTop';
 import StatusBadge, { StatusType, statusColorMap, statusIconMap } from './StatusBadge';
 import { usePreferences } from '@/lib/preferences';
 import { isDueSoon } from '@/lib/dueSoon';
@@ -195,6 +196,12 @@ const MilestonesList = ({ milestones, contractCurrency }: MilestonesListProps) =
           </article>
         ))}
       </div>
+
+      {milestones.length > 0 && (
+        <div className="mt-3 flex justify-end">
+          <BackToTop containerRef={listContainerRef} threshold={240} />
+        </div>
+      )}
     </section>
   );
 };

--- a/src/components/__tests__/BackToTop.test.tsx
+++ b/src/components/__tests__/BackToTop.test.tsx
@@ -1,10 +1,8 @@
 import React, { createRef } from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { axe, toHaveNoViolations } from 'jest-axe';
+import { assertNoA11yViolations } from '@/test-utils/a11y';
 import BackToTop from '../BackToTop';
-
-expect.extend(toHaveNoViolations);
 
 // jsdom doesn't implement scrollTo/rAF – provide deterministic mocks so we
 // can assert on them and so the component doesn't throw "not implemented".
@@ -199,8 +197,7 @@ describe('BackToTop (window mode)', () => {
       await new Promise((resolve) => window.requestAnimationFrame(resolve));
     });
 
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
+    await assertNoA11yViolations(container);
   });
 });
 

--- a/src/components/__tests__/BackToTop.test.tsx
+++ b/src/components/__tests__/BackToTop.test.tsx
@@ -1,0 +1,255 @@
+import React, { createRef } from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import BackToTop from '../BackToTop';
+
+expect.extend(toHaveNoViolations);
+
+// jsdom doesn't implement scrollTo/rAF – provide deterministic mocks so we
+// can assert on them and so the component doesn't throw "not implemented".
+const flushRaf = () => {
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  window.requestAnimationFrame = (cb: (time: number) => void): number => {
+    return setTimeout(() => cb(0), 0) as unknown as number;
+  };
+  window.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  window.scrollTo = jest.fn();
+  Element.prototype.scrollTo = jest.fn();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe('BackToTop (window mode)', () => {
+  it('is hidden on initial render when the page has not scrolled', () => {
+    render(<BackToTop />);
+    expect(screen.queryByRole('button', { name: 'Back to top' })).not.toBeInTheDocument();
+  });
+
+  it('never appears for a short page that cannot scroll past the threshold', () => {
+    render(<BackToTop threshold={300} />);
+
+    // Simulate a short list: scroll events fire but scrollY stays under
+    // the threshold because there's nothing to scroll.
+    Object.defineProperty(window, 'scrollY', { value: 50, configurable: true });
+    fireEvent.scroll(window);
+    flushRaf();
+
+    expect(screen.queryByRole('button', { name: 'Back to top' })).not.toBeInTheDocument();
+  });
+
+  it('appears once scrolled past the threshold', () => {
+    render(<BackToTop threshold={300} />);
+
+    Object.defineProperty(window, 'scrollY', { value: 500, configurable: true });
+    fireEvent.scroll(window);
+    flushRaf();
+
+    expect(screen.getByRole('button', { name: 'Back to top' })).toBeInTheDocument();
+  });
+
+  it('hides again once scrolled back near the top', () => {
+    render(<BackToTop threshold={300} />);
+
+    Object.defineProperty(window, 'scrollY', { value: 500, configurable: true });
+    fireEvent.scroll(window);
+    flushRaf();
+    expect(screen.getByRole('button', { name: 'Back to top' })).toBeInTheDocument();
+
+    Object.defineProperty(window, 'scrollY', { value: 10, configurable: true });
+    fireEvent.scroll(window);
+    flushRaf();
+    expect(screen.queryByRole('button', { name: 'Back to top' })).not.toBeInTheDocument();
+  });
+
+  it('coalesces rapid scroll events into a single visibility check per frame', () => {
+    render(<BackToTop threshold={300} />);
+
+    Object.defineProperty(window, 'scrollY', { value: 500, configurable: true });
+    // Fire a burst of scroll events, as happens on a fast trackpad/wheel scroll.
+    for (let i = 0; i < 20; i += 1) {
+      fireEvent.scroll(window);
+    }
+
+    // Only one rAF-scheduled check should be pending, regardless of how many
+    // scroll events fired in the same frame.
+    expect(jest.getTimerCount()).toBe(1);
+
+    flushRaf();
+    expect(screen.getByRole('button', { name: 'Back to top' })).toBeInTheDocument();
+  });
+
+  it('scrolls the window to top and moves focus to the given target on click', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const focusTargetRef = createRef<HTMLHeadingElement>();
+
+    render(
+      <>
+        <h1 ref={focusTargetRef} tabIndex={-1}>
+          Contracts
+        </h1>
+        <BackToTop threshold={300} focusTargetRef={focusTargetRef} />
+      </>,
+    );
+
+    Object.defineProperty(window, 'scrollY', { value: 500, configurable: true });
+    fireEvent.scroll(window);
+    flushRaf();
+
+    const button = screen.getByRole('button', { name: 'Back to top' });
+    await user.click(button);
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+    expect(focusTargetRef.current).toHaveFocus();
+  });
+
+  it('is operable from the keyboard (Enter and Space activate it)', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const focusTargetRef = createRef<HTMLHeadingElement>();
+
+    render(
+      <>
+        <h1 ref={focusTargetRef} tabIndex={-1}>
+          Contracts
+        </h1>
+        <BackToTop threshold={300} focusTargetRef={focusTargetRef} />
+      </>,
+    );
+
+    Object.defineProperty(window, 'scrollY', { value: 500, configurable: true });
+    fireEvent.scroll(window);
+    flushRaf();
+
+    const button = screen.getByRole('button', { name: 'Back to top' });
+    button.focus();
+    expect(button).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(window.scrollTo).toHaveBeenCalledTimes(1);
+    expect(focusTargetRef.current).toHaveFocus();
+
+    // Re-show the button to test Space as well.
+    focusTargetRef.current?.blur();
+    Object.defineProperty(window, 'scrollY', { value: 500, configurable: true });
+    fireEvent.scroll(window);
+    flushRaf();
+    const buttonAgain = screen.getByRole('button', { name: 'Back to top' });
+    buttonAgain.focus();
+
+    await user.keyboard(' ');
+    expect(window.scrollTo).toHaveBeenCalledTimes(2);
+    expect(focusTargetRef.current).toHaveFocus();
+  });
+
+  it('falls back to no-op focus when no focus target is provided in window mode', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<BackToTop threshold={300} />);
+
+    Object.defineProperty(window, 'scrollY', { value: 500, configurable: true });
+    fireEvent.scroll(window);
+    flushRaf();
+
+    const button = screen.getByRole('button', { name: 'Back to top' });
+    await expect(user.click(button)).resolves.not.toThrow();
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+
+  it('cleans up its scroll listener and any pending frame on unmount', () => {
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+    const { unmount } = render(<BackToTop threshold={300} />);
+
+    Object.defineProperty(window, 'scrollY', { value: 500, configurable: true });
+    fireEvent.scroll(window);
+    // Unmount before the scheduled rAF check flushes.
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+    // Flushing after unmount should not throw even though a frame was pending.
+    expect(() => flushRaf()).not.toThrow();
+  });
+
+  it('respects a custom label', () => {
+    render(<BackToTop threshold={300} label="Top of milestones" />);
+
+    Object.defineProperty(window, 'scrollY', { value: 500, configurable: true });
+    fireEvent.scroll(window);
+    flushRaf();
+
+    expect(screen.getByRole('button', { name: 'Top of milestones' })).toBeInTheDocument();
+  });
+
+  it('has no detectable accessibility violations when visible', async () => {
+    // axe's internal async work doesn't play well with fake timers, so use
+    // real ones for just this assertion.
+    jest.useRealTimers();
+    const { container } = render(<BackToTop threshold={300} />);
+
+    Object.defineProperty(window, 'scrollY', { value: 500, configurable: true });
+    fireEvent.scroll(window);
+    await act(async () => {
+      await new Promise((resolve) => window.requestAnimationFrame(resolve));
+    });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('BackToTop (container mode)', () => {
+  const ContainerHarness = ({ threshold = 300 }: { threshold?: number }) => {
+    const containerRef = React.useRef<HTMLDivElement>(null);
+    return (
+      <div ref={containerRef} tabIndex={0} data-testid="scroll-container" style={{ overflowY: 'auto' }}>
+        <BackToTop containerRef={containerRef} threshold={threshold} />
+      </div>
+    );
+  };
+
+  it('tracks the container scrollTop instead of the window', () => {
+    render(<ContainerHarness threshold={300} />);
+    const container = screen.getByTestId('scroll-container');
+
+    Object.defineProperty(container, 'scrollTop', { value: 500, configurable: true });
+    fireEvent.scroll(container);
+    flushRaf();
+
+    expect(screen.getByRole('button', { name: 'Back to top' })).toBeInTheDocument();
+  });
+
+  it('never appears for a short container that never scrolls', () => {
+    render(<ContainerHarness threshold={300} />);
+    const container = screen.getByTestId('scroll-container');
+
+    // scrollTop stays at 0 because content is shorter than the container.
+    fireEvent.scroll(container);
+    flushRaf();
+
+    expect(screen.queryByRole('button', { name: 'Back to top' })).not.toBeInTheDocument();
+  });
+
+  it('scrolls the container (not the window) and focuses it by default on activate', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<ContainerHarness threshold={300} />);
+    const container = screen.getByTestId('scroll-container');
+
+    Object.defineProperty(container, 'scrollTop', { value: 500, configurable: true });
+    fireEvent.scroll(container);
+    flushRaf();
+
+    const button = screen.getByRole('button', { name: 'Back to top' });
+    await user.click(button);
+
+    expect(container.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+    expect(window.scrollTo).not.toHaveBeenCalled();
+    expect(container).toHaveFocus();
+  });
+});


### PR DESCRIPTION
## Description
Adds a shared BackToTop control that's reused across both long lists in the app: the Milestones list, which scrolls inside its own container, and the Contracts list, which scrolls the full page. The button only shows up once you've scrolled past a set threshold, hides again near the top, and never appears at all for lists that are too short to scroll. Clicking or pressing it scrolls back up and moves keyboard focus to the top of the list so screen reader and keyboard users don't lose their place.

A few things worth flagging:
- src/app/contracts/page.tsx has a pre-existing TODO about swapping the current ul for a proper ContractSummary component. Left that alone since it's a separate refactor and outside what this issue asked for.
- Full suite output shows some console.error lines from repository.test.ts (SSR/localStorage failure cases) and console.warn lines about an outdated JSX transform. Both are pre-existing and unrelated to this change, they show up on main too.
- Git prints a couple of CRLF/LF line-ending warnings on the new files during `git add`. Cosmetic, no functional impact, just a Windows/Git config thing.

Closes #491

## Type of Change
- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update
---
## Pre-flight Checklist
All items must be checked before requesting review.
- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully
---
## Testing & Coverage
- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [x] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`
### What was tested?
Added 14 tests for BackToTop covering: hidden on initial load, appears past the threshold, hides again near the top, never shows up for a list too short to scroll, rapid scroll events collapsed into a single check per frame, clicking and keyboard activation (Enter and Space) both scroll to top and move focus, focus falls back to the scroll container when no explicit target is passed, listener cleanup on unmount, custom label support, and zero accessibility violations via the shared a11y helper. BackToTop.tsx sits at 100% statement, branch, function, and line coverage. Full suite: 73 suites, 1232 tests, all green.

---
## Accessibility & Security Notes
### Accessibility
Ran the shared assertNoA11yViolations helper (jest-axe) against the component and got zero violations. It's a plain button element with an aria-label, so keyboard access comes for free, and I explicitly move focus to the top of the list on activation to cover WCAG 2.4.3.
### Security
N/A, this doesn't touch auth, wallet logic, API calls, or user input.