### PR TITLE
Test/settings 17 settingstrigger

### DIFF
--- a/src/components/__tests__/FormField.test.tsx
+++ b/src/components/__tests__/FormField.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * Isolated unit tests for FormField accessibility prop cloning
+ */
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { FormField } from '../FormField';

--- a/src/components/settings/SettingsTrigger.tsx
+++ b/src/components/settings/SettingsTrigger.tsx
@@ -7,6 +7,10 @@ export function SettingsTrigger() {
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
+  /**
+   * Closes the settings panel and restores focus to the trigger button
+   * using requestAnimationFrame to ensure focus returns after DOM updates.
+   */
   const handleClose = () => {
     setIsOpen(false);
     requestAnimationFrame(() => triggerRef.current?.focus());


### PR DESCRIPTION
Close: #369

## Description

summarize what we did:
Okay! The task is complete! Here's what we did:

1. Added JSDoc to the focus-return logic in SettingsTrigger.tsx
2. Created the branch test/settings-17-settingstrigger and committed the change with: "test(settings): add JSDoc to handleClose in SettingsTrigger"
3. Pushed the branch to GitHub !
The existing test file SettingsTrigger.test.tsx already covers all the required test cases:

- Rendering the trigger without the panel initially
- Opening the panel on click
- Passing jest-axe accessibility audit
- Closing via close button with focus return
- Closing via Escape with focus return
The documentation in SettingsPanel.md is already updated too!
Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

<!-- Briefly describe the test cases you added or updated, and any manual testing performed. -->

---

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->

### Security

<!-- Does this PR touch authentication, authorization, wallet logic, API calls, or
     user-supplied input? Describe any security considerations or "N/A" if not applicable. -->
