### PR TITLE
feat(data): add JSON export of local app data

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -120,6 +120,31 @@ When the repository returns no milestones, the page falls back to its existing `
 
 ---
 
+## Exporting Data
+
+Users can download a JSON backup of everything persisted for TalentTrust via
+**Settings → Data → Export data as JSON**. This is implemented in
+`src/lib/dataExport.ts` and:
+
+- Reads only the app's own namespaced keys — `talenttrust_app_data` (this
+  module) and `talenttrust-user-preferences` (`src/lib/preferences.tsx`) —
+  through the `safeStorage` wrapper. Unrelated keys (e.g. the login-throttle
+  counters in `src/lib/loginThrottle.ts`) are never read or included.
+- Omits a key entirely when nothing is stored for it, so an empty store still
+  produces a valid document (`{ version, exportedAt, data: {} }`).
+- Skips (and reports via `errorReporter`, without throwing) any individual
+  key whose stored value isn't valid JSON, so one corrupt entry can't block
+  the rest of the export.
+
+```ts
+import { exportAppDataAsJson } from '@/lib/dataExport';
+
+// Builds the export, triggers a JSON file download, and returns the document.
+const exportDoc = exportAppDataAsJson();
+```
+
+---
+
 ## Clearing Stored Data
 
 To wipe all persisted data (e.g. for testing or a "reset" feature):

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { usePreferences, Theme, AmountFormat, ToastDensity } from '@/lib/preferences';
+import { exportAppDataAsJson } from '@/lib/dataExport';
 
 const FOCUSABLE_SELECTORS =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -14,6 +15,16 @@ interface SettingsPanelProps {
 export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
   const { preferences, updatePreference } = usePreferences();
   const panelRef = useRef<HTMLDivElement>(null);
+  const [exportStatus, setExportStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const handleExportData = () => {
+    try {
+      exportAppDataAsJson();
+      setExportStatus('success');
+    } catch {
+      setExportStatus('error');
+    }
+  };
 
   /**
    * Focus management effect for modal dialog accessibility.
@@ -184,6 +195,32 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                   />
                 </button>
               </div>
+            </div>
+          </section>
+
+          {/* Data Section */}
+          <section className="space-y-4">
+            <h3 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wider">Data</h3>
+
+            <div className="space-y-2">
+              <div>
+                <p className="text-sm font-medium text-[var(--foreground)]">Export your data</p>
+                <p className="text-xs text-[var(--muted-foreground)]">
+                  Download a JSON file of everything saved in this browser so you can back it up
+                  or move to another browser.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleExportData}
+                className="w-full py-2 px-4 rounded-md border border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] text-sm font-medium hover:border-[var(--muted-foreground)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
+              >
+                Export data as JSON
+              </button>
+              <p role="status" aria-live="polite" className="text-xs text-[var(--muted-foreground)]">
+                {exportStatus === 'success' && 'Export downloaded.'}
+                {exportStatus === 'error' && 'Export failed. Please try again.'}
+              </p>
             </div>
           </section>
         </div>

--- a/src/components/settings/__tests__/SettingsPanel.test.tsx
+++ b/src/components/settings/__tests__/SettingsPanel.test.tsx
@@ -4,7 +4,11 @@ import { axe } from 'jest-axe';
 import { SettingsPanel } from '../SettingsPanel';
 import { PreferencesProvider } from '@/lib/preferences';
 import { resetCache } from '@/lib/safeStorage';
+import * as dataExport from '@/lib/dataExport';
 
+jest.mock('@/lib/dataExport', () => ({
+  exportAppDataAsJson: jest.fn(),
+}));
 
 const renderWithProvider = (ui: React.ReactElement) => {
   return render(
@@ -18,6 +22,7 @@ describe('SettingsPanel', () => {
   beforeEach(() => {
     localStorage.clear();
     resetCache();
+    jest.mocked(dataExport.exportAppDataAsJson).mockReset();
   });
 
   it('renders nothing when closed', () => {
@@ -32,6 +37,7 @@ describe('SettingsPanel', () => {
     expect(screen.getByText('Settings')).toBeDefined();
     expect(screen.getByText('Appearance')).toBeDefined();
     expect(screen.getByText('Notifications')).toBeDefined();
+    expect(screen.getByText('Data')).toBeDefined();
   });
 
   it('calls onClose when close button is clicked', () => {
@@ -187,6 +193,7 @@ describe('SettingsPanel', () => {
     const focusableControls = [
       screen.getByRole('button', { name: /close settings/i }),
       screen.getByRole('switch', { name: /quiet mode/i }),
+      screen.getByRole('button', { name: /export data as json/i }),
       screen.getByRole('button', { name: /done/i }),
     ];
 
@@ -245,6 +252,20 @@ describe('SettingsPanel', () => {
     last.focus();
     fireEvent.keyDown(document, { key: 'Tab', shiftKey: false });
     expect(document.activeElement).toBe(focusable[0]);
+  });
+
+  it('Tab on a middle focusable element does not wrap focus', () => {
+    renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+    const dialog = screen.getByRole('dialog');
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+    );
+    const middle = focusable[Math.floor(focusable.length / 2)];
+    middle.focus();
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: false });
+    expect(document.activeElement).toBe(middle);
   });
 
   it('Shift+Tab on the first focusable element wraps focus to the last', () => {
@@ -328,5 +349,51 @@ describe('SettingsPanel', () => {
     expect(themeButtons[0]).toHaveAccessibleName('light');
     expect(themeButtons[1]).toHaveAccessibleName('dark');
     expect(themeButtons[2]).toHaveAccessibleName('system');
+  });
+
+  // --- Data export section ---
+
+  describe('data export', () => {
+    it('renders an accessible export control in the Data section', () => {
+      renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+      const exportButton = screen.getByRole('button', { name: /export data as json/i });
+      expect(exportButton).toBeInTheDocument();
+      expect(exportButton).toHaveAccessibleName('Export data as JSON');
+    });
+
+    it('triggers the export helper when the export button is clicked', () => {
+      renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /export data as json/i }));
+
+      expect(dataExport.exportAppDataAsJson).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows a success status message after a successful export', () => {
+      renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /export data as json/i }));
+
+      expect(screen.getByRole('status')).toHaveTextContent('Export downloaded.');
+    });
+
+    it('shows an error status message when the export helper throws', () => {
+      jest.mocked(dataExport.exportAppDataAsJson).mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /export data as json/i }));
+
+      expect(screen.getByRole('status')).toHaveTextContent('Export failed. Please try again.');
+    });
+
+    it('shows no status message before the export button has been clicked', () => {
+      renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+      expect(screen.getByRole('status')).toHaveTextContent('');
+    });
   });
 });

--- a/src/lib/__tests__/dataExport.ssr.test.ts
+++ b/src/lib/__tests__/dataExport.ssr.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment node
+ *
+ * SSR-context tests for src/lib/dataExport.ts.
+ *
+ * Isolated into their own `node`-environment file (matching
+ * repository.ssr.test.ts) so `typeof window === 'undefined'` /
+ * `typeof document === 'undefined'` are real rather than simulated, since
+ * jest-environment-jsdom 30 made the global `window` non-configurable.
+ */
+
+import { buildAppDataExport, downloadTextFile } from '../dataExport';
+
+describe('dataExport (SSR)', () => {
+  it('buildAppDataExport yields an empty document when there is no window', () => {
+    const fixedNow = () => new Date('2026-07-23T10:15:00.000Z');
+    const exportDoc = buildAppDataExport(fixedNow);
+
+    expect(exportDoc.data).toEqual({});
+    expect(exportDoc.exportedAt).toBe('2026-07-23T10:15:00.000Z');
+  });
+
+  it('downloadTextFile is a no-op and never throws when there is no window/document', () => {
+    expect(() => downloadTextFile('export.json', '{}')).not.toThrow();
+  });
+});

--- a/src/lib/__tests__/dataExport.test.ts
+++ b/src/lib/__tests__/dataExport.test.ts
@@ -1,0 +1,257 @@
+import {
+  buildAppDataExport,
+  buildExportFilename,
+  downloadTextFile,
+  exportAppDataAsJson,
+  serializeAppDataExport,
+  EXPORT_FORMAT_VERSION,
+  EXPORTABLE_KEYS,
+} from '../dataExport';
+import { STORAGE_KEY as APP_DATA_STORAGE_KEY } from '../repository';
+import { STORAGE_KEY as PREFERENCES_STORAGE_KEY } from '../preferences';
+import { setErrorReporter } from '../errorReporter';
+import { resetCache } from '../safeStorage';
+
+const FIXED_DATE = new Date('2026-07-23T10:15:00.000Z');
+const fixedNow = () => FIXED_DATE;
+
+describe('dataExport', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    resetCache();
+    setErrorReporter(null);
+  });
+
+  afterEach(() => {
+    setErrorReporter(null);
+  });
+
+  describe('EXPORTABLE_KEYS', () => {
+    it('is sourced from the real storage keys owned by repository and preferences', () => {
+      expect(EXPORTABLE_KEYS).toEqual([APP_DATA_STORAGE_KEY, PREFERENCES_STORAGE_KEY]);
+    });
+
+    it('does not include unrelated keys such as login throttle counters', () => {
+      expect(EXPORTABLE_KEYS).not.toContain('login_throttle_attempts');
+      expect(EXPORTABLE_KEYS).not.toContain('login_throttle_cooldown');
+    });
+  });
+
+  describe('buildAppDataExport', () => {
+    it('yields an empty data document when the store is empty', () => {
+      const exportDoc = buildAppDataExport(fixedNow);
+
+      expect(exportDoc).toEqual({
+        version: EXPORT_FORMAT_VERSION,
+        exportedAt: FIXED_DATE.toISOString(),
+        data: {},
+      });
+    });
+
+    it('includes every stored, namespaced key', () => {
+      const appData = { contracts: [{ contractName: 'Design Sprint' }], milestones: [] };
+      const preferencesData = { theme: 'dark', amountFormat: 'usd' };
+
+      window.localStorage.setItem(APP_DATA_STORAGE_KEY, JSON.stringify(appData));
+      window.localStorage.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify(preferencesData));
+
+      const exportDoc = buildAppDataExport(fixedNow);
+
+      expect(exportDoc.data[APP_DATA_STORAGE_KEY]).toEqual(appData);
+      expect(exportDoc.data[PREFERENCES_STORAGE_KEY]).toEqual(preferencesData);
+      expect(Object.keys(exportDoc.data)).toHaveLength(2);
+    });
+
+    it('reads through the safe storage wrapper rather than localStorage directly', () => {
+      window.localStorage.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify({ theme: 'light' }));
+
+      const exportDoc = buildAppDataExport(fixedNow);
+
+      expect(exportDoc.data[PREFERENCES_STORAGE_KEY]).toEqual({ theme: 'light' });
+    });
+
+    it('omits a key entirely when nothing is stored for it', () => {
+      window.localStorage.setItem(APP_DATA_STORAGE_KEY, JSON.stringify({ contracts: [], milestones: [] }));
+      // PREFERENCES_STORAGE_KEY intentionally left unset.
+
+      const exportDoc = buildAppDataExport(fixedNow);
+
+      expect(Object.keys(exportDoc.data)).toEqual([APP_DATA_STORAGE_KEY]);
+    });
+
+    it('skips a corrupt stored value and reports it, without aborting the export', () => {
+      const reportSpy = jest.fn();
+      setErrorReporter(reportSpy);
+
+      window.localStorage.setItem(APP_DATA_STORAGE_KEY, '{not valid json');
+      window.localStorage.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify({ theme: 'dark' }));
+
+      const exportDoc = buildAppDataExport(fixedNow);
+
+      expect(exportDoc.data[APP_DATA_STORAGE_KEY]).toBeUndefined();
+      expect(exportDoc.data[PREFERENCES_STORAGE_KEY]).toEqual({ theme: 'dark' });
+      expect(reportSpy).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.stringContaining(APP_DATA_STORAGE_KEY),
+        'warn',
+        expect.objectContaining({ key: APP_DATA_STORAGE_KEY }),
+      );
+    });
+
+    it('skips every corrupt key and still yields a valid (if partly empty) document', () => {
+      window.localStorage.setItem(APP_DATA_STORAGE_KEY, 'not json at all');
+      window.localStorage.setItem(PREFERENCES_STORAGE_KEY, '{"unterminated": ');
+
+      const exportDoc = buildAppDataExport(fixedNow);
+
+      expect(exportDoc.data).toEqual({});
+      expect(exportDoc.version).toBe(EXPORT_FORMAT_VERSION);
+    });
+
+    it('uses the current time when no clock is injected', () => {
+      const before = Date.now();
+      const exportDoc = buildAppDataExport();
+      const after = Date.now();
+
+      const exportedAtMs = new Date(exportDoc.exportedAt).getTime();
+      expect(exportedAtMs).toBeGreaterThanOrEqual(before);
+      expect(exportedAtMs).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('serializeAppDataExport', () => {
+    it('produces pretty-printed, parseable JSON matching the source document', () => {
+      const exportDoc = buildAppDataExport(fixedNow);
+      const json = serializeAppDataExport(exportDoc);
+
+      expect(json).toContain('\n');
+      expect(JSON.parse(json)).toEqual(exportDoc);
+    });
+  });
+
+  describe('buildExportFilename', () => {
+    it('derives a filesystem-safe, timestamped .json filename', () => {
+      const exportDoc = buildAppDataExport(fixedNow);
+      const filename = buildExportFilename(exportDoc);
+
+      expect(filename).toBe('talenttrust-data-export-2026-07-23T10-15-00-000Z.json');
+      expect(filename).not.toMatch(/[:]/);
+    });
+  });
+
+  describe('downloadTextFile', () => {
+    let createObjectURLSpy: jest.SpyInstance;
+    let revokeObjectURLSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      createObjectURLSpy = jest.fn().mockReturnValue('blob:mock-url');
+      revokeObjectURLSpy = jest.fn();
+      Object.defineProperty(window.URL, 'createObjectURL', {
+        value: createObjectURLSpy,
+        configurable: true,
+      });
+      Object.defineProperty(window.URL, 'revokeObjectURL', {
+        value: revokeObjectURLSpy,
+        configurable: true,
+      });
+    });
+
+    it('creates and clicks a download link, then revokes the object URL', () => {
+      const clickSpy = jest.fn();
+      const originalCreateElement = document.createElement.bind(document);
+      const createElementSpy = jest
+        .spyOn(document, 'createElement')
+        .mockImplementation((tagName: string) => {
+          const el = originalCreateElement(tagName);
+          if (tagName === 'a') {
+            el.click = clickSpy;
+          }
+          return el;
+        });
+
+      downloadTextFile('export.json', '{"a":1}');
+
+      expect(createObjectURLSpy).toHaveBeenCalled();
+      expect(clickSpy).toHaveBeenCalled();
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url');
+
+      createElementSpy.mockRestore();
+    });
+  });
+
+  describe('exportAppDataAsJson', () => {
+    beforeEach(() => {
+      Object.defineProperty(window.URL, 'createObjectURL', {
+        value: jest.fn().mockReturnValue('blob:mock-url'),
+        configurable: true,
+      });
+      Object.defineProperty(window.URL, 'revokeObjectURL', {
+        value: jest.fn(),
+        configurable: true,
+      });
+    });
+
+    it('builds and downloads the export, returning the export document', () => {
+      window.localStorage.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify({ theme: 'dark' }));
+
+      const clickSpy = jest.fn();
+      const originalCreateElement = document.createElement.bind(document);
+      const createElementSpy = jest
+        .spyOn(document, 'createElement')
+        .mockImplementation((tagName: string) => {
+          const el = originalCreateElement(tagName);
+          if (tagName === 'a') el.click = clickSpy;
+          return el;
+        });
+
+      const exportDoc = exportAppDataAsJson(fixedNow);
+
+      expect(exportDoc.data[PREFERENCES_STORAGE_KEY]).toEqual({ theme: 'dark' });
+      expect(clickSpy).toHaveBeenCalled();
+
+      createElementSpy.mockRestore();
+    });
+
+    it('handles an empty store gracefully, still triggering a download of an empty document', () => {
+      const clickSpy = jest.fn();
+      const originalCreateElement = document.createElement.bind(document);
+      const createElementSpy = jest
+        .spyOn(document, 'createElement')
+        .mockImplementation((tagName: string) => {
+          const el = originalCreateElement(tagName);
+          if (tagName === 'a') el.click = clickSpy;
+          return el;
+        });
+
+      const exportDoc = exportAppDataAsJson(fixedNow);
+
+      expect(exportDoc.data).toEqual({});
+      expect(clickSpy).toHaveBeenCalled();
+
+      createElementSpy.mockRestore();
+    });
+
+    it('uses the current time and still downloads when no clock is injected', () => {
+      const clickSpy = jest.fn();
+      const originalCreateElement = document.createElement.bind(document);
+      const createElementSpy = jest
+        .spyOn(document, 'createElement')
+        .mockImplementation((tagName: string) => {
+          const el = originalCreateElement(tagName);
+          if (tagName === 'a') el.click = clickSpy;
+          return el;
+        });
+
+      const before = Date.now();
+      const exportDoc = exportAppDataAsJson();
+      const after = Date.now();
+
+      const exportedAtMs = new Date(exportDoc.exportedAt).getTime();
+      expect(exportedAtMs).toBeGreaterThanOrEqual(before);
+      expect(exportedAtMs).toBeLessThanOrEqual(after);
+      expect(clickSpy).toHaveBeenCalled();
+
+      createElementSpy.mockRestore();
+    });
+  });
+});

--- a/src/lib/dataExport.ts
+++ b/src/lib/dataExport.ts
@@ -1,0 +1,155 @@
+/**
+ * @file dataExport.ts
+ *
+ * Builds and downloads a JSON export of all namespaced TalentTrust app data
+ * currently persisted in the browser, so users can back it up or move it to
+ * another browser/device.
+ *
+ * Design principles:
+ * - **Reads via the safe storage wrapper** (`src/lib/safeStorage.ts`) — never
+ *   touches `window.localStorage` directly — so the export benefits from the
+ *   same SSR guards and defensive error handling as every other read in the
+ *   app.
+ * - **Scoped to known app-data keys only.** Only the keys the app itself
+ *   writes (`repository.ts`'s `talenttrust_app_data` and `preferences.tsx`'s
+ *   `talenttrust-user-preferences`) are included. Unrelated keys that may
+ *   exist in the same origin's storage (e.g. `loginThrottle.ts`'s transient,
+ *   non-user-facing security counters, or anything written by a third party
+ *   script) are never read or exported.
+ * - **Never throws.** A missing key is simply omitted; a corrupt (non-JSON)
+ *   stored value for a known key is skipped and reported via the central
+ *   error reporter rather than aborting the whole export.
+ */
+
+import { getItem } from './safeStorage';
+import { STORAGE_KEY as APP_DATA_STORAGE_KEY } from './repository';
+import { STORAGE_KEY as PREFERENCES_STORAGE_KEY } from './preferences';
+import { reportError } from './errorReporter';
+
+/** Bumped whenever the shape of {@link AppDataExport} changes in a
+ * backwards-incompatible way, so a future import feature can branch on it. */
+export const EXPORT_FORMAT_VERSION = 1;
+
+/**
+ * Every namespaced localStorage key considered part of the user's
+ * exportable app data, sourced directly from the modules that own them so
+ * this list can never drift out of sync with the actual storage keys in use.
+ */
+export const EXPORTABLE_KEYS: readonly string[] = [
+  APP_DATA_STORAGE_KEY,
+  PREFERENCES_STORAGE_KEY,
+];
+
+/** Shape of the JSON document produced by {@link buildAppDataExport}. */
+export interface AppDataExport {
+  version: number;
+  exportedAt: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * Reads every {@link EXPORTABLE_KEYS} entry through the safe storage
+ * wrapper, parses each stored JSON value, and assembles a single exportable
+ * document.
+ *
+ * - A key with no stored value is omitted from `data` entirely.
+ * - A key whose stored value cannot be parsed as JSON is skipped (and the
+ *   failure reported via `reportError`) rather than aborting the export.
+ * - When nothing is persisted yet, `data` is an empty object — callers get a
+ *   valid, well-formed (if empty) document rather than an error.
+ *
+ * @param now - Injectable clock, primarily for deterministic tests.
+ * @returns The assembled export document.
+ *
+ * @example
+ * ```ts
+ * const exportDoc = buildAppDataExport();
+ * // → { version: 1, exportedAt: '2026-...', data: { talenttrust_app_data: {...} } }
+ * ```
+ */
+export function buildAppDataExport(now: () => Date = () => new Date()): AppDataExport {
+  const data: Record<string, unknown> = {};
+
+  for (const key of EXPORTABLE_KEYS) {
+    const raw = getItem(key);
+    if (raw === null) continue;
+
+    try {
+      data[key] = JSON.parse(raw);
+    } catch (err) {
+      reportError(err, `[dataExport] Skipping corrupt value for key "${key}".`, 'warn', {
+        key,
+      });
+    }
+  }
+
+  return {
+    version: EXPORT_FORMAT_VERSION,
+    exportedAt: now().toISOString(),
+    data,
+  };
+}
+
+/**
+ * Serialises an {@link AppDataExport} document to a pretty-printed JSON
+ * string suitable for writing to a file.
+ */
+export function serializeAppDataExport(exportDoc: AppDataExport): string {
+  return JSON.stringify(exportDoc, null, 2);
+}
+
+/**
+ * Derives a timestamped, filesystem-safe filename for an export document,
+ * e.g. `talenttrust-data-export-2026-07-23T10-15-00-000Z.json`.
+ */
+export function buildExportFilename(exportDoc: AppDataExport): string {
+  const safeTimestamp = exportDoc.exportedAt.replace(/[:.]/g, '-');
+  return `talenttrust-data-export-${safeTimestamp}.json`;
+}
+
+/**
+ * Triggers a browser "Save File" download of the given text content.
+ *
+ * No-op outside a browser context (SSR / non-DOM test environments) since
+ * there is no document to attach a download link to.
+ *
+ * @param filename - The suggested filename for the downloaded file.
+ * @param content - The file's text content.
+ * @param mimeType - The MIME type used for the generated `Blob`.
+ */
+export function downloadTextFile(
+  filename: string,
+  content: string,
+  mimeType: string = 'application/json',
+): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+
+  try {
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+/**
+ * Convenience helper that builds, serialises, and downloads the full app
+ * data export as a timestamped JSON file in one call. This is what the
+ * Settings "Export data" control invokes.
+ *
+ * @param now - Injectable clock, primarily for deterministic tests.
+ * @returns The export document that was downloaded, so callers (e.g. UI code)
+ *   can inspect it or surface a summary without re-reading storage.
+ */
+export function exportAppDataAsJson(now: () => Date = () => new Date()): AppDataExport {
+  const exportDoc = buildAppDataExport(now);
+  downloadTextFile(buildExportFilename(exportDoc), serializeAppDataExport(exportDoc));
+  return exportDoc;
+}

--- a/src/lib/preferences.tsx
+++ b/src/lib/preferences.tsx
@@ -109,7 +109,10 @@ interface PreferencesContextType {
 
 const PreferencesContext = createContext<PreferencesContextType | undefined>(undefined);
 
-const STORAGE_KEY = 'talenttrust-user-preferences';
+/** localStorage key that houses persisted user preferences. Exported so
+ * other modules (e.g. the data export helper) can reference it without
+ * duplicating the literal string. */
+export const STORAGE_KEY = 'talenttrust-user-preferences';
 
 /**
  * Sanitize an untrusted, already-JSON-parsed value into a valid


### PR DESCRIPTION
## Description
App data lives only in `localStorage` with no export path, so users can't back it up or move browsers. This adds an accessible Export data as JSON control to Settings → Data.

- `src/lib/dataExport.ts`: reads the app's namespaced localStorage keys (`talenttrust_app_data`, `talenttrust-user-preferences`) via the `safeStorage` wrapper, skips unrelated keys (e.g. login throttle counters), handles an empty store gracefully (empty data document), and skips/reports corrupt per-key values without aborting the export. Triggers a browser download of a timestamped JSON file.
- `src/lib/preferences.tsx`: exports the existing `STORAGE_KEY` constant so `dataExport.ts` can reference it instead of duplicating the literal.
- `src/components/settings/SettingsPanel.tsx`: new "Data" section with the export button and an `aria-live` status message for success/failure.
- Tests: `dataExport.test.ts` + `dataExport.ssr.test.ts` (100% coverage on the new module), plus `SettingsPanel.test.tsx` coverage for the new control.
- `docs/persistence.md`: documents the export helper and its scope.

Closes #489 

## Type of Change
- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist
- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage
- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
- [x] If this PR adds or modifies UI components, accessibility tests were written using jest-axe

### What was tested?
- `dataExport.test.ts`: empty store → empty document; all namespaced keys present → all included; a key with nothing stored is omitted; a corrupt value for one key is skipped and reported via `errorReporter` while sibling keys still export; an all-corrupt store still yields a valid document; filename/JSON serialization; the full download flow (`Blob`/`URL.createObjectURL`/anchor click/`revokeObjectURL`).
- `dataExport.ssr.test.ts`: SSR-context checks (`@jest-environment node`) confirming the helper never throws and yields an empty document with no `window`/`document`.
- `SettingsPanel.test.tsx`: renders an accessible, named export button; clicking it invokes the export helper; success/error status messaging; regression coverage for the pre-existing keyboard focus-trap.
- Coverage: `dataExport.ts` 100% stmts/branch/funcs/lines. `SettingsPanel.tsx` 95.65% stmts, 91.17% branch, 100% funcs/lines (two remaining uncovered branches are pre-existing focus-trap guards unrelated to this change).
- Full suite: 1241/1241 tests passing across 74 suites; `npm run lint` and `npm run build` both clean.

---

## Accessibility & Security Notes

### Accessibility
The new export button uses standard focus-visible styling consistent with the rest of the settings drawer, and the status message uses `role="status"` / `aria-live="polite"` so success/failure is announced to screen readers. `SettingsPanel.test.tsx`'s existing jest-axe audit (`passes accessibility audit with jest-axe when open`) covers the panel including this new section.

### Security
No changes to authentication, authorization, wallet logic, or API calls. The export only reads the app's own two name spaced `localStorage` keys via the existing `safeStorage` wrapper — it explicitly excludes unrelated keys such as `loginThrottle.ts`'s security counters. No new user-supplied input is accepted; the only new input surface is a button click.