### PR TITLE
feat(wallet): add empty and error states with retry and a11y announcements

### DIFF
--- a/src/app/wallet/__tests__/page.test.tsx
+++ b/src/app/wallet/__tests__/page.test.tsx
@@ -1,0 +1,589 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import WalletPage from '../page';
+import { ToastProvider } from '@/components/toast/toast-provider';
+import { PreferencesProvider } from '@/lib/preferences';
+import { useWallet } from '@/contexts/WalletContext';
+import { testA11y } from '@/test-utils/a11y';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// The global jest.setup.ts mocks WalletContext with a connected state.
+// We override it here to control the mock per test.
+const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
+
+// Mock useCopyToClipboard
+jest.mock('@/hooks/useCopyToClipboard', () => ({
+  useCopyToClipboard: jest.fn().mockReturnValue({
+    copied: false,
+    copy: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createWalletState(overrides: Partial<ReturnType<typeof useWallet>> = {}) {
+  return {
+    address: null,
+    isConnecting: false,
+    error: null,
+    connect: jest.fn().mockResolvedValue(undefined),
+    disconnect: jest.fn(),
+    ...overrides,
+  };
+}
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <PreferencesProvider>
+      <ToastProvider>
+        {ui}
+      </ToastProvider>
+    </PreferencesProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// getWalletVisualState
+// ---------------------------------------------------------------------------
+
+describe('getWalletVisualState', () => {
+  const { getWalletVisualState } = require('../page');
+
+  it('returns "loading" when isConnecting is true', () => {
+    expect(getWalletVisualState(true, null, null)).toBe('loading');
+    expect(getWalletVisualState(true, 'GABCD...', null)).toBe('loading');
+    expect(getWalletVisualState(true, null, 'Error')).toBe('loading');
+  });
+
+  it('returns "error" when error is set and not connecting', () => {
+    expect(getWalletVisualState(false, null, 'Connection failed')).toBe('error');
+    expect(getWalletVisualState(false, 'GABCD...', 'Error')).toBe('error');
+  });
+
+  it('returns "empty" when no address and no error and not connecting', () => {
+    expect(getWalletVisualState(false, null, null)).toBe('empty');
+  });
+
+  it('returns "connected" when address is present and no error and not connecting', () => {
+    expect(getWalletVisualState(false, 'GABCD...', null)).toBe('connected');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WalletPage
+// ---------------------------------------------------------------------------
+
+describe('WalletPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Empty / Disconnected state ──────────────────────────────────────────
+
+  describe('empty state (wallet not connected)', () => {
+    beforeEach(() => {
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: null,
+        isConnecting: false,
+      }));
+    });
+
+    it('renders the EmptyState with wallet illustration', () => {
+      renderWithProviders(<WalletPage />);
+      // EmptyState renders a region with the title as its accessible name
+      const emptyStateRegion = screen.getByRole('region', { name: /connect your wallet/i });
+      expect(emptyStateRegion).toBeInTheDocument();
+      expect(screen.getByText('Connect Your Wallet')).toBeInTheDocument();
+      expect(screen.getByText(/Connect a Stellar wallet/i)).toBeInTheDocument();
+    });
+
+    it('renders a Connect Wallet button', () => {
+      renderWithProviders(<WalletPage />);
+      const connectButton = screen.getByRole('button', { name: /connect wallet/i });
+      expect(connectButton).toBeInTheDocument();
+    });
+
+    it('calls connect() when the Connect Wallet button is clicked', () => {
+      const connect = jest.fn().mockResolvedValue(undefined);
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: null,
+        isConnecting: false,
+        connect,
+      }));
+
+      renderWithProviders(<WalletPage />);
+      fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }));
+      expect(connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render connected wallet details', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.queryByText('Connected Wallet')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Disconnect/i)).not.toBeInTheDocument();
+    });
+
+    it('does not render error state', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.queryByText('Wallet Connection Error')).not.toBeInTheDocument();
+    });
+
+    it('has an aria-live region announcing disconnected state', () => {
+      renderWithProviders(<WalletPage />);
+      const liveRegion = document.querySelector('[aria-live="polite"].sr-only');
+      expect(liveRegion).toBeInTheDocument();
+    });
+
+    it('has no axe violations', async () => {
+      const { container } = renderWithProviders(<WalletPage />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('passes testA11y helper', async () => {
+      await testA11y(
+        <PreferencesProvider>
+          <ToastProvider>
+            <WalletPage />
+          </ToastProvider>
+        </PreferencesProvider>
+      );
+    });
+  });
+
+  // ── Loading / Connecting state ─────────────────────────────────────────
+
+  describe('loading state (connecting)', () => {
+    beforeEach(() => {
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: null,
+        isConnecting: true,
+      }));
+    });
+
+    it('renders the connecting message', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.getByText('Connecting Wallet')).toBeInTheDocument();
+      expect(screen.getByText(/approve the connection request/i)).toBeInTheDocument();
+    });
+
+    it('does not render empty state', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.queryByText('Connect Your Wallet')).not.toBeInTheDocument();
+    });
+
+    it('does not render error state', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.queryByText('Wallet Connection Error')).not.toBeInTheDocument();
+    });
+
+    it('does not render connected state', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.queryByText('Connected Wallet')).not.toBeInTheDocument();
+    });
+
+    it('has a spinner indicator', () => {
+      renderWithProviders(<WalletPage />);
+      // The loading state includes a spinning SVG
+      const spinnerContainer = document.querySelector('.animate-spin');
+      expect(spinnerContainer).toBeInTheDocument();
+    });
+
+    it('has an aria-live region announcing connecting state', () => {
+      renderWithProviders(<WalletPage />);
+      const liveRegion = document.querySelector('[aria-live="polite"].sr-only');
+      expect(liveRegion).toBeInTheDocument();
+    });
+
+    it('has no axe violations', async () => {
+      const { container } = renderWithProviders(<WalletPage />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // ── Error state ────────────────────────────────────────────────────────
+
+  describe('error state', () => {
+    const testError = 'Freighter wallet is not installed. Please install the Freighter browser extension.';
+
+    beforeEach(() => {
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: testError,
+        isConnecting: false,
+      }));
+    });
+
+    it('renders the error message', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.getByText('Wallet Connection Error')).toBeInTheDocument();
+      expect(screen.getByText(testError)).toBeInTheDocument();
+    });
+
+    it('renders a Retry Connection button', () => {
+      renderWithProviders(<WalletPage />);
+      const retryButton = screen.getByRole('button', { name: /retry wallet connection/i });
+      expect(retryButton).toBeInTheDocument();
+    });
+
+    it('calls connect() when Retry is clicked', () => {
+      const connect = jest.fn().mockResolvedValue(undefined);
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: testError,
+        isConnecting: false,
+        connect,
+      }));
+
+      renderWithProviders(<WalletPage />);
+      fireEvent.click(screen.getByRole('button', { name: /retry wallet connection/i }));
+      expect(connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('retry button is keyboard accessible (a native button)', () => {
+      renderWithProviders(<WalletPage />);
+      const retryButton = screen.getByRole('button', { name: /retry wallet connection/i });
+      // Native buttons are keyboard-operable by default; verify it isn't an <a> or div
+      expect(retryButton.tagName).toBe('BUTTON');
+    });
+
+    it('does not render empty state', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.queryByText('Connect Your Wallet')).not.toBeInTheDocument();
+    });
+
+    it('does not render connected state', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.queryByText('Connected Wallet')).not.toBeInTheDocument();
+    });
+
+    it('has aria-live="assertive" region for error announcement', () => {
+      renderWithProviders(<WalletPage />);
+      const assertiveRegion = document.querySelector('[aria-live="assertive"].sr-only');
+      expect(assertiveRegion).toBeInTheDocument();
+    });
+
+    it('has no axe violations', async () => {
+      const { container } = renderWithProviders(<WalletPage />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('passes testA11y helper', async () => {
+      await testA11y(
+        <PreferencesProvider>
+          <ToastProvider>
+            <WalletPage />
+          </ToastProvider>
+        </PreferencesProvider>
+      );
+    });
+  });
+
+  // ── Connected state ────────────────────────────────────────────────────
+
+  describe('connected state', () => {
+    const testAddress = 'GBDGTR4S5O3K7I6E7K5QH3Y2W6Z4JFQ2X3C5V7M8N9P0Q1R2S3T4U5V6W7X';
+
+    beforeEach(() => {
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: testAddress,
+        error: null,
+        isConnecting: false,
+      }));
+    });
+
+    it('renders Connected Wallet heading', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.getByText('Connected Wallet')).toBeInTheDocument();
+    });
+
+    it('renders the truncated wallet address', () => {
+      renderWithProviders(<WalletPage />);
+      // truncateAddress shortens the address; use getByLabelText to find the full address
+      const fullAddress = screen.getByLabelText('Full wallet address');
+      expect(fullAddress).toBeInTheDocument();
+      expect(fullAddress).toHaveTextContent(testAddress);
+      // The displayed connection label should mention connected
+      expect(screen.getByText('Connected Wallet')).toBeInTheDocument();
+    });
+
+    it('renders Copy Address button', () => {
+      renderWithProviders(<WalletPage />);
+      const copyButton = screen.getByRole('button', { name: /copy address to clipboard/i });
+      expect(copyButton).toBeInTheDocument();
+    });
+
+    it('renders Disconnect button', () => {
+      renderWithProviders(<WalletPage />);
+      const disconnectButton = screen.getByRole('button', { name: /disconnect wallet/i });
+      expect(disconnectButton).toBeInTheDocument();
+    });
+
+    it('calls disconnect() when Disconnect is clicked', () => {
+      const disconnect = jest.fn();
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: testAddress,
+        error: null,
+        isConnecting: false,
+        disconnect,
+      }));
+
+      renderWithProviders(<WalletPage />);
+      fireEvent.click(screen.getByRole('button', { name: /disconnect wallet/i }));
+      expect(disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders Account Summary section with status and network', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.getByText('Account Summary')).toBeInTheDocument();
+      expect(screen.getByText('Connected')).toBeInTheDocument();
+      expect(screen.getByText('Stellar Testnet')).toBeInTheDocument();
+    });
+
+    it('does not render empty state', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.queryByText('Connect Your Wallet')).not.toBeInTheDocument();
+    });
+
+    it('does not render error state', () => {
+      renderWithProviders(<WalletPage />);
+      expect(screen.queryByText('Wallet Connection Error')).not.toBeInTheDocument();
+    });
+
+    it('has an aria-live region', () => {
+      renderWithProviders(<WalletPage />);
+      const liveRegion = document.querySelector('[aria-live="polite"].sr-only');
+      expect(liveRegion).toBeInTheDocument();
+    });
+
+    it('has no axe violations', async () => {
+      const { container } = renderWithProviders(<WalletPage />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('passes testA11y helper', async () => {
+      await testA11y(
+        <PreferencesProvider>
+          <ToastProvider>
+            <WalletPage />
+          </ToastProvider>
+        </PreferencesProvider>
+      );
+    });
+  });
+
+  // ── State transition announcements ─────────────────────────────────────
+
+  describe('state transition announcements', () => {
+    it('announces state change from empty to connected via aria-live', () => {
+      // Start in empty state
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: null,
+        isConnecting: false,
+      }));
+
+      const connect = jest.fn().mockResolvedValue(undefined);
+      const { rerender } = renderWithProviders(<WalletPage />);
+
+      // Initially empty
+      expect(screen.getByText('Connect Your Wallet')).toBeInTheDocument();
+
+      // Transition to connected
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: 'GABCD...',
+        error: null,
+        isConnecting: false,
+        connect,
+      }));
+
+      rerender(
+        <PreferencesProvider>
+          <ToastProvider>
+            <WalletPage />
+          </ToastProvider>
+        </PreferencesProvider>
+      );
+
+      // The aria-live region should announce the connected state
+      const liveRegion = document.querySelector('[aria-live="polite"].sr-only');
+      expect(liveRegion).toBeInTheDocument();
+      expect(screen.getByText('Connected Wallet')).toBeInTheDocument();
+    });
+
+    it('announces state change from connected to empty on disconnect', () => {
+      // Start in connected state (jest.setup default)
+      const { rerender } = renderWithProviders(<WalletPage />);
+
+      // Transition to empty (disconnected)
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: null,
+        isConnecting: false,
+      }));
+
+      rerender(
+        <PreferencesProvider>
+          <ToastProvider>
+            <WalletPage />
+          </ToastProvider>
+        </PreferencesProvider>
+      );
+
+      expect(screen.getByText('Connect Your Wallet')).toBeInTheDocument();
+    });
+
+    it('announces state change from empty to error on connection failure', () => {
+      // Start in empty state
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: null,
+        isConnecting: false,
+      }));
+
+      const { rerender } = renderWithProviders(<WalletPage />);
+
+      // Transition to error state
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: 'Connection failed',
+        isConnecting: false,
+      }));
+
+      rerender(
+        <PreferencesProvider>
+          <ToastProvider>
+            <WalletPage />
+          </ToastProvider>
+        </PreferencesProvider>
+      );
+
+      expect(screen.getByText('Wallet Connection Error')).toBeInTheDocument();
+      expect(screen.getByText('Connection failed')).toBeInTheDocument();
+    });
+  });
+
+  // ── State exclusivity ──────────────────────────────────────────────────
+
+  describe('state exclusivity (only one state rendered at a time)', () => {
+    it('renders only the loading state when isConnecting is true even if address is set', () => {
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: 'GABCD...',
+        error: null,
+        isConnecting: true,
+      }));
+
+      renderWithProviders(<WalletPage />);
+      expect(screen.getByText('Connecting Wallet')).toBeInTheDocument();
+      expect(screen.queryByText('Connected Wallet')).not.toBeInTheDocument();
+      expect(screen.queryByText('Connect Your Wallet')).not.toBeInTheDocument();
+      expect(screen.queryByText('Wallet Connection Error')).not.toBeInTheDocument();
+    });
+
+    it('renders only the error state when error is set and not connecting', () => {
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: 'GABCD...',
+        error: 'Something went wrong',
+        isConnecting: false,
+      }));
+
+      renderWithProviders(<WalletPage />);
+      expect(screen.getByText('Wallet Connection Error')).toBeInTheDocument();
+      expect(screen.queryByText('Connecting Wallet')).not.toBeInTheDocument();
+      expect(screen.queryByText('Connected Wallet')).not.toBeInTheDocument();
+      expect(screen.queryByText('Connect Your Wallet')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Heading ────────────────────────────────────────────────────────────
+
+  describe('page heading', () => {
+    beforeEach(() => {
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: null,
+        isConnecting: false,
+      }));
+    });
+
+    it('renders h1 with "Wallet" in all states', () => {
+      const { rerender } = renderWithProviders(<WalletPage />);
+      expect(screen.getByRole('heading', { level: 1, name: 'Wallet' })).toBeInTheDocument();
+
+      // Connecting
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: null,
+        isConnecting: true,
+      }));
+      rerender(
+        <PreferencesProvider>
+          <ToastProvider>
+            <WalletPage />
+          </ToastProvider>
+        </PreferencesProvider>
+      );
+      expect(screen.getByRole('heading', { level: 1, name: 'Wallet' })).toBeInTheDocument();
+
+      // Error
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: 'Error',
+        isConnecting: false,
+      }));
+      rerender(
+        <PreferencesProvider>
+          <ToastProvider>
+            <WalletPage />
+          </ToastProvider>
+        </PreferencesProvider>
+      );
+      expect(screen.getByRole('heading', { level: 1, name: 'Wallet' })).toBeInTheDocument();
+    });
+  });
+
+  // ── Retry re-fetches (calls connect) ─────────────────────────────────────
+
+  describe('retry re-fetches', () => {
+    it('calls connect() when retry button is clicked in error state', () => {
+      const connect = jest.fn().mockResolvedValue(undefined);
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: 'Connection failed',
+        isConnecting: false,
+        connect,
+      }));
+
+      renderWithProviders(<WalletPage />);
+      fireEvent.click(screen.getByRole('button', { name: /retry wallet connection/i }));
+      expect(connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles connect rejection gracefully in retry', () => {
+      const connect = jest.fn().mockRejectedValue(new Error('Failed'));
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: null,
+        error: 'Connection failed',
+        isConnecting: false,
+        connect,
+      }));
+
+      renderWithProviders(<WalletPage />);
+      // Should not throw
+      expect(() => {
+        fireEvent.click(screen.getByRole('button', { name: /retry wallet connection/i }));
+      }).not.toThrow();
+    });
+  });
+});

--- a/src/app/wallet/loading.tsx
+++ b/src/app/wallet/loading.tsx
@@ -1,0 +1,89 @@
+/**
+ * loading.tsx – /wallet
+ *
+ * App Router Suspense boundary for the wallet page. Mirrors the layout
+ * of the wallet page:
+ *   - Page heading
+ *   - Wallet info card skeleton (address, copy button, disconnect button)
+ *   - Balance/summary rows
+ *
+ * Accessibility:
+ * - `aria-busy="true"` on <main>.
+ * - Visually-hidden `role="status"` announces "Loading wallet…".
+ * - All shimmer blocks carry `aria-hidden="true"`.
+ * - Animation disabled for `prefers-reduced-motion` via globals.css rule
+ *   and `motion-reduce:animate-none` belt-and-suspenders guard.
+ */
+
+// ---------------------------------------------------------------------------
+// Local sub-skeletons
+// ---------------------------------------------------------------------------
+
+/** Mirrors the wallet info card (address, copy, disconnect). */
+const WalletInfoCardSkeleton = () => (
+  <div
+    aria-hidden="true"
+    className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
+  >
+    {/* Wallet icon + label */}
+    <div className="flex items-center gap-4">
+      <div className="h-12 w-12 rounded-xl bg-slate-200 animate-shimmer motion-reduce:animate-none" />
+      <div className="space-y-2">
+        <div className="h-3.5 w-24 rounded bg-slate-200 animate-shimmer motion-reduce:animate-none" />
+        <div className="h-5 w-48 rounded-lg bg-slate-200 animate-shimmer motion-reduce:animate-none" />
+      </div>
+    </div>
+
+    {/* Action buttons row */}
+    <div className="mt-6 flex gap-3">
+      <div className="h-10 w-32 rounded-xl bg-slate-200 animate-shimmer motion-reduce:animate-none" />
+      <div className="h-10 w-32 rounded-xl bg-slate-200 animate-shimmer motion-reduce:animate-none" />
+    </div>
+  </div>
+);
+
+/** Mirrors the balance summary section. */
+const BalanceCardSkeleton = () => (
+  <div
+    aria-hidden="true"
+    className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8"
+  >
+    {/* Heading */}
+    <div className="mb-4 h-5 w-32 rounded-lg bg-slate-200 animate-shimmer motion-reduce:animate-none" />
+    {/* Balance rows */}
+    <div className="space-y-4">
+      {Array.from({ length: 3 }, (_, i) => (
+        <div key={i} className="flex items-center justify-between">
+          <div className="h-4 w-24 rounded bg-slate-200 animate-shimmer motion-reduce:animate-none" />
+          <div className="h-4 w-20 rounded bg-slate-200 animate-shimmer motion-reduce:animate-none" />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Route loading export
+// ---------------------------------------------------------------------------
+
+export default function WalletLoading() {
+  return (
+    <main className="min-h-screen p-8" aria-busy="true">
+      <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        Loading wallet…
+      </span>
+
+      {/* Page heading skeleton */}
+      <div
+        aria-hidden="true"
+        className="mb-6 h-8 w-32 rounded-lg bg-slate-200 animate-shimmer motion-reduce:animate-none"
+      />
+
+      {/* Wallet page layout */}
+      <div className="mx-auto max-w-3xl space-y-6">
+        <WalletInfoCardSkeleton />
+        <BalanceCardSkeleton />
+      </div>
+    </main>
+  );
+}

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import EmptyState from '../../components/EmptyState';
+import { useWallet } from '@/contexts/WalletContext';
+import { truncateAddress } from '@/lib/truncateAddress';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+
+// ---------------------------------------------------------------------------
+// WalletStateVisual — renders the visual content based on wallet state
+// ---------------------------------------------------------------------------
+
+type WalletVisualState = 'loading' | 'empty' | 'error' | 'connected';
+
+/**
+ * Determines the current wallet visual state from the WalletContext values.
+ * Exported for testing.
+ */
+export function getWalletVisualState(
+  isConnecting: boolean,
+  address: string | null,
+  error: string | null,
+): WalletVisualState {
+  if (isConnecting) return 'loading';
+  if (error) return 'error';
+  if (!address) return 'empty';
+  return 'connected';
+}
+
+// ---------------------------------------------------------------------------
+// Label map for screen-reader announcements
+// ---------------------------------------------------------------------------
+
+const STATE_LABELS: Record<WalletVisualState, string> = {
+  loading: 'Connecting wallet',
+  empty: 'Wallet not connected',
+  error: 'Wallet connection error',
+  connected: 'Wallet connected',
+};
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+/** Connected wallet details card. */
+function ConnectedWallet({ address, onDisconnect }: { address: string; onDisconnect: () => void }) {
+  const { copy, copied } = useCopyToClipboard({ delay: 2000 });
+
+  const handleCopy = useCallback(async () => {
+    await copy(address);
+  }, [address, copy]);
+
+  return (
+    <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      <div className="flex items-center gap-4">
+        {/* Wallet icon */}
+        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-violet-100 text-violet-700 ring-1 ring-violet-200" aria-hidden="true">
+          <svg className="h-6 w-6" fill="none" viewBox="0 0 64 64">
+            <rect x="8" y="16" width="48" height="36" rx="6" stroke="currentColor" strokeWidth="4" />
+            <rect x="24" y="28" width="16" height="12" rx="3" stroke="currentColor" strokeWidth="3" />
+            <circle cx="34" cy="34" r="2" fill="currentColor" />
+          </svg>
+        </div>
+        <div>
+          <p className="text-sm font-medium text-slate-500">Connected Wallet</p>
+          <p className="text-lg font-semibold text-slate-900 font-mono tracking-tight">
+            {truncateAddress(address)}
+          </p>
+          <p className="mt-0.5 text-xs text-slate-400 font-mono break-all" aria-label="Full wallet address">
+            {address}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleCopy}
+          disabled={copied}
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:opacity-70"
+          aria-label={copied ? 'Address copied to clipboard' : 'Copy address to clipboard'}
+        >
+          {copied ? (
+            <>
+              <svg className="h-4 w-4 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              <span>Copied</span>
+            </>
+          ) : (
+            <>
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+              </svg>
+              <span>Copy Address</span>
+            </>
+          )}
+        </button>
+
+        <button
+          type="button"
+          onClick={onDisconnect}
+          className="inline-flex items-center gap-2 rounded-xl border border-red-200 bg-white px-4 py-2 text-sm font-semibold text-red-600 transition hover:bg-red-50 hover:border-red-300 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-red-500"
+          aria-label="Disconnect wallet"
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+          </svg>
+          <span>Disconnect</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** Error state card with retry button. */
+function WalletErrorState({ error, onRetry }: { error: string; onRetry: () => void }) {
+  return (
+    <div className="rounded-3xl border border-red-200 bg-red-50 p-6 shadow-sm sm:p-8">
+      <div className="flex flex-col items-center text-center">
+        <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-red-100 text-red-600 ring-1 ring-red-200" aria-hidden="true">
+          <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+        </div>
+        <h2 className="mb-2 text-xl font-semibold text-red-900">Wallet Connection Error</h2>
+        <p className="mb-6 max-w-md text-sm leading-6 text-red-700">{error}</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-red-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-red-900"
+          aria-label="Retry wallet connection"
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          <span>Retry Connection</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// WalletPage
+// ---------------------------------------------------------------------------
+
+const WalletPage: React.FC = () => {
+  const { address, isConnecting, error, connect, disconnect } = useWallet();
+
+  const visualState = getWalletVisualState(isConnecting, address, error);
+  const prevStateRef = useRef<WalletVisualState | null>(null);
+  const [announcement, setAnnouncement] = useState('');
+
+  // Announce state changes to assistive technology
+  useEffect(() => {
+    if (prevStateRef.current !== null && prevStateRef.current !== visualState) {
+      setAnnouncement(STATE_LABELS[visualState]);
+      // Clear the announcement after it's been read
+      const timer = setTimeout(() => setAnnouncement(''), 3000);
+      return () => clearTimeout(timer);
+    }
+    prevStateRef.current = visualState;
+  }, [visualState]);
+
+  const handleRetry = useCallback(() => {
+    connect().catch(() => {
+      // Error is surfaced through the WalletContext error state;
+      // no additional toast needed here.
+    });
+  }, [connect]);
+
+  const handleConnect = useCallback(() => {
+    connect().catch(() => {
+      // Error surfaced through WalletContext
+    });
+  }, [connect]);
+
+  const handleDisconnect = useCallback(() => {
+    disconnect();
+  }, [disconnect]);
+
+  // Loading state is handled by the route's loading.tsx Suspense boundary,
+  // but we still show an inline loading state for the connection attempt.
+  if (isConnecting) {
+    return (
+      <main className="min-h-screen p-8">
+        <h1 className="text-2xl font-bold mb-6">Wallet</h1>
+
+        {/* Screen-reader announcement */}
+        <div aria-live="polite" aria-atomic="true" className="sr-only">
+          {announcement || 'Connecting wallet…'}
+        </div>
+
+        <div className="mx-auto max-w-3xl">
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+            <div className="flex flex-col items-center text-center">
+              {/* Spinner */}
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-slate-100 text-slate-500 ring-1 ring-slate-200" aria-hidden="true">
+                <svg className="h-8 w-8 animate-spin motion-reduce:animate-none" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+              </div>
+              <h2 className="mb-2 text-xl font-semibold text-slate-900">Connecting Wallet</h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Please approve the connection request in your wallet extension.
+              </p>
+            </div>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  // Error state
+  if (visualState === 'error' && error) {
+    return (
+      <main className="min-h-screen p-8">
+        <h1 className="text-2xl font-bold mb-6">Wallet</h1>
+
+        {/* Screen-reader announcement */}
+        <div aria-live="assertive" aria-atomic="true" className="sr-only">
+          {announcement}
+        </div>
+
+        <div className="mx-auto max-w-3xl">
+          <WalletErrorState error={error} onRetry={handleRetry} />
+        </div>
+      </main>
+    );
+  }
+
+  // Empty / disconnected state
+  if (visualState === 'empty') {
+    return (
+      <main className="min-h-screen p-8">
+        <h1 className="text-2xl font-bold mb-6">Wallet</h1>
+
+        {/* Screen-reader announcement */}
+        <div aria-live="polite" aria-atomic="true" className="sr-only">
+          {announcement || 'No wallet connected'}
+        </div>
+
+        <div className="mx-auto max-w-3xl">
+          <EmptyState
+            illustration="wallet"
+            title="Connect Your Wallet"
+            description="Connect a Stellar wallet to manage your account, track transactions, and interact with the TalentTrust escrow protocol securely."
+            actionLabel="Connect Wallet"
+            onAction={handleConnect}
+          />
+        </div>
+      </main>
+    );
+  }
+
+  // Connected state
+  return (
+    <main className="min-h-screen p-8">
+      <h1 className="text-2xl font-bold mb-6">Wallet</h1>
+
+      {/* Screen-reader announcement */}
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
+        {announcement}
+      </div>
+
+      <div className="mx-auto max-w-3xl space-y-6">
+        <ConnectedWallet address={address!} onDisconnect={handleDisconnect} />
+
+        {/* Placeholder for future wallet details section */}
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+          <h2 className="mb-4 text-lg font-semibold text-slate-900">Account Summary</h2>
+          <div className="space-y-4">
+            <div className="flex items-center justify-between rounded-2xl bg-slate-50 p-4">
+              <span className="text-sm font-medium text-slate-600">Status</span>
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-3 py-1 text-sm font-semibold text-emerald-700 ring-1 ring-emerald-200">
+                <span className="h-2 w-2 rounded-full bg-emerald-500" aria-hidden="true" />
+                Connected
+              </span>
+            </div>
+            <div className="flex items-center justify-between rounded-2xl bg-slate-50 p-4">
+              <span className="text-sm font-medium text-slate-600">Network</span>
+              <span className="text-sm font-semibold text-slate-900">Stellar Testnet</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default WalletPage;

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -2,7 +2,7 @@
 
 import React, { useId } from 'react';
 
-export type EmptyStateVariant = 'contracts' | 'milestones' | 'reputation';
+export type EmptyStateVariant = 'contracts' | 'milestones' | 'reputation' | 'wallet';
 
 interface EmptyStateProps {
   icon?: React.ReactNode;
@@ -19,6 +19,7 @@ const illustrationClassNames: Record<EmptyStateVariant, string> = {
   contracts: 'bg-blue-50 text-blue-700 ring-blue-100',
   milestones: 'bg-emerald-50 text-emerald-700 ring-emerald-100',
   reputation: 'bg-amber-50 text-amber-700 ring-amber-100',
+  wallet: 'bg-violet-50 text-violet-700 ring-violet-100',
 };
 
 const illustrations: Record<EmptyStateVariant, React.ReactNode> = {
@@ -45,6 +46,14 @@ const illustrations: Record<EmptyStateVariant, React.ReactNode> = {
         strokeWidth="4"
       />
       <path d="M24 54h16" stroke="currentColor" strokeLinecap="round" strokeWidth="4" />
+    </svg>
+  ),
+  wallet: (
+    <svg className="h-16 w-16" fill="none" viewBox="0 0 64 64" aria-hidden="true">
+      <rect x="8" y="16" width="48" height="36" rx="6" stroke="currentColor" strokeWidth="4" />
+      <rect x="24" y="28" width="16" height="12" rx="3" stroke="currentColor" strokeWidth="3" />
+      <circle cx="34" cy="34" r="2" fill="currentColor" />
+      <path d="M8 26h4a4 4 0 014 4v0a4 4 0 01-4 4H8" stroke="currentColor" strokeLinecap="round" strokeWidth="3" />
     </svg>
   ),
 };

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,6 +12,7 @@ const NAV_ROUTES = [
   { href: '/contracts', label: 'Contracts' },
   { href: '/milestones', label: 'Milestones' },
   { href: '/reputation', label: 'Reputation' },
+  { href: '/wallet', label: 'Wallet' },
 ] as const;
 
 /**

--- a/src/components/__tests__/EmptyState.test.tsx
+++ b/src/components/__tests__/EmptyState.test.tsx
@@ -145,6 +145,17 @@ describe('EmptyState', () => {
 
     illustration = screen.getByRole('region').querySelector('[aria-hidden="true"]');
     expect(illustration).toHaveClass('bg-amber-50');
+
+    rerender(
+      <EmptyState
+        illustration="wallet"
+        title="Connect Your Wallet"
+        description="Connect a Stellar wallet."
+      />
+    );
+
+    illustration = screen.getByRole('region').querySelector('[aria-hidden="true"]');
+    expect(illustration).toHaveClass('bg-violet-50');
   });
 
   it('does not render action button when actionLabel or onAction is missing', () => {


### PR DESCRIPTION
## Summary

Adds distinct empty, error (with retry), loading, and connected states to the wallet view, replacing the blank screen users saw when no data was available or a load failed.

## Changes

### New files
- **`src/app/wallet/page.tsx`** — Wallet page with four mutually exclusive visual states (loading, empty/disconnected, error, connected). Uses `getWalletVisualState()` helper to derive the current state from wallet context. Includes `aria-live` announcements for assistive tech on state transitions.
- **`src/app/wallet/loading.tsx`** — Accessible shimmer skeleton matching the wallet page layout, with `aria-busy="true"`, `role="status"` announcements, and reduced-motion support.
- **`src/app/wallet/__tests__/page.test.tsx`** — Comprehensive test suite covering all four states, state exclusivity, retry re-fetch, keyboard operability, and axe accessibility checks.

### Modified files
- **`src/components/EmptyState.tsx`** — Added `wallet` variant with violet-themed illustration (wallet SVG icon).
- **`src/components/Navbar.tsx`** — Added `/wallet` route to the primary navigation.
- **`src/components/__tests__/EmptyState.test.tsx`** — Added wallet variant illustration test.

## Implementation Details

| State | Trigger | Visual |
|-------|---------|--------|
| Loading | `isConnecting === true` | Spinner + connecting message |
| Empty | No `address`, no `error` | `EmptyState` with wallet illustration + Connect button |
| Error | `error` is set | Red error card with message + Retry button |
| Connected | `address` is set | Wallet info card (truncated address, copy, disconnect) + account summary |

### Accessibility
- State transitions announced via `aria-live="polite"` / `aria-live="assertive"` live regions
- Retry button is a native `<button>` — inherently keyboard operable
- All interactive elements have `aria-label` attributes
- Skeleton loading has `aria-busy="true"` and `role="status"` with reduced-motion support

### Edge cases covered
- Exclusivity: only one state renders at a time (loading > error > empty > connected priority)
- Retry re-fetches: clicking retry calls `connect()` again
- Connect rejection handled gracefully (no unhandled promise rejections)
- Copy address with clipboard API

## Test Output

```
Test Suites: 5 passed, 5 total
Tests:       98 passed, 98 total
```

Full output from `npm test`:
```
Test Suites: 73 passed, 73 total
Tests:      1265 passed, 1265 total
```

## Related Issues

Closes #531