### PR TITLE
test(milestones): cover MilestoneFilter keyboard nav, zero-result announcements, a11y helper

### DIFF
--- a/docs/components/MilestonesList.md
+++ b/docs/components/MilestonesList.md
@@ -26,6 +26,8 @@ An accessible, dismissible banner is surfaced above the milestones list when the
 
 ## Testing
 
+### MilestonesList
+
 Comprehensive test coverage is provided in [MilestonesList.test.tsx](file:///c:/Users/USER/Desktop/Talenttrust-Frontend/src/components/__tests__/MilestonesList.test.tsx):
 - Renders banner when due-soon milestones exist.
 - Correct pluralization (e.g., "1 milestone is due..." vs "2 milestones are due...").
@@ -35,9 +37,23 @@ Comprehensive test coverage is provided in [MilestonesList.test.tsx](file:///c:/
 - Dismiss interaction and focus restoration checking.
 - Accessibility validation using `axe`.
 
-Run tests with:
 ```bash
 npx jest src/components/__tests__/MilestonesList.test.tsx
+```
+
+### MilestoneFilter
+
+Comprehensive test coverage is provided in [MilestoneFilter.test.tsx](file:///c:/Users/USER/Desktop/Talenttrust-Frontend/src/components/__tests__/MilestoneFilter.test.tsx):
+- Every status option renders as a radio input inside a `role="radiogroup"`.
+- The currently selected status is marked `checked`; all others are unchecked.
+- Pointer (click) selection calls `onChange` with the correct value exactly once.
+- Keyboard navigation via ArrowDown, ArrowUp, ArrowRight, and ArrowLeft moves between options and fires `onChange` exactly once per step.
+- The `aria-live="polite"` region announces result counts with correct singular/plural wording at 0, 1, and 2+ results.
+- The announcement uses "Showing all …" phrasing when the filter is `'All'` and lowers the status name for specific filters.
+- Axe accessibility audit passes (uses `assertNoA11yViolations` from `@/test-utils/a11y`).
+
+```bash
+npx jest src/components/__tests__/MilestoneFilter.test.tsx
 ```
 
 ## URL Status Filtering

--- a/src/components/__tests__/MilestoneFilter.test.tsx
+++ b/src/components/__tests__/MilestoneFilter.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import userEvent from '@testing-library/user-event';
+import { assertNoA11yViolations } from '@/test-utils/a11y';
 import MilestoneFilter, { type MilestoneStatusFilter } from '../milestones/MilestoneFilter';
 
 const FILTER_OPTIONS: MilestoneStatusFilter[] = [
@@ -46,7 +47,7 @@ describe('MilestoneFilter', () => {
     expect(screen.getByRole('radio', { name: 'All' })).not.toBeChecked();
   });
 
-  it('calls onChange with the newly selected status', () => {
+  it('calls onChange with the newly selected status on click', () => {
     const handleChange = jest.fn();
 
     render(
@@ -63,43 +64,171 @@ describe('MilestoneFilter', () => {
     expect(handleChange).toHaveBeenCalledWith('Active');
   });
 
-  it('announces the all-status result count in a polite live region', () => {
-    render(
-      <MilestoneFilter
-        selected="All"
-        onChange={jest.fn()}
-        resultCount={2}
-      />,
-    );
+  describe('keyboard navigation', () => {
+    it('moves forward with ArrowDown and fires onChange exactly once', async () => {
+      const user = userEvent.setup();
+      const handleChange = jest.fn();
 
-    const liveRegion = screen.getByText('Showing all 2 milestones');
-    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
-    expect(liveRegion).toHaveAttribute('aria-atomic', 'true');
+      render(
+        <MilestoneFilter
+          selected="All"
+          onChange={handleChange}
+          resultCount={12}
+        />,
+      );
+
+      screen.getByRole('radio', { name: 'All' }).focus();
+      await user.keyboard('{ArrowDown}');
+
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      expect(handleChange).toHaveBeenCalledWith('Active');
+    });
+
+    it('moves backward with ArrowUp and fires onChange exactly once', async () => {
+      const user = userEvent.setup();
+      const handleChange = jest.fn();
+
+      render(
+        <MilestoneFilter
+          selected="Pending"
+          onChange={handleChange}
+          resultCount={12}
+        />,
+      );
+
+      screen.getByRole('radio', { name: 'Pending' }).focus();
+      await user.keyboard('{ArrowUp}');
+
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      expect(handleChange).toHaveBeenCalledWith('Active');
+    });
+
+    it('moves forward with ArrowRight', async () => {
+      const user = userEvent.setup();
+      const handleChange = jest.fn();
+
+      render(
+        <MilestoneFilter
+          selected="Completed"
+          onChange={handleChange}
+          resultCount={12}
+        />,
+      );
+
+      screen.getByRole('radio', { name: 'Completed' }).focus();
+      await user.keyboard('{ArrowRight}');
+
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      expect(handleChange).toHaveBeenCalledWith('Paid');
+    });
+
+    it('moves backward with ArrowLeft', async () => {
+      const user = userEvent.setup();
+      const handleChange = jest.fn();
+
+      render(
+        <MilestoneFilter
+          selected="Paid"
+          onChange={handleChange}
+          resultCount={12}
+        />,
+      );
+
+      screen.getByRole('radio', { name: 'Paid' }).focus();
+      await user.keyboard('{ArrowLeft}');
+
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      expect(handleChange).toHaveBeenCalledWith('Completed');
+    });
   });
 
-  it('announces filtered result counts with singular and lowercase status text', () => {
-    const { rerender } = render(
-      <MilestoneFilter
-        selected="Paid"
-        onChange={jest.fn()}
-        resultCount={1}
-      />,
-    );
+  describe('live region announcements', () => {
+    it('marks the container as a polite atomic live region', () => {
+      render(
+        <MilestoneFilter
+          selected="All"
+          onChange={jest.fn()}
+          resultCount={2}
+        />,
+      );
 
-    expect(screen.getByText('Showing 1 paid milestone')).toBeInTheDocument();
+      const liveRegion = screen.getByText('Showing all 2 milestones');
+      expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+      expect(liveRegion).toHaveAttribute('aria-atomic', 'true');
+    });
 
-    rerender(
-      <MilestoneFilter
-        selected="Disputed"
-        onChange={jest.fn()}
-        resultCount={3}
-      />,
-    );
+    it('announces count with plural wording when resultCount > 1', () => {
+      render(
+        <MilestoneFilter
+          selected="Disputed"
+          onChange={jest.fn()}
+          resultCount={5}
+        />,
+      );
 
-    expect(screen.getByText('Showing 3 disputed milestones')).toBeInTheDocument();
+      expect(screen.getByText('Showing 5 disputed milestones')).toBeInTheDocument();
+    });
+
+    it('announces count with singular wording when resultCount === 1', () => {
+      render(
+        <MilestoneFilter
+          selected="Paid"
+          onChange={jest.fn()}
+          resultCount={1}
+        />,
+      );
+
+      expect(screen.getByText('Showing 1 paid milestone')).toBeInTheDocument();
+    });
+
+    it('announces zero results with plural wording', () => {
+      const { rerender } = render(
+        <MilestoneFilter
+          selected="All"
+          onChange={jest.fn()}
+          resultCount={0}
+        />,
+      );
+
+      expect(screen.getByText('Showing all 0 milestones')).toBeInTheDocument();
+
+      rerender(
+        <MilestoneFilter
+          selected="Pending"
+          onChange={jest.fn()}
+          resultCount={0}
+        />,
+      );
+
+      expect(screen.getByText('Showing 0 pending milestones')).toBeInTheDocument();
+    });
+
+    it('uses "Showing all ..." phrasing when filter is All', () => {
+      render(
+        <MilestoneFilter
+          selected="All"
+          onChange={jest.fn()}
+          resultCount={3}
+        />,
+      );
+
+      expect(screen.getByText('Showing all 3 milestones')).toBeInTheDocument();
+    });
+
+    it('lowercases the status name in the announcement', () => {
+      render(
+        <MilestoneFilter
+          selected="Completed"
+          onChange={jest.fn()}
+          resultCount={2}
+        />,
+      );
+
+      expect(screen.getByText('Showing 2 completed milestones')).toBeInTheDocument();
+    });
   });
 
-  it('passes axe accessibility checks', async () => {
+  it('passes axe accessibility checks via a11y helper', async () => {
     const { container } = render(
       <MilestoneFilter
         selected="Pending"
@@ -108,6 +237,6 @@ describe('MilestoneFilter', () => {
       />,
     );
 
-    expect(await axe(container)).toHaveNoViolations();
+    await assertNoA11yViolations(container);
   });
 });


### PR DESCRIPTION
## Summary

Adds comprehensive tests for `MilestoneFilter` covering keyboard navigation via arrow keys, live region announcements for result counts (including 0 and 1), and uses the `assertNoA11yViolations` helper from `@/test-utils/a11y`.

## Changes

- **`MilestoneFilter.test.tsx`** — 14 tests total (8 new):
  - Keyboard navigation: ArrowDown, ArrowUp, ArrowRight, ArrowLeft each fire `onChange` exactly once
  - Live region: verifies `aria-live=\polite\`, `aria-atomic=\true\`, plural/singular wording at 0/1/2+ results, `"Showing all …"` phrasing, and lowercase status name
  - Uses `assertNoA11yViolations` from `@/test-utils/a11y` instead of raw `axe`
- **`docs/components/MilestonesList.md`** — added MilestoneFilter testing documentation section

## Verification

```
npx jest src/components/__tests__/MilestoneFilter.test.tsx
```
All 14 tests pass. Existing MilestonesList and a11y tests also pass.


Closes #431 