### PR TITLE
feat(wallet): show connected network name in header

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -75,6 +75,7 @@ if (typeof window !== 'undefined') {
 jest.mock('@/contexts/WalletContext', () => ({
   useWallet: jest.fn().mockReturnValue({
     address: 'GBDGTR4S5O3K7I6E7K5QH3Y2W6Z4JFQ2X3C5V7M8N9P0Q1R2S3T4U5V6W7X',
+    network: 'Testnet',
     isConnecting: false,
     error: null,
     connect: jest.fn(),

--- a/src/components/WalletConnectButton.tsx
+++ b/src/components/WalletConnectButton.tsx
@@ -7,7 +7,7 @@ import { truncateAddress } from '@/lib/truncateAddress';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 
 export const WalletConnectButton = () => {
-  const { address, isConnecting, error, connect, disconnect } = useWallet();
+  const { address, network, isConnecting, error, connect, disconnect } = useWallet();
   const { showError } = useToast();
 
   const { copied, copy } = useCopyToClipboard({
@@ -71,6 +71,14 @@ export const WalletConnectButton = () => {
           <span className="text-sm font-medium text-slate-700 font-mono">
             {truncateAddress(address)}
           </span>
+          {network && (
+            <span
+              className="ml-1 inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700"
+              aria-label={`Connected to ${network}`}
+            >
+              {network}
+            </span>
+          )}
         </div>
         <button
           onClick={handleCopy}

--- a/src/components/__tests__/WalletConnectButton.test.tsx
+++ b/src/components/__tests__/WalletConnectButton.test.tsx
@@ -385,3 +385,129 @@ describe('WalletConnectButton', () => {
     jest.useFakeTimers();
   });
 });
+
+
+describe('WalletConnectButton - network badge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('displays network badge when connected', () => {
+    mockUseWallet.mockReturnValue(createWalletState({
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      network: 'Testnet',
+    }));
+    installClipboardMock();
+
+    render(<WalletConnectButton />);
+
+    expect(screen.getByText('Testnet')).toBeInTheDocument();
+    expect(screen.getByLabelText('Connected to Testnet')).toBeInTheDocument();
+  });
+
+  it('hides network badge when disconnected', () => {
+    mockUseWallet.mockReturnValue(createWalletState({ network: null }));
+
+    render(<WalletConnectButton />);
+
+    expect(screen.queryByText('Testnet')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Connected to/)).not.toBeInTheDocument();
+  });
+
+  it('displays Mainnet network badge when connected to mainnet', () => {
+    mockUseWallet.mockReturnValue(createWalletState({
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      network: 'Mainnet',
+    }));
+    installClipboardMock();
+
+    render(<WalletConnectButton />);
+
+    expect(screen.getByText('Mainnet')).toBeInTheDocument();
+    expect(screen.getByLabelText('Connected to Mainnet')).toBeInTheDocument();
+  });
+
+  it('displays Futurenet network badge', () => {
+    mockUseWallet.mockReturnValue(createWalletState({
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      network: 'Futurenet',
+    }));
+    installClipboardMock();
+
+    render(<WalletConnectButton />);
+
+    expect(screen.getByText('Futurenet')).toBeInTheDocument();
+    expect(screen.getByLabelText('Connected to Futurenet')).toBeInTheDocument();
+  });
+
+  it('displays Unknown network badge gracefully', () => {
+    mockUseWallet.mockReturnValue(createWalletState({
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      network: 'Unknown',
+    }));
+    installClipboardMock();
+
+    render(<WalletConnectButton />);
+
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+    expect(screen.getByLabelText('Connected to Unknown')).toBeInTheDocument();
+  });
+
+  it('network badge is hidden on error state', () => {
+    mockUseWallet.mockReturnValue(createWalletState({
+      error: 'Connection failed',
+      network: 'Testnet',
+    }));
+
+    render(<WalletConnectButton />);
+
+    expect(screen.queryByText('Testnet')).not.toBeInTheDocument();
+    expect(screen.getByText('Connection Error')).toBeInTheDocument();
+  });
+
+  it('network badge remains visible when copying address', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    mockUseWallet.mockReturnValue(createWalletState({
+      address: '0xABCDEF1234567890',
+      network: 'Testnet',
+    }));
+    installClipboardMock();
+
+    render(<WalletConnectButton />);
+
+    expect(screen.getByText('Testnet')).toBeInTheDocument();
+
+    const copyButton = screen.getByRole('button', { name: 'Copy address to clipboard' });
+    await user.click(copyButton);
+
+    expect(screen.getByText('Testnet')).toBeInTheDocument();
+  });
+
+  it('network badge is positioned next to the address', () => {
+    const truncateAddressSpy = jest.spyOn(truncateAddressModule, 'truncateAddress')
+      .mockReturnValue('0x1234...5678');
+
+    mockUseWallet.mockReturnValue(createWalletState({
+      address: '0x1234567890abcdef1234567890abcdef12345678',
+      network: 'Testnet',
+    }));
+    installClipboardMock();
+
+    render(<WalletConnectButton />);
+
+    const addressSpan = screen.getByText('0x1234...5678');
+    const networkBadge = screen.getByText('Testnet');
+
+    expect(addressSpan.parentElement).toContainElement(networkBadge);
+
+    truncateAddressSpy.mockRestore();
+  });
+});

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -6,6 +6,11 @@ import { getItem, setItem, removeItem } from '@/lib/safeStorage';
 import { usePreferences } from '@/lib/preferences';
 
 /**
+ * Supported Stellar networks.
+ */
+export type StellarNetwork = 'Mainnet' | 'Testnet' | 'Futurenet' | 'Unknown';
+
+/**
  * Shape of the value exposed by {@link WalletContext}.
  *
  * Consumed exclusively through the {@link useWallet} hook; do not read from
@@ -20,6 +25,15 @@ export type WalletContextType = {
    * @example "GAAQ…DZ7H"
    */
   address: string | null;
+
+  /**
+   * The active Stellar network name when wallet is connected, or `null` when
+   * disconnected. Possible values are 'Mainnet', 'Testnet', 'Futurenet', or
+   * 'Unknown' if the network cannot be determined.
+   *
+   * @example "Testnet" | "Mainnet"
+   */
+  network: StellarNetwork | null;
 
   /**
    * `true` while a connection attempt is in progress (i.e. between the
@@ -92,13 +106,14 @@ export const MOCKED_STELLAR_ADDRESS = 'GAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBA
  * ```
  *
  * ## Exposed context fields
- * | Field          | Type                  | Description                                      |
- * |----------------|-----------------------|--------------------------------------------------|
- * | `address`      | `string \| null`      | Connected Stellar public key; `null` if none.    |
- * | `isConnecting` | `boolean`             | `true` while a connection attempt is in flight.  |
- * | `error`        | `string \| null`      | Last connection error message, or `null`.        |
- * | `connect`      | `() => Promise<void>` | Initiates a connection attempt (currently mock). |
- * | `disconnect`   | `() => void`          | Clears session state and storage.                |
+ * | Field          | Type                     | Description                                      |
+ * |----------------|--------------------------|-------------------------------------------------|
+ * | `address`      | `string \| null`         | Connected Stellar public key; `null` if none.    |
+ * | `network`      | `StellarNetwork \| null` | Active network name; `null` if disconnected.     |
+ * | `isConnecting` | `boolean`                | `true` while a connection attempt is in flight.  |
+ * | `error`        | `string \| null`         | Last connection error message, or `null`.        |
+ * | `connect`      | `() => Promise<void>`    | Initiates a connection attempt (currently mock). |
+ * | `disconnect`   | `() => void`             | Clears session state and storage.                |
  *
  * ## Idle auto-disconnect
  * When `idleTimeout` is a positive number, the provider listens for pointer,
@@ -122,6 +137,7 @@ export function WalletProvider({
   const idleTimeout = propIdleTimeout !== undefined ? propIdleTimeout : preferences.idleDisconnectMs;
 
   const [address, setAddress] = useState<string | null>(null);
+  const [network, setNetwork] = useState<StellarNetwork | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Safely obtain toast functions; fallback to no-ops if provider is absent
@@ -136,13 +152,14 @@ export function WalletProvider({
   const { showSuccess, showError } = useSafeToast();
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const STORAGE_KEY = 'wallet_connected_address';
-
-
+  const STORAGE_KEY_ADDRESS = 'wallet_connected_address';
+  const STORAGE_KEY_NETWORK = 'wallet_connected_network';
 
   const disconnect = useCallback(() => {
     setAddress(null);
-    removeItem(STORAGE_KEY);
+    setNetwork(null);
+    removeItem(STORAGE_KEY_ADDRESS);
+    removeItem(STORAGE_KEY_NETWORK);
     if (timerRef.current) {
       clearTimeout(timerRef.current);
       timerRef.current = null;
@@ -165,12 +182,16 @@ export function WalletProvider({
     }
   }, [address, idleTimeout, disconnect, showSuccess]);
 
-  // Rehydrate address from storage on mount (client only)
+  // Rehydrate address and network from storage on mount (client only)
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const stored = getItem(STORAGE_KEY);
-    if (stored) {
-      setAddress(stored);
+    const storedAddress = getItem(STORAGE_KEY_ADDRESS);
+    const storedNetwork = getItem(STORAGE_KEY_NETWORK);
+    if (storedAddress) {
+      setAddress(storedAddress);
+    }
+    if (storedNetwork && ['Mainnet', 'Testnet', 'Futurenet', 'Unknown'].includes(storedNetwork)) {
+      setNetwork(storedNetwork as StellarNetwork);
     }
   }, []);
 
@@ -199,7 +220,7 @@ export function WalletProvider({
    *   2. Waits exactly **1 second** via `setTimeout` to simulate network /
    *      extension latency (no real wallet API is called).
    *   3. Sets `address` to the hard-coded {@link MOCKED_STELLAR_ADDRESS}
-   *      constant and persists it to `localStorage` under `wallet_connected_address`.
+   *      constant, sets `network` to "Testnet", and persists both to `localStorage`.
    *   4. Resets `isConnecting` to `false` in the `finally` block.
    *
    * Intended behaviour (post-integration):
@@ -208,7 +229,8 @@ export function WalletProvider({
    *      {@link FREIGHTER_NOT_INSTALLED} if absent.
    *   3. Call `window.freighter.requestAccess()`; map a user-rejection to
    *      {@link USER_REJECTED}.
-   *   4. Validate and persist the returned Stellar public key.
+   *   4. Detect the active network from Freighter wallet state.
+   *   5. Validate and persist the returned Stellar public key and network.
    */
   const connect = useCallback(async () => {
     setIsConnecting(true);
@@ -222,7 +244,13 @@ export function WalletProvider({
       // Replace with the public key returned by window.freighter.getPublicKey()
       // once the real wallet integration is in place.
       setAddress(MOCKED_STELLAR_ADDRESS);
-      setItem(STORAGE_KEY, MOCKED_STELLAR_ADDRESS);
+      setItem(STORAGE_KEY_ADDRESS, MOCKED_STELLAR_ADDRESS);
+      // ── MOCK: hard-coded network for UI development (Testnet). ────────────
+      // Replace with network detection from window.freighter.getNetworkDetails()
+      // once the real wallet integration is in place.
+      const mockNetwork: StellarNetwork = 'Testnet';
+      setNetwork(mockNetwork);
+      setItem(STORAGE_KEY_NETWORK, mockNetwork);
     } catch (_err) {
       const message = 'Failed to connect wallet';
       /**
@@ -244,10 +272,10 @@ export function WalletProvider({
     } finally {
       setIsConnecting(false);
     }
-  }, []);
+  }, [showError]);
 
   return (
-    <WalletContext.Provider value={{ address, isConnecting, error, connect, disconnect }}>
+    <WalletContext.Provider value={{ address, network, isConnecting, error, connect, disconnect }}>
       {children}
     </WalletContext.Provider>
   );
@@ -257,8 +285,8 @@ export function WalletProvider({
  * Accesses the wallet connection context from any client component.
  *
  * Returns the full {@link WalletContextType} value: the connected Stellar
- * address, connection-in-progress flag, last error string, and the
- * `connect` / `disconnect` actions.
+ * address, active network, connection-in-progress flag, last error string,
+ * and the `connect` / `disconnect` actions.
  *
  * **Safety guard:** throws an `Error` with a descriptive message if called
  * outside of a `<WalletProvider>` subtree. This makes misconfigured trees
@@ -267,7 +295,7 @@ export function WalletProvider({
  *
  * @example
  * ```tsx
- * const { address, isConnecting, connect, disconnect, error } = useWallet();
+ * const { address, network, isConnecting, connect, disconnect, error } = useWallet();
  * ```
  *
  * @returns The current {@link WalletContextType} value.

--- a/src/contexts/__tests__/WalletContext.test.tsx
+++ b/src/contexts/__tests__/WalletContext.test.tsx
@@ -591,3 +591,202 @@ describe('WalletContext – error toast surfacing', () => {
     expect(screen.getByTestId('inline-error').textContent).toBe('Failed to connect wallet');
   });
 });
+
+describe('WalletContext - network field', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('network state management', () => {
+    it('initializes with null network', () => {
+      function NetworkConsumer() {
+        const { network } = useWallet();
+        return <div data-testid="network">{network || 'null'}</div>;
+      }
+
+      renderWithProviders(<NetworkConsumer />);
+      expect(screen.getByTestId('network')).toHaveTextContent('null');
+    });
+
+    it('sets network to Testnet when connecting', async () => {
+      function NetworkConsumer() {
+        const { network, address, connect } = useWallet();
+        return (
+          <div>
+            <div data-testid="network">{network || 'null'}</div>
+            <div data-testid="address">{address || 'null'}</div>
+            <button onClick={connect}>Connect</button>
+          </div>
+        );
+      }
+
+      renderWithProviders(<NetworkConsumer />);
+
+      expect(screen.getByTestId('network')).toHaveTextContent('null');
+
+      await act(async () => {
+        screen.getByText('Connect').click();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(screen.getByTestId('network')).toHaveTextContent('Testnet');
+      expect(screen.getByTestId('address')).toHaveTextContent(MOCKED_STELLAR_ADDRESS);
+    });
+
+    it('clears network when disconnecting', async () => {
+      function NetworkConsumer() {
+        const { network, address, connect, disconnect } = useWallet();
+        return (
+          <div>
+            <div data-testid="network">{network || 'null'}</div>
+            <div data-testid="address">{address || 'null'}</div>
+            <button data-testid="connect-btn" onClick={connect}>Connect</button>
+            <button data-testid="disconnect-btn" onClick={disconnect}>Disconnect</button>
+          </div>
+        );
+      }
+
+      renderWithProviders(<NetworkConsumer />);
+
+      // Connect
+      await act(async () => {
+        screen.getByTestId('connect-btn').click();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(screen.getByTestId('network')).toHaveTextContent('Testnet');
+
+      // Disconnect
+      await act(async () => {
+        screen.getByTestId('disconnect-btn').click();
+      });
+
+      expect(screen.getByTestId('network')).toHaveTextContent('null');
+      expect(screen.getByTestId('address')).toHaveTextContent('null');
+    });
+  });
+
+  describe('network persistence', () => {
+    it('persists network to localStorage on connect', async () => {
+      function NetworkConsumer() {
+        const { connect } = useWallet();
+        return <button onClick={connect}>Connect</button>;
+      }
+
+      renderWithProviders(<NetworkConsumer />);
+
+      await act(async () => {
+        screen.getByText('Connect').click();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(setItem).toHaveBeenCalledWith('wallet_connected_network', 'Testnet');
+    });
+
+    it('removes network from localStorage on disconnect', async () => {
+      function NetworkConsumer() {
+        const { connect, disconnect, address } = useWallet();
+        return (
+          <div>
+            <div data-testid="address">{address || 'null'}</div>
+            <button data-testid="connect-btn" onClick={connect}>Connect</button>
+            <button data-testid="disconnect-btn" onClick={disconnect}>Disconnect</button>
+          </div>
+        );
+      }
+
+      renderWithProviders(<NetworkConsumer />);
+
+      await act(async () => {
+        screen.getByTestId('connect-btn').click();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      await act(async () => {
+        screen.getByTestId('disconnect-btn').click();
+      });
+
+      expect(removeItem).toHaveBeenCalledWith('wallet_connected_network');
+    });
+
+    it('rehydrates network from localStorage on mount', () => {
+      const mockGetItem = getItem as jest.MockedFunction<typeof getItem>;
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === 'wallet_connected_address') return MOCKED_STELLAR_ADDRESS;
+        if (key === 'wallet_connected_network') return 'Testnet';
+        return null;
+      });
+
+      function NetworkConsumer() {
+        const { network, address } = useWallet();
+        return (
+          <div>
+            <div data-testid="network">{network || 'null'}</div>
+            <div data-testid="address">{address || 'null'}</div>
+          </div>
+        );
+      }
+
+      renderWithProviders(<NetworkConsumer />);
+
+      expect(screen.getByTestId('network')).toHaveTextContent('Testnet');
+      expect(screen.getByTestId('address')).toHaveTextContent(MOCKED_STELLAR_ADDRESS);
+    });
+
+    it('ignores invalid network values in localStorage', () => {
+      const mockGetItem = getItem as jest.MockedFunction<typeof getItem>;
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === 'wallet_connected_address') return MOCKED_STELLAR_ADDRESS;
+        if (key === 'wallet_connected_network') return 'InvalidNetwork';
+        return null;
+      });
+
+      function NetworkConsumer() {
+        const { network } = useWallet();
+        return <div data-testid="network">{network || 'null'}</div>;
+      }
+
+      renderWithProviders(<NetworkConsumer />);
+
+      expect(screen.getByTestId('network')).toHaveTextContent('null');
+    });
+  });
+
+  describe('network with unknown state', () => {
+    it('accepts Unknown as a valid network', async () => {
+      const mockGetItem = getItem as jest.MockedFunction<typeof getItem>;
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === 'wallet_connected_address') return MOCKED_STELLAR_ADDRESS;
+        if (key === 'wallet_connected_network') return 'Unknown';
+        return null;
+      });
+
+      function NetworkConsumer() {
+        const { network } = useWallet();
+        return <div data-testid="network">{network || 'null'}</div>;
+      }
+
+      renderWithProviders(<NetworkConsumer />);
+
+      expect(screen.getByTestId('network')).toHaveTextContent('Unknown');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Displays the active Stellar network name in the header's wallet status component when a wallet is connected.

## Changes
- **WalletContext**: Add network state, persistence, and type safety
- **WalletConnectButton**: Add network badge display
- **Tests**: Update to cover network field

## Checks
- ✅ Lint: `npm run lint`
- ✅ Tests: `npm test`
- ✅ Build: `npm run build`

Commit: `feat(wallet): show connected network name in header`

## Related Issue:
Closes #481 