### PR TITLE
a11y(dialogs): announce content changes via polite live region

### DIFF
--- a/src/components/DialogAnnouncer.tsx
+++ b/src/components/DialogAnnouncer.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export interface DialogAnnouncerProps {
+  count?: number;
+  label?: string;
+  status?: string;
+  debounceMs?: number;
+}
+
+const DialogAnnouncer = ({
+  count,
+  label = 'items',
+  status,
+  debounceMs = 300,
+}: DialogAnnouncerProps) => {
+  const [announcement, setAnnouncement] = useState('');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevCount = useRef(count);
+  const prevStatus = useRef(status);
+
+  useEffect(() => {
+    const countChanged = count !== undefined && prevCount.current !== count;
+    const statusChanged = status !== undefined && prevStatus.current !== status;
+
+    if (!countChanged && !statusChanged) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      return;
+    }
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = setTimeout(() => {
+      if (countChanged) {
+        prevCount.current = count;
+        setAnnouncement(`${count} ${label}`);
+      } else if (statusChanged) {
+        prevStatus.current = status;
+        setAnnouncement(status ?? '');
+      }
+    }, debounceMs);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [count, status, label, debounceMs]);
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="sr-only"
+    >
+      {announcement}
+    </span>
+  );
+};
+
+export default DialogAnnouncer;

--- a/src/components/__tests__/DialogAnnouncer.test.tsx
+++ b/src/components/__tests__/DialogAnnouncer.test.tsx
@@ -1,0 +1,167 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import DialogAnnouncer from '../DialogAnnouncer';
+import { assertNoA11yViolations } from '@/test-utils/a11y';
+
+describe('DialogAnnouncer', () => {
+  it('renders empty on initial mount', () => {
+    render(<DialogAnnouncer count={0} />);
+    const region = screen.getByRole('status');
+    expect(region).toBeEmptyDOMElement();
+  });
+
+  it('has correct aria attributes', () => {
+    render(<DialogAnnouncer count={0} />);
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveAttribute('aria-atomic', 'true');
+    expect(region).toHaveAttribute('class', 'sr-only');
+  });
+
+  it('announces a count change', async () => {
+    const { rerender } = render(<DialogAnnouncer count={0} />);
+
+    rerender(<DialogAnnouncer count={3} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('3 items');
+    });
+  });
+
+  it('announces a status change', async () => {
+    const { rerender } = render(<DialogAnnouncer status="closed" />);
+
+    rerender(<DialogAnnouncer status="open" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('open');
+    });
+  });
+
+  it('does not announce a same-count rerender', () => {
+    const { rerender } = render(<DialogAnnouncer count={5} />);
+
+    rerender(<DialogAnnouncer count={5} />);
+
+    expect(screen.getByRole('status')).toBeEmptyDOMElement();
+  });
+
+  it('does not announce a same-status rerender', () => {
+    const { rerender } = render(<DialogAnnouncer status="pending" />);
+
+    rerender(<DialogAnnouncer status="pending" />);
+
+    expect(screen.getByRole('status')).toBeEmptyDOMElement();
+  });
+
+  it('does not announce on mount even when count is provided', () => {
+    render(<DialogAnnouncer count={42} />);
+    expect(screen.getByRole('status')).toBeEmptyDOMElement();
+  });
+
+  it('does not announce on mount even when status is provided', () => {
+    render(<DialogAnnouncer status="open" />);
+    expect(screen.getByRole('status')).toBeEmptyDOMElement();
+  });
+
+  it('settles on the latest count during rapid updates', async () => {
+    const { rerender } = render(<DialogAnnouncer count={0} />);
+
+    act(() => {
+      rerender(<DialogAnnouncer count={1} />);
+      rerender(<DialogAnnouncer count={2} />);
+      rerender(<DialogAnnouncer count={5} />);
+    });
+
+    await waitFor(() => {
+      const region = screen.getByRole('status');
+      expect(region).toHaveTextContent('5 items');
+      expect(region).not.toHaveTextContent('1 items');
+      expect(region).not.toHaveTextContent('2 items');
+    });
+  });
+
+  it('settles on the latest status during rapid updates', async () => {
+    const { rerender } = render(<DialogAnnouncer status="closed" />);
+
+    act(() => {
+      rerender(<DialogAnnouncer status="editing" />);
+      rerender(<DialogAnnouncer status="saving" />);
+      rerender(<DialogAnnouncer status="submitted" />);
+    });
+
+    await waitFor(() => {
+      const region = screen.getByRole('status');
+      expect(region).toHaveTextContent('submitted');
+      expect(region).not.toHaveTextContent('editing');
+      expect(region).not.toHaveTextContent('saving');
+    });
+  });
+
+  it('announces zero count', async () => {
+    const { rerender } = render(<DialogAnnouncer count={5} />);
+
+    rerender(<DialogAnnouncer count={0} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('0 items');
+    });
+  });
+
+  it('uses a custom label for count announcements', async () => {
+    const { rerender } = render(<DialogAnnouncer count={0} label="errors" />);
+
+    rerender(<DialogAnnouncer count={2} label="errors" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('2 errors');
+    });
+  });
+
+  it('respects a custom debounce delay', async () => {
+    const { rerender } = render(
+      <DialogAnnouncer count={0} debounceMs={500} />,
+    );
+
+    rerender(<DialogAnnouncer count={1} debounceMs={500} />);
+
+    await waitFor(
+      () => {
+        expect(screen.getByRole('status')).toHaveTextContent('1 items');
+      },
+      { timeout: 800 },
+    );
+  });
+
+  it('cancels pending announcement when value reverts to original', async () => {
+    const { rerender } = render(<DialogAnnouncer count={5} />);
+
+    act(() => {
+      rerender(<DialogAnnouncer count={10} />);
+      rerender(<DialogAnnouncer count={5} />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 500));
+    });
+
+    expect(screen.getByRole('status')).toBeEmptyDOMElement();
+  });
+
+  it('uses count change when both count and status change', async () => {
+    const { rerender } = render(
+      <DialogAnnouncer count={0} status="closed" />,
+    );
+
+    rerender(<DialogAnnouncer count={3} status="open" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('3 items');
+      expect(screen.getByRole('status')).not.toHaveTextContent('open');
+    });
+  });
+
+  it('has no automated accessibility violations', async () => {
+    const { container } = render(<DialogAnnouncer count={0} />);
+    await assertNoA11yViolations(container);
+  });
+});


### PR DESCRIPTION
## Description

Adds DialogAnnouncer, a reusable polite live-region component that announces dialog content changes (count/status) to assistive technology. Previously, when dialog content updated (e.g., error count changed), screen-reader users received no feedback. The component debounces rapid updates and skips announcement on initial mount.

Closes #542

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage

- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [x] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

 Initial mount silence (no announcement before first change)
- Count change announcement (0 → 3 → "3 items")
- Status change announcement ("closed" → "open" → "open")
- Same-value re-render produces no announcement
- Rapid successive updates settle on the latest value (debounce)
- Zero-count edge case (5 → 0 → "0 items")
- Custom label and custom debounce delay
- Revert cancellation (value changes back before timer fires → no announcement)
- Count takes priority when both count and status change simultaneously
- Correct ARIA attributes (role="status", aria-live="polite", aria-atomic="true", sr-only)
- jest-axe accessibility audit via assertNoA11yViolations from src/test-utils/a11y.tsx

---

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->

### Security

no authentication, authorization, wallet logic, API calls, or user-supplied input was touched. The component renders static props into a plain-text live region with no XSS surface.