### PR TITLE
a11y(nav): mark active nav item with aria-current

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,12 +15,32 @@ const NAV_ROUTES = [
 ] as const;
 
 /**
+ * Returns true when `pathname` matches `href` exactly or is a nested
+ * sub-route of it (e.g. `/contracts/abc` is nested under `/contracts`).
+ *
+ * The root `/` segment is intentionally excluded from prefix matching to
+ * avoid it matching every route.
+ *
+ * @internal
+ */
+export function isNavRouteActive(pathname: string, href: string): boolean {
+  if (pathname === href) return true;
+  // Prevent the root path from matching everything via prefix check.
+  if (href === '/') return false;
+  // Match nested routes: pathname must start with href followed by '/'.
+  return pathname.startsWith(href + '/');
+}
+
+/**
  * Navbar — accessible primary navigation for the TalentTrust application.
  *
  * Renders persistent links to /contracts, /milestones, and /reputation.
  * The active route is determined via `usePathname` and announced to
- * assistive technology through `aria-current="page"`. Inactive routes
- * are styled with subdued foreground color to reduce visual noise.
+ * assistive technology through `aria-current="page"`. Both exact matches
+ * and nested sub-routes (e.g. `/contracts/abc`) are treated as active so
+ * the correct nav item is highlighted regardless of nesting depth.
+ * Inactive routes are styled with subdued foreground color to reduce
+ * visual noise.
  *
  * @remarks
  * - This component is marked `'use client'` because it consumes
@@ -45,7 +65,7 @@ export default function Navbar(): React.JSX.Element {
     <nav aria-label="Primary">
       <ul className="flex flex-wrap items-center gap-1 sm:gap-2">
         {NAV_ROUTES.map(({ href, label }) => {
-          const isActive = pathname === href;
+          const isActive = isNavRouteActive(pathname, href);
 
           return (
             <li key={href}>

--- a/src/components/__tests__/Navbar.test.tsx
+++ b/src/components/__tests__/Navbar.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
-import Navbar from '../Navbar';
+import Navbar, { isNavRouteActive } from '../Navbar';
 
 expect.extend(toHaveNoViolations);
 
@@ -12,6 +12,54 @@ jest.mock('next/navigation', () => ({
   usePathname: () => mockUsePathname(),
 }));
 
+// ---------------------------------------------------------------------------
+// Unit tests for the pure isNavRouteActive helper
+// ---------------------------------------------------------------------------
+describe('isNavRouteActive', () => {
+  it('returns true for an exact match', () => {
+    expect(isNavRouteActive('/contracts', '/contracts')).toBe(true);
+    expect(isNavRouteActive('/milestones', '/milestones')).toBe(true);
+    expect(isNavRouteActive('/reputation', '/reputation')).toBe(true);
+  });
+
+  it('returns true for a nested sub-route (one level deep)', () => {
+    expect(isNavRouteActive('/contracts/abc-123', '/contracts')).toBe(true);
+    expect(isNavRouteActive('/milestones/42', '/milestones')).toBe(true);
+    expect(isNavRouteActive('/reputation/overview', '/reputation')).toBe(true);
+  });
+
+  it('returns true for a nested sub-route (multiple levels deep)', () => {
+    expect(isNavRouteActive('/contracts/abc/milestones', '/contracts')).toBe(true);
+    expect(isNavRouteActive('/contracts/abc/milestones/1', '/contracts')).toBe(true);
+  });
+
+  it('returns false for an unrelated route', () => {
+    expect(isNavRouteActive('/milestones', '/contracts')).toBe(false);
+    expect(isNavRouteActive('/reputation', '/contracts')).toBe(false);
+  });
+
+  it('returns false when pathname only shares a prefix but no slash separator', () => {
+    // "/contractsExtra" should NOT match "/contracts"
+    expect(isNavRouteActive('/contractsExtra', '/contracts')).toBe(false);
+    expect(isNavRouteActive('/milestonesX', '/milestones')).toBe(false);
+  });
+
+  it('returns false when href is "/" to prevent matching every route', () => {
+    expect(isNavRouteActive('/contracts', '/')).toBe(false);
+    expect(isNavRouteActive('/milestones', '/')).toBe(false);
+    expect(isNavRouteActive('/', '/')).toBe(true); // exact match still works
+  });
+
+  it('returns false for an unknown/unrelated route', () => {
+    expect(isNavRouteActive('/settings', '/contracts')).toBe(false);
+    expect(isNavRouteActive('/unknown', '/milestones')).toBe(false);
+    expect(isNavRouteActive('/404', '/reputation')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests for the Navbar component
+// ---------------------------------------------------------------------------
 describe('Navbar', () => {
   beforeEach(() => {
     mockUsePathname.mockReturnValue('/');
@@ -29,23 +77,55 @@ describe('Navbar', () => {
     expect(screen.getByRole('link', { name: 'Reputation' })).toHaveAttribute('href', '/reputation');
   });
 
-  it('marks the current route with aria-current="page"', () => {
+  it('marks the current route with aria-current="page" (exact match)', () => {
     mockUsePathname.mockReturnValue('/contracts');
     render(<Navbar />);
 
-    const contractsLink = screen.getByRole('link', { name: 'Contracts' });
-    expect(contractsLink).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Contracts' })).toHaveAttribute('aria-current', 'page');
   });
 
   it('does not mark inactive routes with aria-current', () => {
     mockUsePathname.mockReturnValue('/contracts');
     render(<Navbar />);
 
-    const milestonesLink = screen.getByRole('link', { name: 'Milestones' });
-    const reputationLink = screen.getByRole('link', { name: 'Reputation' });
+    expect(screen.getByRole('link', { name: 'Milestones' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: 'Reputation' })).not.toHaveAttribute('aria-current');
+  });
 
-    expect(milestonesLink).not.toHaveAttribute('aria-current');
-    expect(reputationLink).not.toHaveAttribute('aria-current');
+  it('marks the parent nav item with aria-current="page" on a nested route', () => {
+    mockUsePathname.mockReturnValue('/contracts/abc-123');
+    render(<Navbar />);
+
+    expect(screen.getByRole('link', { name: 'Contracts' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Milestones' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: 'Reputation' })).not.toHaveAttribute('aria-current');
+  });
+
+  it('marks the parent nav item with aria-current="page" on a deeply nested route', () => {
+    mockUsePathname.mockReturnValue('/contracts/abc-123/milestones');
+    render(<Navbar />);
+
+    expect(screen.getByRole('link', { name: 'Contracts' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Milestones' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: 'Reputation' })).not.toHaveAttribute('aria-current');
+  });
+
+  it('marks no nav item with aria-current on an unknown route', () => {
+    mockUsePathname.mockReturnValue('/unknown-page');
+    render(<Navbar />);
+
+    expect(screen.getByRole('link', { name: 'Contracts' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: 'Milestones' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: 'Reputation' })).not.toHaveAttribute('aria-current');
+  });
+
+  it('marks no nav item with aria-current on the home "/" route', () => {
+    mockUsePathname.mockReturnValue('/');
+    render(<Navbar />);
+
+    expect(screen.getByRole('link', { name: 'Contracts' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: 'Milestones' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: 'Reputation' })).not.toHaveAttribute('aria-current');
   });
 
   it('updates active highlight when route changes', () => {
@@ -56,6 +136,23 @@ describe('Navbar', () => {
 
     expect(screen.getByRole('link', { name: 'Milestones' })).toHaveAttribute('aria-current', 'page');
     expect(screen.getByRole('link', { name: 'Contracts' })).not.toHaveAttribute('aria-current');
+  });
+
+  it('updates active highlight from nested route to a different section', () => {
+    mockUsePathname.mockReturnValue('/contracts/abc');
+    const { rerender } = render(<Navbar />);
+    expect(screen.getByRole('link', { name: 'Contracts' })).toHaveAttribute('aria-current', 'page');
+
+    mockUsePathname.mockReturnValue('/milestones');
+    rerender(<Navbar />);
+
+    expect(screen.getByRole('link', { name: 'Milestones' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Contracts' })).not.toHaveAttribute('aria-current');
+  });
+
+  it('renders inside a <nav> landmark with accessible label "Primary"', () => {
+    render(<Navbar />);
+    expect(screen.getByRole('navigation', { name: 'Primary' })).toBeInTheDocument();
   });
 
   it('maintains logical focus order (keyboard tab navigation)', () => {
@@ -86,8 +183,18 @@ describe('Navbar', () => {
     });
   });
 
+  it('applies active visual styling to the current nav item', () => {
+    mockUsePathname.mockReturnValue('/milestones');
+    render(<Navbar />);
+
+    const activeLink = screen.getByRole('link', { name: 'Milestones' });
+    const inactiveLink = screen.getByRole('link', { name: 'Contracts' });
+
+    expect(activeLink.className).toMatch(/text-\[var\(--primary\)\]/);
+    expect(inactiveLink.className).toMatch(/text-\[var\(--muted-foreground\)\]/);
+  });
+
   it('renders without horizontal overflow on 320px viewport (mobile)', () => {
-    // Simulate mobile viewport
     Object.defineProperty(window, 'innerWidth', {
       writable: true,
       configurable: true,
@@ -102,10 +209,24 @@ describe('Navbar', () => {
     expect(list?.className).toMatch(/flex-wrap/);
   });
 
-  it('passes jest-axe accessibility audit', async () => {
+  it('passes jest-axe accessibility audit on home route', async () => {
+    mockUsePathname.mockReturnValue('/');
     const { container } = render(<Navbar />);
     const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 
+  it('passes jest-axe accessibility audit on an active route', async () => {
+    mockUsePathname.mockReturnValue('/contracts');
+    const { container } = render(<Navbar />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('passes jest-axe accessibility audit on a nested route', async () => {
+    mockUsePathname.mockReturnValue('/contracts/abc-123');
+    const { container } = render(<Navbar />);
+    const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 });


### PR DESCRIPTION
## Summary

Sets `aria-current="page"` on the header nav link matching the current route, so screen-reader users can always identify where they are in the app.

### Changes

**`src/components/Navbar.tsx`**
- Extracted and exported a pure `isNavRouteActive(pathname, href)` helper that returns `true` for both exact matches and nested sub-routes (e.g. `/contracts/abc` correctly highlights the Contracts link).
- Replaced the previous exact-only `pathname === href` check with the new helper.
- No visual change — active styling was already in place.

**`src/components/__tests__/Navbar.test.tsx`**
- Added a dedicated `isNavRouteActive` unit-test suite (7 cases) covering exact match, one-level nested, multi-level nested, unrelated route, prefix-but-no-slash, root-`/` exclusion, and unknown routes.
- Extended the Navbar integration suite with edge-case tests: nested route, deeply nested route, unknown route, home route, cross-section route transition, active visual styling, and three separate jest-axe audits (home, active, nested).
- Total: **24 tests — 100 % branch / statement / function / line coverage** on `Navbar.tsx`.

### Test output

```
PASS src/components/__tests__/Navbar.test.tsx
  isNavRouteActive
    ✓ returns true for an exact match
    ✓ returns true for a nested sub-route (one level deep)
    ✓ returns true for a nested sub-route (multiple levels deep)
    ✓ returns false for an unrelated route
    ✓ returns false when pathname only shares a prefix but no slash separator
    ✓ returns false when href is "/" to prevent matching every route
    ✓ returns false for an unknown/unrelated route
  Navbar
    ✓ renders navigation links to /contracts, /milestones, and /reputation
    ✓ marks the current route with aria-current="page" (exact match)
    ✓ does not mark inactive routes with aria-current
    ✓ marks the parent nav item with aria-current="page" on a nested route
    ✓ marks the parent nav item with aria-current="page" on a deeply nested route
    ✓ marks no nav item with aria-current on an unknown route
    ✓ marks no nav item with aria-current on the home "/" route
    ✓ updates active highlight when route changes
    ✓ updates active highlight from nested route to a different section
    ✓ renders inside a <nav> landmark with accessible label "Primary"
    ✓ maintains logical focus order (keyboard tab navigation)
    ✓ applies visible focus rings to all interactive elements
    ✓ applies active visual styling to the current nav item
    ✓ renders without horizontal overflow on 320px viewport (mobile)
    ✓ passes jest-axe accessibility audit on home route
    ✓ passes jest-axe accessibility audit on an active route
    ✓ passes jest-axe accessibility audit on a nested route

Tests: 24 passed, 24 total

------------|---------|----------|---------|---------|
File        | % Stmts | % Branch | % Funcs | % Lines |
------------|---------|----------|---------|---------|
Navbar.tsx  |     100 |      100 |     100 |     100 |
------------|---------|----------|---------|---------|
```

### Pre-flight checklist

- [x] `npm run lint` — clean, no warnings
- [x] `npm test` — 24 / 24 passing, 100 % coverage
- [x] `npm run build` — pre-existing `@tailwindcss/oxide` native binding failure in this environment; confirmed identical failure on `main` before these changes — unrelated to this PR
- [x] 95 %+ coverage for impacted modules (100 % achieved)
- [x] Accessibility: `aria-current="page"` set correctly; three jest-axe audits pass with no violations

Closes #482