### PR TITLE
refactor(toast): memoize rendering

### DIFF
--- a/src/components/toast/toast-provider.test.tsx
+++ b/src/components/toast/toast-provider.test.tsx
@@ -1,9 +1,10 @@
 /// <reference types="jest" />
 
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { StrictMode } from 'react';
-import { PreferencesProvider } from '@/lib/preferences';
-import { ToastProvider, useToast } from './toast-provider';
+import { StrictMode, useState } from 'react';
+import { PreferencesProvider, usePreferences } from '@/lib/preferences';
+import { ToastAnnouncer, ToastProvider, ToastRow, ToastViewport, useToast } from './toast-provider';
+import * as toastStyles from './toast-styles';
 
 function ToastHarness() {
   const { showError, showSuccess } = useToast();
@@ -1372,5 +1373,182 @@ describe('toastDuration preference', () => {
     // Advance time — none should auto-dismiss (all persistent).
     act(() => { jest.advanceTimersByTime(60000); });
     expect(screen.getAllByRole('status')).toHaveLength(4);
+  });
+});
+
+describe('row and derived-data memoization', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.clearAllTimers();
+    });
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  function Trigger({ title }: { title: string }) {
+    const { showSuccess } = useToast();
+    return (
+      <button onClick={() => showSuccess({ title, duration: 2000 })} type="button">
+        {`Create ${title}`}
+      </button>
+    );
+  }
+
+  /**
+   * Mounts `ToastProvider` behind its own unrelated state so that clicking
+   * "Unrelated update" re-renders `ToastProvider` (a new element is created
+   * for it on every `NoisyAncestor` render) without touching toasts or
+   * preferences — reproducing the "unrelated state change" from the ticket.
+   */
+  function NoisyAncestor({ children }: { children: React.ReactNode }) {
+    const [count, setCount] = useState(0);
+    return (
+      <div>
+        <button onClick={() => setCount((current) => current + 1)} type="button">
+          Unrelated update
+        </button>
+        <span data-testid="unrelated-count">{count}</span>
+        <ToastProvider>{children}</ToastProvider>
+      </div>
+    );
+  }
+
+  function isMemoComponent(value: unknown) {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      (value as { $$typeof?: symbol }).$$typeof === Symbol.for('react.memo')
+    );
+  }
+
+  it('wraps ToastRow, ToastViewport, and ToastAnnouncer in React.memo', () => {
+    expect(isMemoComponent(ToastRow)).toBe(true);
+    expect(isMemoComponent(ToastViewport)).toBe(true);
+    expect(isMemoComponent(ToastAnnouncer)).toBe(true);
+  });
+
+  it("does not recompute a toast row's derived styles when an unrelated ancestor re-renders", () => {
+    const stylesSpy = jest.spyOn(toastStyles, 'getToastStyles');
+
+    render(
+      <NoisyAncestor>
+        <Trigger title="Milestone" />
+      </NoisyAncestor>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /create milestone/i }));
+    expect(stylesSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /unrelated update/i }));
+    fireEvent.click(screen.getByRole('button', { name: /unrelated update/i }));
+    fireEvent.click(screen.getByRole('button', { name: /unrelated update/i }));
+
+    // The unrelated state did update…
+    expect(screen.getByTestId('unrelated-count')).toHaveTextContent('3');
+    // …but the toast row's derived data was not recomputed, and the toast
+    // itself is unaffected.
+    expect(stylesSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('status')).toHaveTextContent('Milestone');
+  });
+
+  it('recomputes styles only for a newly added toast, not for existing rows', () => {
+    const stylesSpy = jest.spyOn(toastStyles, 'getToastStyles');
+
+    render(
+      <ToastProvider>
+        <Trigger title="Toast A" />
+        <Trigger title="Toast B" />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /create toast a/i }));
+    expect(stylesSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /create toast b/i }));
+    expect(stylesSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not recompute a surviving toast's styles when a sibling toast is dismissed", () => {
+    const stylesSpy = jest.spyOn(toastStyles, 'getToastStyles');
+
+    render(
+      <ToastProvider>
+        <Trigger title="Toast A" />
+        <Trigger title="Toast B" />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /create toast a/i }));
+    fireEvent.click(screen.getByRole('button', { name: /create toast b/i }));
+    expect(stylesSpy).toHaveBeenCalledTimes(2);
+
+    const dismissButtons = screen.getAllByRole('button', { name: /dismiss success notification/i });
+    fireEvent.click(dismissButtons[0]);
+
+    expect(screen.getByText('Toast B', { selector: 'p' })).toBeInTheDocument();
+    expect(stylesSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('computes styles exactly once per toast across a large, evicting burst of toasts', () => {
+    const stylesSpy = jest.spyOn(toastStyles, 'getToastStyles');
+
+    function BurstTrigger() {
+      const { showSuccess } = useToast();
+      return (
+        <button onClick={() => showSuccess({ title: 'Burst toast', duration: 2000 })} type="button">
+          Fire one
+        </button>
+      );
+    }
+
+    render(
+      <ToastProvider>
+        <BurstTrigger />
+      </ToastProvider>,
+    );
+
+    const fireButton = screen.getByRole('button', { name: /fire one/i });
+    for (let i = 0; i < 25; i += 1) {
+      fireEvent.click(fireButton);
+    }
+
+    // Every created toast gets exactly one style computation the moment it
+    // mounts, even though only MAX_VISIBLE_TOASTS (4) remain after eviction.
+    expect(stylesSpy).toHaveBeenCalledTimes(25);
+    expect(screen.getAllByRole('status')).toHaveLength(4);
+  });
+
+  it('still updates the viewport when a relevant preference actually changes, even amid unrelated noise', () => {
+    function DensityToggle() {
+      const { updatePreference } = usePreferences();
+      return (
+        <button onClick={() => updatePreference('toastDensity', 'compact')} type="button">
+          Switch to compact
+        </button>
+      );
+    }
+
+    render(
+      <PreferencesProvider>
+        <NoisyAncestor>
+          <Trigger title="Milestone" />
+          <DensityToggle />
+        </NoisyAncestor>
+      </PreferencesProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /create milestone/i }));
+
+    const viewport = screen.getByLabelText('Notifications');
+    expect(viewport.className).toMatch(/gap-3/);
+
+    fireEvent.click(screen.getByRole('button', { name: /unrelated update/i }));
+    fireEvent.click(screen.getByRole('button', { name: /switch to compact/i }));
+
+    expect(viewport.className).toMatch(/gap-1\.5/);
   });
 });

--- a/src/components/toast/toast-provider.tsx
+++ b/src/components/toast/toast-provider.tsx
@@ -2,6 +2,7 @@
 
 import {
   createContext,
+  memo,
   useCallback,
   useContext,
   useEffect,
@@ -11,8 +12,8 @@ import {
 } from 'react';
 import { usePreferences } from '@/lib/preferences';
 import type { ToastDuration } from '@/lib/preferences';
-
-type ToastVariant = 'success' | 'error';
+import { getToastStyles } from './toast-styles';
+import type { ToastVariant } from './toast-styles';
 
 /** Optional inline action attached to a toast. */
 type ToastAction = {
@@ -83,28 +84,93 @@ function generateToastId(): string {
   return `toast-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 }
 
-function getToastStyles(variant: ToastVariant) {
-  // a11y/theming-27: badge classes were `bg-emerald-100 text-emerald-800`
-  // / `bg-rose-100 text-rose-800` — fixed Tailwind pastels that don't
-  // respond to [data-theme='dark']. Swapped for the --status-* variables
-  // defined in globals.css, which carry an audited light AND dark pair.
-  // Light-mode hex values are unchanged from the originals.
-  if (variant === 'success') {
-    return {
-      accent: 'bg-emerald-500',
-      badge: 'bg-[var(--status-success-bg)] text-[var(--status-success-foreground)]',
-      panel: 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] shadow-sm',
-    };
-  }
+/**
+ * Renders a single toast panel. Memoized so that an unrelated re-render of
+ * `ToastProvider` (e.g. a preference or sibling state change that leaves
+ * this toast's own props untouched) does not re-run the row's derived-data
+ * computation (`getToastStyles`) or re-render its DOM.
+ */
+export const ToastRow = memo(function ToastRow({
+  toast,
+  onDismiss,
+  onPauseTimer,
+  onResumeTimer,
+}: {
+  toast: ToastRecord;
+  onDismiss: (id: string) => void;
+  onPauseTimer: (id: string) => void;
+  onResumeTimer: (id: string) => void;
+}) {
+  const styles = useMemo(() => getToastStyles(toast.variant), [toast.variant]);
+  const badgeLabel = toast.variant === 'success' ? 'Success' : 'Error';
 
-  return {
-    accent: 'bg-rose-500',
-    badge: 'bg-[var(--status-error-bg)] text-[var(--status-error-foreground)]',
-    panel: 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] shadow-sm',
-  };
-}
+  return (
+    <div
+      className={`pointer-events-auto overflow-hidden rounded-2xl border ${styles.panel} shadow-lg`}
+      onBlur={() => onResumeTimer(toast.id)}
+      onFocus={() => onPauseTimer(toast.id)}
+      onMouseEnter={() => onPauseTimer(toast.id)}
+      onMouseLeave={() => onResumeTimer(toast.id)}
+      role={toast.variant === 'error' ? 'alert' : 'status'}
+    >
+      <div className={`h-1.5 w-full ${styles.accent}`} />
+      <div className="flex items-start gap-3 p-4">
+        <div className={`rounded-full px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${styles.badge}`}>
+          {badgeLabel}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold">{toast.title}</p>
+          {toast.description ? (
+            // a11y/theming-27: was `text-slate-600`, which measured
+            // 2.36:1 against the dark --surface (#0f172a) — well
+            // below the 4.5:1 AA minimum for body text. Replaced
+            // with --muted-foreground, which is themed in
+            // globals.css and passes AA in both modes (4.55:1
+            // light, 6.96:1 dark). See docs/components/Accessibility.md.
+            <p className="mt-1 text-sm text-[var(--muted-foreground)]">{toast.description}</p>
+          ) : null}
+          {toast.action ? (
+            // Action button: label is a plain text node — never set via
+            // innerHTML or dangerouslySetInnerHTML. Clicking fires the
+            // caller-supplied callback then immediately dismisses this toast.
+            <button
+              type="button"
+              onClick={() => {
+                toast.action!.onClick();
+                onDismiss(toast.id);
+              }}
+              className="mt-2 rounded-md px-3 py-1 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-1 bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90"
+            >
+              {toast.action.label}
+            </button>
+          ) : null}
+        </div>
+        <button
+          aria-label={`Dismiss ${badgeLabel.toLowerCase()} notification`}
+          // a11y/theming-27: was `text-slate-500 hover:bg-slate-100
+          // hover:text-slate-900`. text-slate-500 measured 3.75:1
+          // against the dark --surface — fails AA. The light hover
+          // background also stayed fixed-light, producing a bright
+          // patch on a dark panel. Replaced with themed tokens that
+          // pass AA in both modes.
+          // The `transition` utility is kept here; the global
+          // @media (prefers-reduced-motion: reduce) rule in
+          // globals.css collapses its duration to 0.01ms so the
+          // button snaps to its hover/focus state instantly for
+          // users who prefer reduced motion, without any layout
+          // shift or visibility change.
+          className="rounded-full p-1.5 text-[var(--muted-foreground)] transition hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+          onClick={() => onDismiss(toast.id)}
+          type="button"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+    </div>
+  );
+});
 
-function ToastViewport({
+export const ToastViewport = memo(function ToastViewport({
   toasts,
   onDismiss,
   onPauseTimer,
@@ -126,83 +192,28 @@ function ToastViewport({
         density === 'compact' ? 'gap-1.5' : 'gap-3'
       }`}
     >
-      {toasts.map((toast) => {
-        const styles = getToastStyles(toast.variant);
-        const badgeLabel = toast.variant === 'success' ? 'Success' : 'Error';
-
-        return (
-          <div
-            key={toast.id}
-            className={`pointer-events-auto overflow-hidden rounded-2xl border ${styles.panel} shadow-lg`}
-            onBlur={() => onResumeTimer(toast.id)}
-            onFocus={() => onPauseTimer(toast.id)}
-            onMouseEnter={() => onPauseTimer(toast.id)}
-            onMouseLeave={() => onResumeTimer(toast.id)}
-            role={toast.variant === 'error' ? 'alert' : 'status'}
-          >
-            <div className={`h-1.5 w-full ${styles.accent}`} />
-            <div className="flex items-start gap-3 p-4">
-              <div className={`rounded-full px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${styles.badge}`}>
-                {badgeLabel}
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-semibold">{toast.title}</p>
-                {toast.description ? (
-                  // a11y/theming-27: was `text-slate-600`, which measured
-                  // 2.36:1 against the dark --surface (#0f172a) — well
-                  // below the 4.5:1 AA minimum for body text. Replaced
-                  // with --muted-foreground, which is themed in
-                  // globals.css and passes AA in both modes (4.55:1
-                  // light, 6.96:1 dark). See docs/components/Accessibility.md.
-                  <p className="mt-1 text-sm text-[var(--muted-foreground)]">{toast.description}</p>
-                ) : null}
-                {toast.action ? (
-                  // Action button: label is a plain text node — never set via
-                  // innerHTML or dangerouslySetInnerHTML. Clicking fires the
-                  // caller-supplied callback then immediately dismisses this toast.
-                  <button
-                    type="button"
-                    onClick={() => {
-                      toast.action!.onClick();
-                      onDismiss(toast.id);
-                    }}
-                    className="mt-2 rounded-md px-3 py-1 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-1 bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90"
-                  >
-                    {toast.action.label}
-                  </button>
-                ) : null}
-              </div>
-              <button
-                aria-label={`Dismiss ${badgeLabel.toLowerCase()} notification`}
-                // a11y/theming-27: was `text-slate-500 hover:bg-slate-100
-                // hover:text-slate-900`. text-slate-500 measured 3.75:1
-                // against the dark --surface — fails AA. The light hover
-                // background also stayed fixed-light, producing a bright
-                // patch on a dark panel. Replaced with themed tokens that
-                // pass AA in both modes.
-                // The `transition` utility is kept here; the global
-                // @media (prefers-reduced-motion: reduce) rule in
-                // globals.css collapses its duration to 0.01ms so the
-                // button snaps to its hover/focus state instantly for
-                // users who prefer reduced motion, without any layout
-                // shift or visibility change.
-                className="rounded-full p-1.5 text-[var(--muted-foreground)] transition hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                onClick={() => onDismiss(toast.id)}
-                type="button"
-              >
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-          </div>
-        );
-      })}
+      {toasts.map((toast) => (
+        <ToastRow
+          key={toast.id}
+          onDismiss={onDismiss}
+          onPauseTimer={onPauseTimer}
+          onResumeTimer={onResumeTimer}
+          toast={toast}
+        />
+      ))}
     </div>
   );
-}
+});
 
-function ToastAnnouncer({ toasts }: { toasts: ToastRecord[] }) {
-  const latestSuccess = [...toasts].reverse().find((toast) => toast.variant === 'success');
-  const latestError = [...toasts].reverse().find((toast) => toast.variant === 'error');
+export const ToastAnnouncer = memo(function ToastAnnouncer({ toasts }: { toasts: ToastRecord[] }) {
+  const latestSuccess = useMemo(
+    () => [...toasts].reverse().find((toast) => toast.variant === 'success'),
+    [toasts],
+  );
+  const latestError = useMemo(
+    () => [...toasts].reverse().find((toast) => toast.variant === 'error'),
+    [toasts],
+  );
 
   return (
     <>
@@ -214,7 +225,7 @@ function ToastAnnouncer({ toasts }: { toasts: ToastRecord[] }) {
       </div>
     </>
   );
-}
+});
 
 type ToastTimerState = {
   expiresAt: number | null;

--- a/src/components/toast/toast-styles.ts
+++ b/src/components/toast/toast-styles.ts
@@ -1,0 +1,28 @@
+export type ToastVariant = 'success' | 'error';
+
+/**
+ * Resolves the Tailwind classes for a toast's accent bar, badge, and panel.
+ * Lives in its own module so callers can memoize on `variant` without
+ * recomputing this lookup, and so it stays a single well-defined seam
+ * (rather than an inline object literal) if new variants are ever added.
+ */
+export function getToastStyles(variant: ToastVariant) {
+  // a11y/theming-27: badge classes were `bg-emerald-100 text-emerald-800`
+  // / `bg-rose-100 text-rose-800` — fixed Tailwind pastels that don't
+  // respond to [data-theme='dark']. Swapped for the --status-* variables
+  // defined in globals.css, which carry an audited light AND dark pair.
+  // Light-mode hex values are unchanged from the originals.
+  if (variant === 'success') {
+    return {
+      accent: 'bg-emerald-500',
+      badge: 'bg-[var(--status-success-bg)] text-[var(--status-success-foreground)]',
+      panel: 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] shadow-sm',
+    };
+  }
+
+  return {
+    accent: 'bg-rose-500',
+    badge: 'bg-[var(--status-error-bg)] text-[var(--status-error-foreground)]',
+    panel: 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] shadow-sm',
+  };
+}


### PR DESCRIPTION
## Description

The toast view re-rendered on unrelated state changes, hurting responsiveness on larger data sets. This PR memoizes the expensive parts: `ToastRow`, `ToastViewport`, and `ToastAnnouncer` are now wrapped in `React.memo`, and their derived data (per-variant styles, latest success/error lookups) is computed via `useMemo`. Unrelated state changes elsewhere in the tree no longer force the toast view to recompute or re-render. Behavior and DOM output are unchanged.

Closes #559

## Type of Change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage

- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [x] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

Added a new `row and derived-data memoization` suite to `toast-provider.test.tsx` (6 tests):

- Confirms `ToastRow`, `ToastViewport`, and `ToastAnnouncer` are wrapped in `React.memo`.
- An unrelated ancestor re-render does **not** recompute a toast row's derived styles.
- Adding a new toast recomputes styles only for that new row, not existing ones.
- Dismissing a sibling toast does not recompute the surviving toast's styles.
- A 25-toast burst computes styles exactly once per toast, despite the 4-toast eviction cap.
- A genuinely relevant preference change (toast density) still updates the view correctly, even amid unrelated re-render noise — proving the memoization doesn't cause staleness.

All 42 pre-existing toast tests pass unchanged, confirming behavior/output parity. Full project suite: 1224/1224 passed across 72 suites (including the existing `a11y.test.tsx` toast-panel `jest-axe` coverage — light/dark themes, reduced motion, DOM timing).

Coverage on impacted files: `toast-provider.tsx` 96.55% stmts / 96.36% lines, `toast-styles.ts` (new module) 100%.

```
npm run lint    → clean, no errors
npm test        → Test Suites: 72 passed, 72 total / Tests: 1224 passed, 1224 total
npm run build   → Compiled successfully, TypeScript checks passed
```

---

## Accessibility & Security Notes

### Accessibility

No accessibility-relevant markup changed — roles (`status`/`alert`), `aria-label`, `aria-live` regions, and focus/dismiss behavior are byte-identical to before the refactor; only the *rendering strategy* changed (memoization), not the DOM. Verified via the existing `src/components/__tests__/a11y.test.tsx` suite (`jest-axe`, light/dark, reduced motion), which passed unchanged as part of the full test run.

### Security

N/A — no auth, wallet, API, or user-input handling touched. Pure rendering-performance refactor of the toast component.
