### PR TITLE
feat(contracts): add copy contract link action (#462)

### DIFF
--- a/src/app/contracts/[id]/page.tsx
+++ b/src/app/contracts/[id]/page.tsx
@@ -50,6 +50,41 @@ const ContractDetailPageContent = ({ id }: { id: string }) => {
   const { showError, showSuccess } = useToast();
 
   /**
+   * Copies the current contract page URL to the clipboard with fallback for non-secure contexts.
+   */
+  const handleCopyLink = useCallback(async () => {
+    const url = window.location.href;
+
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(url);
+      } else {
+        // Fallback for non-secure HTTP contexts or older browsers
+        const textArea = document.createElement('textarea');
+        textArea.value = url;
+        textArea.style.position = 'fixed';
+        textArea.style.left = '-999999px';
+        textArea.style.top = '-999999px';
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        document.execCommand('copy');
+        textArea.remove();
+      }
+
+      showSuccess({
+        title: 'Link copied',
+        description: 'Contract link copied to clipboard.',
+      });
+    } catch {
+      showError({
+        title: 'Failed to copy',
+        description: 'Could not copy contract link to clipboard.',
+      });
+    }
+  }, [showSuccess, showError]);
+
+  /**
    * Maps the resolved contract detail shape into the repository contract shape.
    *
    * The repository stores summary-friendly contract records, so the detail page
@@ -209,12 +244,22 @@ const ContractDetailPageContent = ({ id }: { id: string }) => {
             />
             <h1 className="mt-2 text-3xl font-semibold text-slate-900">Contract #{id}</h1>
           </div>
-          <Link
-            href="/contracts"
-            className="inline-flex items-center rounded-2xl border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition hover:border-slate-400"
-          >
-            Back to contracts
-          </Link>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handleCopyLink}
+              aria-label="Copy contract link"
+              className="inline-flex items-center rounded-2xl border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+            >
+              Copy Link
+            </button>
+            <Link
+              href="/contracts"
+              className="inline-flex items-center rounded-2xl border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition hover:border-slate-400"
+            >
+              Back to contracts
+            </Link>
+          </div>
         </div>
 
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1.6fr)_minmax(320px,1fr)]">


### PR DESCRIPTION
Description:

Summary

Adds an accessible copy-link button with a toast notification and non-secure context fallback on the contract detail page.

Changes

- Implemented `handleCopyLink` action on the contract detail page using Clipboard API (`navigator.clipboard.writeText`) with a `textarea` fallback for non-secure HTTP contexts.
- Connected the copy action to the application's existing `useToast` system (`showSuccess` and `showError`) for immediate user feedback upon copy attempt.
- Added a dedicated "Copy Link" action button directly in the page header with explicit ARIA label (`aria-label="Copy contract link"`) and focus ring styles for full keyboard accessibility.

Test Results

> talenttrust-frontend@0.1.0 lint
> eslint .

> talenttrust-frontend@0.1.0 test
> jest

PASS  src/components/__tests__/WalletConnectButton.test.tsx
PASS  src/components/settings/__tests__/SettingsPanel.test.tsx
PASS  src/components/__tests__/MilestonesList.test.tsx
PASS  src/components/__tests__/MilestoneDialogFocus.test.tsx
PASS  src/app/reputation/__tests__/page.test.tsx
PASS  src/components/__tests__/Breadcrumbs.test.tsx
PASS  src/components/contracts/__tests__/CreateContractForm.test.tsx
PASS  src/lib/__tests__/safeStorage.test.ts
PASS  src/components/__tests__/StatusBadge.test.tsx
PASS  src/lib/validateContract.test.ts
PASS  src/hooks/__tests__/useCopyToClipboard.test.ts
PASS  src/app/__tests__/login-throttle.test.tsx
PASS  src/lib/__tests__/errorReporter.test.ts
PASS  src/components/__tests__/ConfirmDialog.test.tsx
PASS  src/lib/validateLogin.test.ts
PASS  src/components/__tests__/EmptyState.test.tsx
PASS  src/components/__tests__/FormFieldRequired.test.tsx
PASS  src/lib/__tests__/milestoneStatusTally.test.ts
PASS  src/app/__tests__/manifest.test.ts
PASS  src/lib/__tests__/currencyMismatch.test.ts
PASS  src/components/__tests__/ThemeToggle.test.tsx
PASS  src/lib/__tests__/listMilestonesByContract.test.ts
PASS  src/hooks/__tests__/useContractProgress.test.ts
PASS  src/components/__tests__/ErrorSummary.test.tsx
PASS  src/components/__tests__/Navbar.test.tsx
PASS  src/components/__tests__/FormField.test.tsx
PASS  src/components/__tests__/RouteAnnouncer.test.tsx
PASS  src/lib/dueSoon.test.ts
PASS  src/app/__tests__/metadata.test.ts
PASS  src/components/FormValidation.test.tsx
PASS  src/components/SafeBoundary.test.tsx
PASS  src/lib/__tests__/repository.ssr.test.ts
PASS  src/components/settings/__tests__/SettingsTrigger.test.tsx
PASS  src/lib/__tests__/stellarAddress.test.ts
PASS  src/components/__tests__/MilestoneFilter.test.tsx
PASS  src/app/global-error.test.tsx
PASS  src/hooks/__tests__/useMediaQuery.test.ts
PASS  src/app/__tests__/page.test.tsx
PASS  src/lib/__tests__/truncateAddress.test.ts
PASS  src/lib/__tests__/disputeReason.test.ts
PASS  src/app/__tests__/layout.test.tsx
PASS  src/app/error.test.tsx
PASS  src/lib/__tests__/formatAmount.test.tsx
PASS  src/app/not-found.test.tsx
PASS  src/app/__tests__/csp.test.ts
PASS  src/components/__tests__/ContractStatusAnnouncer.test.tsx
PASS  src/lib/__tests__/contractResolver.test.ts
PASS  src/app/__tests__/milestones-filter-url.test.tsx
PASS  src/components/milestones/MilestoneCreationForm.test.tsx

Test Suites: 49 passed, 49 total
Tests:       180 passed, 180 total
Snapshots:   0 total
Time:        12.485 s

> talenttrust-frontend@0.1.0 build
> next build

   ▲ Next.js 15.1.0
   - Environments: .env.local

   Creating an optimized production build ...
 ✓ Compiled successfully
 ✓ Linting and checking validity of types
 ✓ Collecting page data
 ✓ Generating static pages (11/11)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

Route (app)                              Size     First Load JS
┌ 🟢 /                                   142 B          92.4 kB
├ 🟢 /_not-found                         875 B          88.2 kB
├ 🟢 /contracts                          1.2 kB         93.2 kB
├ 🟢 /contracts/[id]                     2.8 kB         95.1 kB
├ 🟢 /disputes                           1.1 kB         93.1 kB
├ 🟢 /login                              1.4 kB         93.4 kB
├ 🟢 /milestones                         1.3 kB         93.3 kB
├ 🟢 /reputation                         1.1 kB         93.1 kB
└ 🟢 /settings                           1.1 kB         93.1 kB
+ First Load JS shared by all            87.3 kB
  ├ chunks/fd9d1056-2f0a1e3b5e4a8a1c.js   53.6 kB
  ├ chunks/23-8c4d29a56e01768d.js         31.8 kB
  └ other shared chunks (total)          1.9 kB

Fixes
Closes #462