### PR TITLE
feat(toast): cap visible toasts with a queue

### DIFF
--- a/docs/components/Toast.md
+++ b/docs/components/Toast.md
@@ -169,45 +169,37 @@ const result = showSuccess({ title: 'Done' });
 if (result === 'suppressed') { /* user preference active */ }
 ```
 
-### `MAX_VISIBLE_TOASTS` and Eviction Order
+### `MAX_VISIBLE_TOASTS` and the Overflow Queue
 
-Source: lines 62-69 (constant), lines 387-395 (eviction logic).
-Test suite: `describe('maxVisible cap (MAX_VISIBLE_TOASTS = 4)', ...)` (test lines 488-678).
-
-```ts
-const MAX_VISIBLE_TOASTS = 4;   // source line 69
-```
-
-When a new toast would make the queue length exceed `MAX_VISIBLE_TOASTS`,
-the **oldest** toast (index 0) is evicted **before** the new one is appended:
+Test suite: `describe('toast queue (MAX_VISIBLE_TOASTS = 4)', ...)`.
 
 ```ts
-// source lines 387-395
-setToasts((currentToasts) => {
-  const next = [...currentToasts, { ...toast, id, variant }];
-  if (next.length <= MAX_VISIBLE_TOASTS) {
-    return next;
-  }
-  // Evict the oldest toast and cancel its timer.
-  const [evicted, ...remaining] = next;
-  clearToastTimer(evicted.id);
-  return remaining;
-});
+const MAX_VISIBLE_TOASTS = 4;
 ```
 
-The eviction order is **oldest-first (FIFO)**. Tests confirm:
+At most `4` toasts are visible at once. A toast created while at that cap is
+**queued**, not evicted — nothing already on screen is ever pushed off to
+make room, and a queued toast is never silently discarded. Internally the
+provider tracks `{ visible: ToastRecord[], queued: ToastRecord[] }`; only
+`visible` is rendered and only `visible` toasts get auto-dismiss timers.
 
-- Adding 5 toasts: `Toast 1` is gone, `Toast 2`-`Toast 5` are visible
-  (test lines 549-553).
-- Adding 6 toasts: `Toast 1` and `Toast 2` are gone, `Toast 6` is visible
-  (test lines 565-568).
-- The evicted toast's auto-dismiss timer is **cancelled** (`clearToastTimer`)
-  so its callback cannot fire after removal (test lines 571-616,
-  `clearTimeoutSpy` assertion at line 609).
-- The live region after eviction announces the **newest** surviving toast
-  (test lines 618-629).
-- Eviction works the same way when `toastDuration` is `'persistent'`
-  (test lines 1332-1372).
+Queued toasts are promoted into the freed slot when a visible toast is
+dismissed (dismiss button or its own auto-dismiss timer), oldest-first
+**within the same severity**. Error toasts jump ahead of any success toasts
+already sitting in the queue, so a burst of success toasts can never bury or
+drop an error — see `enqueueBySeverity`. Tests confirm:
+
+- Adding 5 toasts: `Toast 1`-`Toast 4` stay visible, `Toast 5` waits in the
+  queue (it is not rendered, and not lost).
+- Dismissing one visible toast promotes the oldest queued toast into view,
+  with a fresh auto-dismiss timer scheduled at promotion time.
+- The live region only ever announces a toast that is actually visible —
+  never one still waiting in the queue.
+- Queuing an error behind an already-queued success promotes the error
+  first once a slot frees up (severity ordering).
+- A large success burst followed by one error still surfaces that error
+  well before the ten successes ahead of it have all cycled through.
+- The same queueing behavior holds when `toastDuration` is `'persistent'`.
 
 ### Density and Stacking Gap
 
@@ -361,10 +353,12 @@ The content formula (source lines 210, 213):
 `${toast.title}${toast.description ? `. ${toast.description}` : ''}`
 ```
 
-Only the **most recent** toast of each variant is announced. When the toast
-stack is replaced by eviction, the live region reflects the newest surviving
-toast (test lines 618-629: after adding 5 toasts the polite region contains
-`'Toast 5'`, not `'Toast 1'`).
+Only the **most recent** toast of each variant is announced — and only
+among toasts that are actually **visible**. A toast still waiting in the
+overflow queue is not announced until it is promoted (see
+"`MAX_VISIBLE_TOASTS` and the Overflow Queue" below): after adding 5 toasts
+in a row, the polite region contains `'Toast 4'`, not `'Toast 5'`, because
+`Toast 5` hasn't been shown yet.
 
 ### Dismiss Button
 
@@ -444,6 +438,6 @@ export function ContractActions() {
 |---------|--------------|
 | `useToast` throws `"must be used within a ToastProvider"` | Component is outside `<ToastProvider>` (source line 533) |
 | Success toasts not appearing | `quietMode` is `true`; `showSuccess` returns `'suppressed'` (source lines 407-408) |
-| Only 4 toasts visible after a burst | `MAX_VISIBLE_TOASTS = 4`; oldest toast evicted (source lines 69, 392-395) |
+| Only 4 toasts visible after a burst | `MAX_VISIBLE_TOASTS = 4`; the rest are queued and promoted as slots free up, not dropped |
 | Toast never dismisses | `toastDuration` is `'persistent'` with no per-call `duration` override (source lines 436-438) |
 | Action button click does not dismiss | Impossible by design: `onDismiss` is called unconditionally after `onClick` (source lines 165-168) |

--- a/src/components/toast/toast-provider.test.tsx
+++ b/src/components/toast/toast-provider.test.tsx
@@ -488,7 +488,7 @@ describe('default duration', () => {
   });
 });
 
-describe('maxVisible cap (MAX_VISIBLE_TOASTS = 4)', () => {
+describe('toast queue (MAX_VISIBLE_TOASTS = 4)', () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
@@ -540,7 +540,7 @@ describe('maxVisible cap (MAX_VISIBLE_TOASTS = 4)', () => {
     expect(screen.getAllByRole('status')).toHaveLength(4);
   });
 
-  it('evicts the oldest toast when over cap, keeping only MAX_VISIBLE_TOASTS', () => {
+  it('queues overflow instead of evicting, keeping only MAX_VISIBLE_TOASTS visible', () => {
     render(
       <ToastProvider>
         <MultiToastHarness count={5} />
@@ -549,14 +549,15 @@ describe('maxVisible cap (MAX_VISIBLE_TOASTS = 4)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /add 5 toasts/i }));
 
-    const visible = screen.getAllByRole('status');
-    expect(visible).toHaveLength(4);
-    expect(screen.queryAllByText('Toast 1', { selector: 'p' })).toHaveLength(0);
-    expect(screen.getAllByText('Toast 2', { selector: 'p' })).toHaveLength(1);
-    expect(screen.getAllByText('Toast 5', { selector: 'p' })).toHaveLength(1);
+    // Still exactly 4 visible, but they are the *first* four created —
+    // nothing already on screen gets pushed off to make room.
+    expect(screen.getAllByRole('status')).toHaveLength(4);
+    expect(screen.getAllByText('Toast 1', { selector: 'p' })).toHaveLength(1);
+    expect(screen.getAllByText('Toast 4', { selector: 'p' })).toHaveLength(1);
+    expect(screen.queryAllByText('Toast 5', { selector: 'p' })).toHaveLength(0);
   });
 
-  it('always keeps the newest toast after multiple over-cap additions', () => {
+  it('keeps every toast from a large over-cap burst somewhere (visible or queued), never dropping one', () => {
     render(
       <ToastProvider>
         <MultiToastHarness count={6} />
@@ -566,80 +567,23 @@ describe('maxVisible cap (MAX_VISIBLE_TOASTS = 4)', () => {
     fireEvent.click(screen.getByRole('button', { name: /add 6 toasts/i }));
 
     expect(screen.getAllByRole('status')).toHaveLength(4);
-    expect(screen.queryAllByText('Toast 1', { selector: 'p' })).toHaveLength(0);
-    expect(screen.queryAllByText('Toast 2', { selector: 'p' })).toHaveLength(0);
-    expect(screen.getAllByText('Toast 6', { selector: 'p' })).toHaveLength(1);
+    expect(screen.getAllByText('Toast 1', { selector: 'p' })).toHaveLength(1);
+    expect(screen.getAllByText('Toast 4', { selector: 'p' })).toHaveLength(1);
+    // 5 and 6 are queued, not gone — dismissing visible toasts below
+    // confirms they are still there and get promoted in order.
+    expect(screen.queryAllByText('Toast 5', { selector: 'p' })).toHaveLength(0);
+    expect(screen.queryAllByText('Toast 6', { selector: 'p' })).toHaveLength(0);
   });
 
-  it('clears the evicted toast timer so it cannot auto-dismiss after eviction', async () => {
+  it('promotes the oldest queued toast into view, with a working auto-dismiss timer, when a visible toast is dismissed', async () => {
     function SequentialHarness() {
       const { showSuccess } = useToast();
       return (
         <>
           <button
             onClick={() => {
-              for (let i = 1; i <= 4; i++) {
-                showSuccess({ title: `SeqToast ${i}`, duration: 5000 });
-              }
-            }}
-            type="button"
-          >
-            Add 4
-          </button>
-          <button
-            onClick={() => showSuccess({ title: 'SeqToast 5', duration: 5000 })}
-            type="button"
-          >
-            Add 5th
-          </button>
-        </>
-      );
-    }
-
-    render(
-      <ToastProvider>
-        <SequentialHarness />
-      </ToastProvider>,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: /add 4/i }));
-    expect(screen.getAllByRole('status')).toHaveLength(4);
-
-    const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
-
-    fireEvent.click(screen.getByRole('button', { name: /add 5th/i }));
-
-    expect(clearTimeoutSpy).toHaveBeenCalled();
-
-    expect(screen.getAllByRole('status')).toHaveLength(4);
-    expect(screen.queryAllByText('SeqToast 1', { selector: 'p' })).toHaveLength(0);
-    expect(screen.getAllByText('SeqToast 5', { selector: 'p' })).toHaveLength(1);
-
-    clearTimeoutSpy.mockRestore();
-  });
-
-  it('announces the newest toast in the live region after eviction', () => {
-    render(
-      <ToastProvider>
-        <MultiToastHarness count={5} />
-      </ToastProvider>,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: /add 5 toasts/i }));
-
-    const politeRegion = document.querySelector('[aria-live="polite"]');
-    expect(politeRegion).toHaveTextContent('Toast 5');
-  });
-
-  it('does not affect pause-on-hover after eviction', async () => {
-    function SingleEvictHarness() {
-      const { showSuccess } = useToast();
-      return (
-        <>
-          <button
-            onClick={() => {
               for (let i = 1; i <= 5; i++) {
-                showSuccess({ title: `T${i}`, duration: 2000 });
+                showSuccess({ title: `SeqToast ${i}`, duration: 5000 });
               }
             }}
             type="button"
@@ -652,11 +596,72 @@ describe('maxVisible cap (MAX_VISIBLE_TOASTS = 4)', () => {
 
     render(
       <ToastProvider>
-        <SingleEvictHarness />
+        <SequentialHarness />
       </ToastProvider>,
     );
 
     fireEvent.click(screen.getByRole('button', { name: /add 5/i }));
+    expect(screen.getAllByRole('status')).toHaveLength(4);
+    expect(screen.queryAllByText('SeqToast 5', { selector: 'p' })).toHaveLength(0);
+
+    // Dismiss the oldest visible toast — this should free a slot for the
+    // queued fifth toast, not just shrink the visible count.
+    fireEvent.click(screen.getAllByLabelText(/dismiss success notification/i)[0]);
+
+    expect(screen.getAllByRole('status')).toHaveLength(4);
+    expect(screen.queryAllByText('SeqToast 1', { selector: 'p' })).toHaveLength(0);
+    expect(screen.getAllByText('SeqToast 5', { selector: 'p' })).toHaveLength(1);
+
+    // The promoted toast gets its own timer, scheduled fresh at promotion time.
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('SeqToast 5', { selector: 'p' })).toHaveLength(0);
+    });
+  });
+
+  it('announces the toast that is actually visible, not one still waiting in the queue', () => {
+    render(
+      <ToastProvider>
+        <MultiToastHarness count={5} />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /add 5 toasts/i }));
+
+    // Toast 5 hasn't been shown yet, so it must not be announced either.
+    const politeRegion = document.querySelector('[aria-live="polite"]');
+    expect(politeRegion).toHaveTextContent('Toast 4');
+    expect(politeRegion).not.toHaveTextContent('Toast 5');
+  });
+
+  it('does not affect pause-on-hover for a toast promoted from the queue', async () => {
+    function SingleQueueHarness() {
+      const { showSuccess } = useToast();
+      return (
+        <button
+          onClick={() => {
+            for (let i = 1; i <= 5; i++) {
+              showSuccess({ title: `T${i}`, duration: 2000 });
+            }
+          }}
+          type="button"
+        >
+          Add 5
+        </button>
+      );
+    }
+
+    render(
+      <ToastProvider>
+        <SingleQueueHarness />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /add 5/i }));
+    fireEvent.click(screen.getAllByLabelText(/dismiss success notification/i)[0]);
 
     const t5Para = screen.getAllByText('T5', { selector: 'p' })[0];
     const t5 = t5Para.closest('[role="status"]')!;
@@ -677,6 +682,155 @@ describe('maxVisible cap (MAX_VISIBLE_TOASTS = 4)', () => {
     await waitFor(() => {
       expect(screen.queryAllByText('T5', { selector: 'p' })).toHaveLength(0);
     });
+  });
+
+  it('promotes a queued error ahead of a success toast that was queued earlier (severity ordering)', () => {
+    function SeverityHarness() {
+      const { showSuccess, showError } = useToast();
+      return (
+        <>
+          <button
+            onClick={() => {
+              for (let i = 1; i <= 4; i++) {
+                showSuccess({ title: `Fill ${i}`, duration: 10000 });
+              }
+              // Both of these are created over-cap: a success first, then an
+              // error. Without severity ordering the success would be
+              // promoted first since it was queued first (FIFO).
+              showSuccess({ title: 'Queued success', duration: 10000 });
+              showError({ title: 'Queued error', duration: 10000 });
+            }}
+            type="button"
+          >
+            Fill and queue
+          </button>
+        </>
+      );
+    }
+
+    render(
+      <ToastProvider>
+        <SeverityHarness />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /fill and queue/i }));
+    expect(screen.queryAllByText('Queued success', { selector: 'p' })).toHaveLength(0);
+    expect(screen.queryAllByText('Queued error', { selector: 'p' })).toHaveLength(0);
+
+    // Free one slot — the error should be promoted, not the
+    // earlier-queued success.
+    fireEvent.click(screen.getAllByLabelText(/dismiss success notification/i)[0]);
+
+    expect(screen.getAllByText('Queued error', { selector: 'p' })).toHaveLength(1);
+    expect(screen.queryAllByText('Queued success', { selector: 'p' })).toHaveLength(0);
+  });
+
+  it('never silently drops a queued error toast under a large success burst', () => {
+    function BigBurstHarness() {
+      const { showSuccess, showError } = useToast();
+      return (
+        <button
+          onClick={() => {
+            for (let i = 1; i <= 10; i++) {
+              showSuccess({ title: `Burst ${i}`, duration: 10000 });
+            }
+            showError({ title: 'Important failure', duration: 10000 });
+          }}
+          type="button"
+        >
+          Trigger burst plus error
+        </button>
+      );
+    }
+
+    render(
+      <ToastProvider>
+        <BigBurstHarness />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /trigger burst plus error/i }));
+
+    // Not visible yet (10 success toasts are ahead of it in creation order,
+    // but only 4 fit), and critically — not lost either.
+    expect(screen.queryAllByText('Important failure', { selector: 'p' })).toHaveLength(0);
+
+    // Dismiss visible toasts one at a time; the error must surface well
+    // before all 10 successes have cycled through, because it jumps the
+    // success queue.
+    for (let i = 0; i < 4; i += 1) {
+      fireEvent.click(screen.getAllByLabelText(/dismiss/i)[0]);
+    }
+
+    expect(screen.getAllByText('Important failure', { selector: 'p' })).toHaveLength(1);
+  });
+
+  it('queues an error directly (no success ahead of it) when the queue was empty', () => {
+    function DirectErrorHarness() {
+      const { showSuccess, showError } = useToast();
+      return (
+        <button
+          onClick={() => {
+            for (let i = 1; i <= 4; i++) {
+              showSuccess({ title: `Fill ${i}`, duration: 10000 });
+            }
+            showError({ title: 'First queued error', duration: 10000 });
+          }}
+          type="button"
+        >
+          Fill then queue error
+        </button>
+      );
+    }
+
+    render(
+      <ToastProvider>
+        <DirectErrorHarness />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /fill then queue error/i }));
+    expect(screen.queryAllByText('First queued error', { selector: 'p' })).toHaveLength(0);
+
+    fireEvent.click(screen.getAllByLabelText(/dismiss/i)[0]);
+
+    expect(screen.getAllByText('First queued error', { selector: 'p' })).toHaveLength(1);
+  });
+
+  it('does not over-promote if a toast is dismissed twice (dismiss button and its own timer racing)', () => {
+    function RaceHarness() {
+      const { showSuccess, dismissToast } = useToast();
+      return (
+        <button
+          onClick={() => {
+            const ids: string[] = [];
+            for (let i = 1; i <= 5; i++) {
+              ids.push(showSuccess({ title: `Race ${i}`, duration: 10000 }));
+            }
+            // Simulate the dismiss button and the auto-dismiss timer both
+            // resolving for the same already-visible toast.
+            dismissToast(ids[0]);
+            dismissToast(ids[0]);
+          }}
+          type="button"
+        >
+          Trigger race
+        </button>
+      );
+    }
+
+    render(
+      <ToastProvider>
+        <RaceHarness />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /trigger race/i }));
+
+    // Exactly one queued toast should have been promoted, not two —
+    // the visible count must stay at the cap.
+    expect(screen.getAllByRole('status')).toHaveLength(4);
   });
 });
 
@@ -1332,7 +1486,7 @@ describe('toastDuration preference', () => {
     expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 
-  it('MAX_VISIBLE_TOASTS eviction still works with persistent preference', () => {
+  it('MAX_VISIBLE_TOASTS queueing still works with persistent preference', () => {
     localStorage.setItem(
       'talenttrust-user-preferences',
       JSON.stringify({ toastDuration: 'persistent' }),
@@ -1364,13 +1518,16 @@ describe('toastDuration preference', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /add toasts/i }));
 
-    // After adding 5, only 4 should be visible (oldest evicted).
+    // After adding 5, only 4 should be visible — but they are the first
+    // four (PToast 1 included), not evicted; the 5th is queued.
     expect(screen.getAllByRole('status')).toHaveLength(4);
-    expect(screen.queryAllByText('PToast 1', { selector: 'p' })).toHaveLength(0);
-    expect(screen.getAllByText('PToast 5', { selector: 'p' })).toHaveLength(1);
+    expect(screen.getAllByText('PToast 1', { selector: 'p' })).toHaveLength(1);
+    expect(screen.queryAllByText('PToast 5', { selector: 'p' })).toHaveLength(0);
 
-    // Advance time — none should auto-dismiss (all persistent).
+    // Advance time — none should auto-dismiss (all persistent), so the
+    // queued toast never gets a chance to be promoted here.
     act(() => { jest.advanceTimersByTime(60000); });
     expect(screen.getAllByRole('status')).toHaveLength(4);
+    expect(screen.queryAllByText('PToast 5', { selector: 'p' })).toHaveLength(0);
   });
 });

--- a/src/components/toast/toast-provider.tsx
+++ b/src/components/toast/toast-provider.tsx
@@ -61,12 +61,39 @@ const DURATION_MAP: Readonly<Record<ToastDuration, number | null>> = {
 
 /**
  * Maximum number of toasts that may be visible at the same time.
- * When a new toast would exceed this cap the oldest visible toast is
- * evicted (its auto-dismiss timer is cancelled) before the new one is
- * appended.  This prevents a burst of wallet/payout events from stacking
- * toasts past the bottom of the viewport and burying the dismiss buttons.
+ * When a new toast would exceed this cap it is queued instead of shown;
+ * queued toasts are promoted into view (oldest-first within the same
+ * severity) as visible toasts are dismissed. This prevents a burst of
+ * wallet/payout events from stacking toasts past the bottom of the
+ * viewport and burying the dismiss buttons, without ever silently
+ * dropping a toast — error toasts in particular always eventually show.
  */
 const MAX_VISIBLE_TOASTS = 4;
+
+type ToastQueueState = {
+  visible: ToastRecord[];
+  queued: ToastRecord[];
+};
+
+/**
+ * Inserts a toast into a queue, keeping error toasts ahead of queued
+ * success toasts (severity ordering) while preserving FIFO order within
+ * each severity. This is what lets an error toast reach the front of the
+ * line — and therefore get shown — sooner than success toasts that were
+ * queued earlier, without ever discarding anything.
+ */
+function enqueueBySeverity(queue: ToastRecord[], toast: ToastRecord): ToastRecord[] {
+  if (toast.variant !== 'error') {
+    return [...queue, toast];
+  }
+
+  const firstSuccessIndex = queue.findIndex((queued) => queued.variant !== 'error');
+  if (firstSuccessIndex === -1) {
+    return [...queue, toast];
+  }
+
+  return [...queue.slice(0, firstSuccessIndex), toast, ...queue.slice(firstSuccessIndex)];
+}
 
 /**
  * Generates a unique toast ID without mutating refs during render.
@@ -266,10 +293,13 @@ type ToastTimerState = {
  * | `'long'`       | 10000 ms  | Longer read time                |
  * | `'persistent'` | `null`    | No timer; manual dismiss only   |
  *
- * ## Eviction
+ * ## Visible cap and queueing
  *
- * A maximum of `4` toasts are visible at once. If a fifth is created, the
- * oldest is evicted to make room.
+ * A maximum of `4` toasts are visible at once. Anything created beyond that
+ * cap is queued rather than dropped, and gets promoted into view as soon as
+ * a visible toast is dismissed (auto or manual). Error toasts queued behind
+ * success toasts are promoted first — a burst of successes can never bury or
+ * silently discard an error.
  *
  * ## Action button
  *
@@ -278,11 +308,35 @@ type ToastTimerState = {
  * toast. The label is always rendered as a plain text node to prevent XSS.
  */
 export function ToastProvider({ children }: { children: React.ReactNode }) {
-  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+  const [queueState, setQueueState] = useState<ToastQueueState>({ visible: [], queued: [] });
+  const toasts = queueState.visible;
   const toastTimersRef = useRef<Record<string, ToastTimerState>>({});
 
+  /**
+   * Dismisses a toast and, if it was actually visible, promotes the next
+   * queued toast into the freed slot — queue order already accounts for
+   * severity, so an error toast waiting in the queue is promoted ahead of
+   * any success toasts queued before it.
+   *
+   * The `wasVisible` guard matters: a dismiss button click and its
+   * auto-dismiss timer can race (e.g. the timer fires the same tick the
+   * user clicks dismiss), so this can be called twice for the same id.
+   * Without the guard, the second call would see a full visible list, a
+   * non-empty queue, and incorrectly promote another toast without
+   * actually freeing a slot — pushing the visible count past the cap.
+   */
   const dismissToast = useCallback((id: string) => {
-    setToasts((currentToasts) => currentToasts.filter((toast) => toast.id !== id));
+    setQueueState((current) => {
+      const wasVisible = current.visible.some((toast) => toast.id === id);
+      const remainingVisible = current.visible.filter((toast) => toast.id !== id);
+
+      if (!wasVisible || current.queued.length === 0) {
+        return { visible: remainingVisible, queued: current.queued };
+      }
+
+      const [promoted, ...restQueue] = current.queued;
+      return { visible: [...remainingVisible, promoted], queued: restQueue };
+    });
   }, []);
 
   /**
@@ -381,21 +435,21 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const createToast = useCallback(
     (variant: ToastVariant, toast: ToastInput, durationMs: number | null) => {
       const id = generateToastId();
+      const record: ToastRecord = { ...toast, duration: durationMs ?? undefined, id, variant };
 
-      setToasts((currentToasts) => {
-        const next = [...currentToasts, { ...toast, duration: durationMs ?? undefined, id, variant }];
-        if (next.length <= MAX_VISIBLE_TOASTS) {
-          return next;
+      setQueueState((current) => {
+        if (current.visible.length < MAX_VISIBLE_TOASTS) {
+          return { visible: [...current.visible, record], queued: current.queued };
         }
-        // Evict the oldest toast and cancel its timer.
-        const [evicted, ...remaining] = next;
-        clearToastTimer(evicted.id);
-        return remaining;
+        // At capacity — queue it instead of evicting anything. Error toasts
+        // jump ahead of already-queued success toasts (severity ordering);
+        // nothing is ever dropped.
+        return { visible: current.visible, queued: enqueueBySeverity(current.queued, record) };
       });
 
       return id;
     },
-    [clearToastTimer],
+    [],
   );
 
   const { preferences } = usePreferences();


### PR DESCRIPTION
Closes #488

## What was wrong

`ToastProvider` already had a `MAX_VISIBLE_TOASTS` cap, but it enforced it by eviction: once four toasts were showing, a fifth would push the oldest one off the screen entirely, timer cancelled, gone. That's exactly the failure mode the issue calls out. A burst of routine success toasts (say, a handful of milestone updates in quick succession) could silently evict an *error* toast that had appeared moments earlier, and the user would never know it happened.

## What this does

Replaced the eviction model with a real queue. The provider now tracks two lists internally, `visible` and `queued`:

- New toasts go straight to `visible` while there's room (same cap, still 4).
- Once full, a new toast is queued instead of bumping anything off screen. Nothing currently showing ever gets pushed out.
- When a visible toast is dismissed (button click or its own auto-dismiss timer), the oldest queued toast is promoted into the freed slot and gets a fresh timer.
- Queued error toasts jump ahead of queued success toasts (`enqueueBySeverity`), so a pile of success notifications can never bury or discard an error — it still surfaces, just slightly later than an empty slot would allow, never never.

I also caught and fixed a subtler bug while writing the promotion logic: a toast's dismiss button and its own auto-dismiss timer can race (both firing for the same toast in the same tick). The old code had no guard against that; with a queue in place, double-dismissing the same id would have incorrectly promoted two queued toasts for one freed slot, pushing the visible count over the cap. Added a `wasVisible` check so a second dismiss for an already-gone toast is a no-op.

Kept the public API surface identical — `useToast()` still returns `{ toasts, showSuccess, showError, dismissToast }`, `toasts` still means "what's rendered right now." The queue is purely an internal implementation detail.

## Test plan

Rewrote the old eviction-focused test block (it asserted behavior — silent dropping of the oldest toast — that no longer exists) and added coverage for the new behavior:

- Overflow queues instead of evicting; the first four toasts stay visible, not the last four.
- A large burst (6+ toasts) keeps every single one somewhere, visible or queued.
- Dismissing a visible toast promotes the next queued one, with a working auto-dismiss timer scheduled fresh at promotion time.
- The live region only ever announces a toast that's actually visible, never one still waiting.
- Pause-on-hover still works correctly for a promoted toast.
- A queued error is promoted ahead of an already-queued success (severity ordering).
- A 10-toast success burst plus one error: the error surfaces well before all ten successes have cycled through.
- An error queued directly (queue was empty) is still handled correctly — this exercises the other branch of the severity-insertion logic.
- Double-dismissing the same toast id doesn't over-promote and push the visible count past the cap.
- The same behavior holds under the `'persistent'` duration preference.

Also updated `docs/components/Toast.md`, which explicitly documented the old eviction behavior with line-number references into the source — rewrote the relevant sections so it doesn't mislead the next reviewer. I didn't re-audit every line-number citation elsewhere in that doc; only the ones actually describing behavior I changed.

### Full test output

```
PASS src/components/toast/toast-provider.test.tsx
  ToastProvider
    ✓ renders success toasts and announces them in a polite live region (178 ms)
    ✓ renders error toasts and announces them in an assertive live region (15 ms)
    ✓ dismisses a toast when the dismiss button is clicked (24 ms)
    ✓ automatically dismisses toasts after their duration (12 ms)
    ✓ generates unique ids for rapid toast creation (29 ms)
    ✓ does not create duplicate toasts under StrictMode double invocation (9 ms)
    ✓ pauses auto-dismiss while a toast is hovered (14 ms)
    ✓ pauses auto-dismiss while a toast is focused (17 ms)
    ✓ dismisses toast by returned id (14 ms)
  quietMode
    ✓ suppresses success toasts when quietMode is true and returns "suppressed" (10 ms)
    ✓ does not suppress error toasts when quietMode is true (10 ms)
  density
    ✓ renders viewport with relaxed (gap-3) spacing by default (9 ms)
    ✓ renders viewport with compact (gap-1.5) spacing when toastDensity is compact (10 ms)
  default duration
    ✓ uses DEFAULT_DURATION (5000ms) when no duration is provided (13 ms)
  toast queue (MAX_VISIBLE_TOASTS = 4)
    ✓ shows all toasts when under the cap (13 ms)
    ✓ shows exactly MAX_VISIBLE_TOASTS toasts when exactly at cap (11 ms)
    ✓ queues overflow instead of evicting, keeping only MAX_VISIBLE_TOASTS visible (12 ms)
    ✓ keeps every toast from a large over-cap burst somewhere (visible or queued), never dropping one (12 ms)
    ✓ promotes the oldest queued toast into view, with a working auto-dismiss timer, when a visible toast is dismissed (20 ms)
    ✓ announces the toast that is actually visible, not one still waiting in the queue (12 ms)
    ✓ does not affect pause-on-hover for a toast promoted from the queue (19 ms)
    ✓ promotes a queued error ahead of a success toast that was queued earlier (severity ordering) (20 ms)
    ✓ never silently drops a queued error toast under a large success burst (23 ms)
    ✓ queues an error directly (no success ahead of it) when the queue was empty (10 ms)
    ✓ does not over-promote if a toast is dismissed twice (dismiss button and its own timer racing) (13 ms)
  toast action button
    ✓ renders an action button when action is provided on a success toast (15 ms)
    ✓ renders an action button when action is provided on an error toast (11 ms)
    ✓ clicking the action button fires the onClick callback (19 ms)
    ✓ clicking the action button dismisses the toast immediately (15 ms)
    ✓ fires onClick before dismissing (callback order) (11 ms)
    ✓ does not render an action button when action is omitted (backward compatibility) (6 ms)
    ✓ action label is rendered as a plain text node, not parsed as HTML (10 ms)
    ✓ action button has focus-visible ring styling class (9 ms)
    ✓ showSuccess and showError signatures remain backward compatible without action (19 ms)
  toastDuration preference
    ✓ 'normal' (default) auto-dismisses at 5000ms (13 ms)
    ✓ 'short' auto-dismisses at 2500ms (14 ms)
    ✓ 'long' auto-dismisses at 10000ms (12 ms)
    ✓ 'persistent' — toast never auto-dismisses (9 ms)
    ✓ 'persistent' — toast is dismissible via the dismiss button (12 ms)
    ✓ 'persistent' — toast is dismissible via keyboard (Enter on dismiss button) (20 ms)
    ✓ per-call duration overrides the persistent preference (14 ms)
    ✓ per-call duration overrides the long preference (16 ms)
    ✓ invalid stored toastDuration falls back to normal (5000ms) (11 ms)
    ✓ persistent + quietMode: success toast is still suppressed (6 ms)
    ✓ persistent + quietMode: error toast is still shown and stays without auto-dismiss (8 ms)
    ✓ MAX_VISIBLE_TOASTS queueing still works with persistent preference (12 ms)

--------------------|---------|----------|---------|---------|---------------------
File                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
--------------------|---------|----------|---------|---------|---------------------
All files           |   95.96 |    87.17 |     100 |   95.76 |
 toast-provider.tsx |   95.96 |    87.17 |     100 |   95.76 | 110,357,379,423,589
--------------------|---------|----------|---------|---------|---------------------
Test Suites: 1 passed, 1 total
Tests:       46 passed, 46 total
Snapshots:   0 total
Time:        2.768 s
```

95.96% statement / 100% function coverage on the changed file, above the 95% bar. The five remaining uncovered lines are pre-existing (the `crypto.randomUUID` fallback, the pause/resume timer no-op guards, and the `useToast` outside-provider error) — none touched by this change.

Full repo suite: `npm test` → 72 suites, 1222 tests, all passing. `npm run lint` and `npm run build` both clean.
