### PR TITLE
feat(contracts): capture required dispute reason before raising a dispute

### DIFF
--- a/docs/components/ActionPanel.md
+++ b/docs/components/ActionPanel.md
@@ -32,7 +32,8 @@ The inline dispute form also re-checks the wallet connection at submit time befo
 - Visible focus rings use high-contrast Tailwind `focus-visible:outline` utilities and are not removed in any state.
 - Actions are rendered in contract workflow order: submit milestone, release funds, dispute, then summary when applicable.
 - Submit Milestone opens the shared confirmation dialog before invoking the callback, then shows a success toast once the action is confirmed.
-- Dispute opens an inline reason form. The submitted reason is validated using the shared `validateDisputeReason` utility from [disputeReason.ts](file:///c:/Users/USER/Desktop/Talenttrust-Frontend/src/lib/disputeReason.ts), which enforces `DISPUTE_REASON_MAX_LENGTH` (500 characters). The submitted reason is trimmed, must be non-empty, and is only passed to `onDispute` while a wallet address is still connected.
+- Dispute opens an inline reason form. The submitted reason is validated using the shared `validateDisputeReason` utility from [`src/lib/disputeReason.ts`](../../src/lib/disputeReason.ts), which enforces `DISPUTE_REASON_MAX_LENGTH` (500 characters). The submitted reason is trimmed, must be non-empty, and is only passed to `onDispute` while a wallet address is still connected.
+- **Consuming the reason:** `src/app/contracts/[id]/page.tsx`'s `handleDispute` receives this reason as its argument and includes it in the success toast description shown after the dispute is persisted. It's rendered through JSX (`{toast.description}`), so it's always plain text — never interpreted as HTML — no matter what the reason contains.
 - Unavailable actions stay visible as disabled buttons with an accessible reason. Use `disabledReasons` for states such as no wallet, missing permissions, pending API responses, or unmet milestone conditions.
 - Loading states disable all visible actions and describe that contract data is still loading.
 - Error states are announced through `role="alert"` without moving focus or changing the action order.
@@ -78,7 +79,7 @@ import ActionPanel from '@/components/ActionPanel';
 export default function ContractDetail({ contractData, isLoading, errorMessage }) {
   const handleSubmitMilestone = () => { /* ... */ };
   const handleReleaseFunds = () => { /* ... */ };
-  const handleDispute = () => { /* ... */ };
+  const handleDispute = (reason: string) => { /* ... */ };
   const handleViewSummary = () => { /* ... */ };
 
   return (

--- a/src/app/contracts/[id]/__tests__/page.test.tsx
+++ b/src/app/contracts/[id]/__tests__/page.test.tsx
@@ -440,6 +440,32 @@ describe('existing contract detail page behaviour', () => {
     );
     expect(screen.queryByRole('button', { name: /release funds to the contractor/i })).not.toBeInTheDocument();
     expect(await screen.findByText('Dispute opened')).toBeInTheDocument();
+    expect(
+      screen.getByText('The contract was marked as Disputed and the change was saved. Reason: Dispute reason'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a dispute reason containing markup as literal text, never as HTML', async () => {
+    const user = userEvent.setup();
+    const unsafeReason = '<script>window.__pwned = true</script>';
+
+    await renderPage();
+
+    await user.click(await screen.findByRole('button', { name: /open a dispute for this contract/i }));
+    const textarea = screen.getByRole('textbox', { name: /reason/i });
+    await user.type(textarea, unsafeReason);
+    await user.click(screen.getByRole('button', { name: /^confirm dispute$/i }));
+
+    const toastDescription = await screen.findByText((_, node) =>
+      node?.textContent === `The contract was marked as Disputed and the change was saved. Reason: ${unsafeReason}`,
+    );
+    // The literal string is present as text content...
+    expect(toastDescription).toBeInTheDocument();
+    // ...but was never parsed as markup: no <script> element was created for
+    // it anywhere on the page, and the global it would have set is absent.
+    const scriptTags = Array.from(document.querySelectorAll('script'));
+    expect(scriptTags.some((tag) => tag.textContent?.includes('__pwned'))).toBe(false);
+    expect((window as unknown as { __pwned?: boolean }).__pwned).toBeUndefined();
   });
 
   it('keeps destructive actions disabled when the wallet is disconnected', async () => {

--- a/src/app/contracts/[id]/page.tsx
+++ b/src/app/contracts/[id]/page.tsx
@@ -179,14 +179,24 @@ const ContractDetailPageContent = ({ id }: { id: string }) => {
 
   /**
    * Persists the confirmed dispute action as a disputed contract.
+   *
+   * `reason` is the trimmed, non-empty, length-capped string ActionPanel's
+   * inline dispute form already validates before calling `onDispute` — it is
+   * surfaced in the success toast description (rendered as plain text, never
+   * as HTML) so the person who opened the dispute can see it was recorded.
+   *
+   * @param reason - Why the dispute was opened, as entered in ActionPanel.
    */
-  const handleDispute = useCallback(() => {
-    persistContractStatus(
-      'Disputed',
-      'Dispute opened',
-      'The contract was marked as Disputed and the change was saved.',
-    );
-  }, [persistContractStatus]);
+  const handleDispute = useCallback(
+    (reason: string) => {
+      persistContractStatus(
+        'Disputed',
+        'Dispute opened',
+        `The contract was marked as Disputed and the change was saved. Reason: ${reason}`,
+      );
+    },
+    [persistContractStatus],
+  );
 
   const handleViewSummary = () => {
     // Replace with summary navigation.


### PR DESCRIPTION
Closes #356

---


Worth saying up front: ActionPanel already had almost all of this built — the inline reason textarea, validateDisputeReason (empty/whitespace/500-char cap), the label/aria-describedby/aria-invalid wiring, focus moving into the textarea on open and back to the Dispute button on cancel or submit, and onDispute already typed as (reason: string). ActionPanel.test.tsx already has dedicated tests for empty, whitespace-only, over-length, and valid-trimmed-reason submission, and docs/components/ActionPanel.md already described most of this in detail.

The actual gap was one level up: src/app/contracts/[id]/page.tsx's handleDispute was still declared as () => void, so the reason the user typed and ActionPanel validated was being silently thrown away the moment it reached the page — persistContractStatus never saw it, and the success toast never mentioned it. Fixed handleDispute to accept (reason: string) and include it in the toast description (plain JSX text, so it's never interpreted as HTML no matter what's in it).

Extended the existing dispute-flow test in page.test.tsx to assert the reason actually shows up in the toast, and added a dedicated test that submits a reason containing a <script> tag and confirms it only ever appears as literal text — no script element gets created, no global gets set.

Also fixed a stale docs link in ActionPanel.md that pointed at file:///c:/Users/USER/Desktop/... (someone's local Windows path) instead of the repo file, added a short note on how the reason reaches page.tsx, and updated the doc's usage example to show the real (reason: string) signature.

Didn't touch ActionPanel.tsx itself — it was already correct, so changing it would just be unnecessary churn against already-passing, already-thorough tests.

Coverage on the two files this issue names: ActionPanel.tsx 97.61%/93.07% (stmts/branch, unchanged, not touched), page.tsx 90.9%/70.58%. The uncovered branches in page.tsx are two pre-existing defensive fallbacks unrelated to this change (a !contractData guard in persistContractStatus, and a non-Error-thrown fallback in the initial load's catch) — left alone rather than contriving unrelated scenarios to hit them.

```
Test Suites: 72 passed, 72 total
Tests:       1219 passed, 1219 total
Snapshots:   7 passed, 7 total
Ran all test suites.
```

npm run lint and npm run build both pass clean.