### PR TITLE
feat(navigation): add responsive header with accessible mobile disclosure

### DIFF
--- a/docs/components/HeaderActions.md
+++ b/docs/components/HeaderActions.md
@@ -166,7 +166,12 @@ function CustomHeader() {
 
 ## Testing
 
-The test suite in `src/components/__tests__/HeaderActions.test.tsx` provides 100% line and branch coverage:
+Two test files cover this component:
+
+- **`src/components/__tests__/HeaderActions.test.tsx`** — stubs `WalletConnectButton` with a static placeholder to isolate the disclosure mechanics (toggle, ARIA wiring, keyboard, axe).
+- **`src/components/__tests__/HeaderActions.wallet-states.test.tsx`** — renders the *real* `WalletConnectButton` against a mocked `WalletContext` for both the connected (address pill + copy/disconnect buttons) and disconnected (Connect Wallet button) states, so the connected-state markup is proven to actually fit inside the disclosure rather than just asserting a stand-in renders. It also asserts the `sm:hidden` / `sm:block` responsive classes directly, since jsdom has no layout engine and can't measure rendered pixel widths — verifying the "no overflow at 320px" requirement in a real browser (or via a visual-regression/E2E tool) remains a manual/CI-follow-up check.
+
+Together they provide 100% line and branch coverage on `HeaderActions.tsx`:
 
 ### Coverage areas
 1. **Initial render** — verifies the toggle, panel, `ThemeToggle`, and `WalletConnectButton` all mount.

--- a/src/components/__tests__/HeaderActions.wallet-states.test.tsx
+++ b/src/components/__tests__/HeaderActions.wallet-states.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * @file HeaderActions.wallet-states.test.tsx
+ *
+ * HeaderActions.test.tsx stubs WalletConnectButton with a static placeholder,
+ * which proves the disclosure toggle/panel mechanics but can't show that the
+ * real connected-state markup (address pill + copy + disconnect buttons)
+ * actually fits inside the disclosure without breaking it. This file renders
+ * the real WalletConnectButton against a mocked WalletContext for both the
+ * connected and disconnected cases.
+ *
+ * Also covers the "no horizontal overflow at 320px" requirement the way a
+ * jsdom test actually can: jsdom has no layout engine, so it cannot measure
+ * rendered pixel widths. What it CAN verify is that the responsive contract
+ * itself is in place — the disclosure toggle carries `sm:hidden` and the
+ * panel carries `sm:block`, which is what prevents the connected-state pill
+ * from ever sharing a row with the brand/nav on a 320px viewport.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import HeaderActions from '../HeaderActions';
+import { WalletContextType, useWallet } from '@/contexts/WalletContext';
+
+expect.extend(toHaveNoViolations);
+
+jest.mock('@/contexts/WalletContext', () => ({
+  useWallet: jest.fn(),
+}));
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: jest.fn(() => ({ showError: jest.fn() })),
+}));
+
+jest.mock('@/components/ThemeToggle', () => ({
+  ThemeToggle: () => <button type="button">Theme</button>,
+}));
+
+const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
+
+function walletState(overrides: Partial<WalletContextType> = {}): WalletContextType {
+  return {
+    address: null,
+    isConnecting: false,
+    error: null,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('HeaderActions with the real WalletConnectButton — disconnected wallet', () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue(walletState());
+  });
+
+  it('renders the Connect Wallet button inside the disclosure panel', () => {
+    render(<HeaderActions />);
+    expect(screen.getByRole('button', { name: /^connect wallet$/i })).toBeInTheDocument();
+  });
+
+  it('keeps the toggle and panel working normally', async () => {
+    const user = userEvent.setup();
+    render(<HeaderActions />);
+
+    const toggle = screen.getByRole('button', { name: /open wallet actions/i });
+    await user.click(toggle);
+
+    expect(screen.getByRole('button', { name: /close wallet actions/i })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByRole('region', { name: /wallet actions/i })).not.toHaveClass('hidden');
+  });
+
+  it('has no axe violations when expanded', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<HeaderActions />);
+    await user.click(screen.getByRole('button', { name: /open wallet actions/i }));
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe('HeaderActions with the real WalletConnectButton — connected wallet', () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue(
+      walletState({ address: 'GABCDE1234FGHIJ5678KLMNO9012PQRST3456UVWX' }),
+    );
+  });
+
+  it('renders the address pill, copy button, and disconnect button inside the disclosure panel', () => {
+    render(<HeaderActions />);
+
+    expect(screen.getByRole('button', { name: /copy address to clipboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /disconnect wallet/i })).toBeInTheDocument();
+    // The connected pill is present in the DOM even while the panel is
+    // collapsed (display:none via the "hidden" class) — it isn't remounted
+    // when the disclosure toggles, so wallet state is preserved.
+    expect(screen.getByRole('region', { name: /wallet actions/i })).toHaveClass('hidden');
+  });
+
+  it('the connected-state markup remains present after opening and closing the disclosure', async () => {
+    const user = userEvent.setup();
+    render(<HeaderActions />);
+
+    const toggle = screen.getByRole('button', { name: /open wallet actions/i });
+    await user.click(toggle);
+    expect(screen.getByRole('button', { name: /disconnect wallet/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /close wallet actions/i }));
+    expect(screen.getByRole('button', { name: /disconnect wallet/i })).toBeInTheDocument();
+  });
+
+  it('has no axe violations with a connected wallet in either disclosure state', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<HeaderActions />);
+
+    expect(await axe(container)).toHaveNoViolations();
+
+    await user.click(screen.getByRole('button', { name: /open wallet actions/i }));
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe('HeaderActions — narrow-viewport responsive contract', () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue(walletState());
+  });
+
+  // jsdom has no layout engine, so "no horizontal overflow at 320px" can't be
+  // measured directly here — that's a manual/visual-regression concern. What
+  // this test confirms is the CSS contract that makes it true: the toggle is
+  // only ever visible below the `sm` breakpoint, and the panel is only ever
+  // visible inline at `sm` and above, so the connected-state pill (with its
+  // copy/disconnect icons) never shares a row with the brand and nav links
+  // on a viewport narrower than `sm`.
+  it('the disclosure toggle is hidden at sm and above (sm:hidden)', () => {
+    render(<HeaderActions />);
+    const toggle = screen.getByRole('button', { name: /open wallet actions/i });
+    expect(toggle.className).toContain('sm:hidden');
+  });
+
+  it('the wallet-actions panel is always visible at sm and above (sm:block)', () => {
+    render(<HeaderActions />);
+    const panel = screen.getByRole('region', { name: /wallet actions/i });
+    expect(panel.className).toContain('sm:block');
+  });
+});


### PR DESCRIPTION
Closes #357

---


Worth being upfront about: src/components/HeaderActions.tsx, its wiring into src/app/layout.tsx, its test file, and docs/components/HeaderActions.md were already fully built — the disclosure toggle (aria-expanded/aria-controls), the sm:hidden/sm:block breakpoint split, the icon swap, focus rings, and 29 tests already at 100% line/branch coverage including a jest-axe pass on both states. I ran the existing suite before touching anything to confirm this rather than assuming.

The one real gap: the existing test file stubs WalletConnectButton with a static placeholder, so it proves the disclosure mechanics but never actually proves the real connected-state markup (address pill + copy button + disconnect button) fits inside the panel without breaking anything — which is exactly the case this issue is about (an overflowing connected-state button). Added HeaderActions.wallet-states.test.tsx, which mocks WalletContext directly and renders the real WalletConnectButton for both the connected and disconnected cases, checks the toggle/panel still work, and runs axe against both. Also added two small tests asserting the sm:hidden / sm:block classes are actually present — noted plainly in both the test file and the docs that jsdom has no layout engine, so it can't literally measure for zero overflow at 320px; that part is a real-browser/visual-regression concern, not something a jsdom test can claim to verify.

Didn't change HeaderActions.tsx or layout.tsx — there was nothing to fix in either. Updated docs/components/HeaderActions.md's Testing section to describe both test files.

```
Test Suites: 73 passed, 73 total
Tests:       1226 passed, 1226 total
Snapshots:   7 passed, 7 total
Ran all test suites.
```

npm run lint and npm run build both pass clean.