### PR TITLE
a11y(milestones): announce updates politely

### DIFF
--- a/src/app/milestones/__tests__/page.test.tsx
+++ b/src/app/milestones/__tests__/page.test.tsx
@@ -435,9 +435,9 @@ describe('MilestoneFilter — live region announcements', () => {
   it('announces correct count after switching from All to Active filter', async () => {
     const user = userEvent.setup();
     mockedListMilestones.mockReturnValue(mixedMilestones);
-    await renderPage();
+    const { container } = await renderPage();
 
-    await waitFor(() => expect(screen.getByText(/showing all 5 milestones/i)).toBeInTheDocument());
+    expect(container.querySelector('[aria-live="polite"]')).toBeEmptyDOMElement();
 
     await user.click(screen.getByRole('radio', { name: 'Active' }));
 

--- a/src/components/__tests__/MilestoneFilter.test.tsx
+++ b/src/components/__tests__/MilestoneFilter.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
-import MilestoneFilter, { type MilestoneStatusFilter } from '../milestones/MilestoneFilter';
+import MilestoneFilter, {
+  MILESTONE_ANNOUNCEMENT_DELAY_MS,
+  type MilestoneStatusFilter,
+} from '../milestones/MilestoneFilter';
 
 const FILTER_OPTIONS: MilestoneStatusFilter[] = [
   'All',
@@ -13,6 +16,10 @@ const FILTER_OPTIONS: MilestoneStatusFilter[] = [
 ];
 
 describe('MilestoneFilter', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('renders every milestone status as a radio option', () => {
     render(
       <MilestoneFilter
@@ -63,22 +70,53 @@ describe('MilestoneFilter', () => {
     expect(handleChange).toHaveBeenCalledWith('Active');
   });
 
-  it('announces the all-status result count in a polite live region', () => {
-    render(
+  it('does not announce the initial filter state', () => {
+    jest.useFakeTimers();
+
+    const { container } = render(
+      <React.StrictMode>
+        <MilestoneFilter
+          selected="All"
+          onChange={jest.fn()}
+          resultCount={2}
+        />
+      </React.StrictMode>,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(MILESTONE_ANNOUNCEMENT_DELAY_MS);
+    });
+
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    expect(liveRegion).toHaveAttribute('aria-atomic', 'true');
+    expect(liveRegion).toBeEmptyDOMElement();
+  });
+
+  it('debounces rapid updates and announces only the latest result', () => {
+    jest.useFakeTimers();
+
+    const { container, rerender } = render(
       <MilestoneFilter
         selected="All"
         onChange={jest.fn()}
-        resultCount={2}
+        resultCount={5}
       />,
     );
 
-    const liveRegion = screen.getByText('Showing all 2 milestones');
-    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
-    expect(liveRegion).toHaveAttribute('aria-atomic', 'true');
-  });
+    rerender(
+      <MilestoneFilter
+        selected="Active"
+        onChange={jest.fn()}
+        resultCount={3}
+      />,
+    );
 
-  it('announces filtered result counts with singular and lowercase status text', () => {
-    const { rerender } = render(
+    act(() => {
+      jest.advanceTimersByTime(MILESTONE_ANNOUNCEMENT_DELAY_MS - 100);
+    });
+
+    rerender(
       <MilestoneFilter
         selected="Paid"
         onChange={jest.fn()}
@@ -86,17 +124,77 @@ describe('MilestoneFilter', () => {
       />,
     );
 
-    expect(screen.getByText('Showing 1 paid milestone')).toBeInTheDocument();
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).toBeEmptyDOMElement();
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(liveRegion).toBeEmptyDOMElement();
+
+    act(() => {
+      jest.advanceTimersByTime(MILESTONE_ANNOUNCEMENT_DELAY_MS - 100);
+    });
+
+    expect(liveRegion).toHaveTextContent('Showing 1 paid milestone');
+    expect(liveRegion).not.toHaveTextContent('active');
+  });
+
+  it('announces zero results after the debounce interval', () => {
+    jest.useFakeTimers();
+
+    const { container, rerender } = render(
+      <MilestoneFilter
+        selected="All"
+        onChange={jest.fn()}
+        resultCount={5}
+      />,
+    );
 
     rerender(
       <MilestoneFilter
         selected="Disputed"
         onChange={jest.fn()}
-        resultCount={3}
+        resultCount={0}
       />,
     );
 
-    expect(screen.getByText('Showing 3 disputed milestones')).toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(MILESTONE_ANNOUNCEMENT_DELAY_MS);
+    });
+
+    expect(container.querySelector('[aria-live="polite"]')).toHaveTextContent(
+      'Showing 0 disputed milestones',
+    );
+  });
+
+  it('announces count changes while showing all statuses', () => {
+    jest.useFakeTimers();
+
+    const { container, rerender } = render(
+      <MilestoneFilter
+        selected="All"
+        onChange={jest.fn()}
+        resultCount={5}
+      />,
+    );
+
+    rerender(
+      <MilestoneFilter
+        selected="All"
+        onChange={jest.fn()}
+        resultCount={2}
+      />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(MILESTONE_ANNOUNCEMENT_DELAY_MS);
+    });
+
+    expect(container.querySelector('[aria-live="polite"]')).toHaveTextContent(
+      'Showing all 2 milestones',
+    );
   });
 
   it('passes axe accessibility checks', async () => {

--- a/src/components/milestones/MilestoneFilter.tsx
+++ b/src/components/milestones/MilestoneFilter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 /**
  * The set of statuses a user can filter milestones by.
@@ -17,6 +17,8 @@ const FILTER_OPTIONS: MilestoneStatusFilter[] = [
   'Paid',
   'Disputed',
 ];
+
+export const MILESTONE_ANNOUNCEMENT_DELAY_MS = 300;
 
 export interface MilestoneFilterProps {
   /** The currently active filter. */
@@ -54,6 +56,29 @@ export interface MilestoneFilterProps {
  * ```
  */
 const MilestoneFilter = ({ selected, onChange, resultCount }: MilestoneFilterProps) => {
+  const [announcement, setAnnouncement] = useState('');
+  const previousResult = useRef({ selected, resultCount });
+
+  useEffect(() => {
+    const previous = previousResult.current;
+
+    if (previous.selected === selected && previous.resultCount === resultCount) {
+      return;
+    }
+
+    previousResult.current = { selected, resultCount };
+    setAnnouncement('');
+
+    const timeoutId = window.setTimeout(() => {
+      const milestoneLabel = resultCount === 1 ? 'milestone' : 'milestones';
+      const filterLabel = selected === 'All' ? `all ${resultCount}` : `${resultCount} ${selected.toLowerCase()}`;
+
+      setAnnouncement(`Showing ${filterLabel} ${milestoneLabel}`);
+    }, MILESTONE_ANNOUNCEMENT_DELAY_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [resultCount, selected]);
+
   return (
     <div className="mb-6">
       <fieldset>
@@ -100,9 +125,7 @@ const MilestoneFilter = ({ selected, onChange, resultCount }: MilestoneFilterPro
         aria-live="polite"
         aria-atomic="true"
       >
-        {selected === 'All'
-          ? `Showing all ${resultCount} milestone${resultCount !== 1 ? 's' : ''}`
-          : `Showing ${resultCount} ${selected.toLowerCase()} milestone${resultCount !== 1 ? 's' : ''}`}
+        {announcement}
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

- keep the milestones live region empty on initial mount, including React Strict Mode
- debounce count and status announcements for 300 ms so rapid changes produce one message
- announce the latest filter state with correct singular, plural, and zero-result wording
- update the page integration expectation to match the update-only behavior

## Verification

- `npm test -- --runInBand` - 72 suites passed, 1220 tests passed, 7 snapshots passed
- `npm run lint` - passed
- `npm run build` - passed
- focused `MilestoneFilter` coverage - 100% statements, branches, functions, and lines
- `jest-axe` component check - passed

The test output still includes the repository's existing outdated JSX transform and React `act()` warnings; there are no test failures.

Closes #522
