### PR TITLE
Feature/settings 01 states

### DIFF
--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { usePreferences, Theme, AmountFormat, ToastDensity } from '@/lib/preferences';
+import { useFetchState } from '@/hooks/useFetchState';
+import {
+  SettingsLoadingState,
+  SettingsEmptyState,
+  SettingsErrorState,
+} from './SettingsStates';
 
 const FOCUSABLE_SELECTORS =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -11,9 +17,47 @@ interface SettingsPanelProps {
   onClose: () => void;
 }
 
+/**
+ * SettingsPanel — A settings drawer with empty, error, and loading state support.
+ * 
+ * Features:
+ * - Uses useFetchState hook to manage preferences loading states
+ * - Distinct empty state when no preferences are available
+ * - Error state with keyboard-accessible retry button
+ * - Proper focus management and ARIA announcements
+ * - Keyboard navigation with focus trapping
+ * - Accessibility: WCAG 2.1 AA compliant dialog with proper semantics
+ */
 export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
   const { preferences, updatePreference } = usePreferences();
   const panelRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [hasInitialized, setHasInitialized] = useState(false);
+
+  /**
+   * Simulated fetch function that loads preferences.
+   * In a real app, this would call an API endpoint.
+   * 
+   * For now, it returns the preferences after a short delay to simulate network latency.
+   * Preferences are loaded from localStorage via usePreferences hook.
+   */
+  const fetchPreferences = async () => {
+    // Simulate network delay
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    return preferences;
+  };
+
+  const { state, error, retry } = useFetchState(fetchPreferences);
+
+  /**
+   * Initialize preferences fetch when panel opens
+   */
+  useEffect(() => {
+    if (isOpen && !hasInitialized) {
+      retry();
+      setHasInitialized(true);
+    }
+  }, [isOpen, hasInitialized, retry]);
 
   /**
    * Focus management effect for modal dialog accessibility.
@@ -87,105 +131,138 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-6 space-y-8">
-          {/* Appearance Section */}
-          <section className="space-y-4">
-            <h3 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wider">Appearance</h3>
-            
-            <div className="space-y-4">
-              <div>
-                <label id="theme-label" className="block text-sm font-medium mb-2 text-[var(--foreground)]">Theme</label>
-                <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-labelledby="theme-label" aria-label="Theme">
-                  {(['light', 'dark', 'system'] as Theme[]).map((t) => (
-                    <button
-                      key={t}
-                      onClick={() => updatePreference('theme', t)}
-                      role="radio"
-                      aria-checked={preferences.theme === t}
-                      className={`px-3 py-2 text-sm rounded-md border capitalize transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ${
-                        preferences.theme === t 
-                          ? 'border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]' 
-                          : 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]'
-                      }`}
-                    >
-                      {t}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              <div>
-                <label id="currency-label" className="block text-sm font-medium mb-2 text-[var(--foreground)]">Currency Display</label>
-                <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-labelledby="currency-label" aria-label="Currency Display">
-                  {(['usd', 'ngn', 'compact'] as AmountFormat[]).map((f) => (
-                    <button
-                      key={f}
-                      onClick={() => updatePreference('amountFormat', f)}
-                      role="radio"
-                      aria-checked={preferences.amountFormat === f}
-                      className={`px-3 py-2 text-sm rounded-md border uppercase transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ${
-                        preferences.amountFormat === f 
-                          ? 'border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]' 
-                          : 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]'
-                      }`}
-                    >
-                      {f}
-                    </button>
-                  ))}
-                </div>
-              </div>
+        <div className="flex-1 overflow-y-auto">
+          {/* Loading State */}
+          {state === 'loading' && (
+            <div className="p-6">
+              <SettingsLoadingState message="Loading your settings..." />
             </div>
-          </section>
+          )}
 
-          {/* Notifications Section */}
-          <section className="space-y-4">
-            <h3 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wider">Notifications</h3>
-            
-            <div className="space-y-4">
-              <div>
-                <label id="density-label" className="block text-sm font-medium mb-2 text-[var(--foreground)]">Toast Density</label>
-                <div className="grid grid-cols-2 gap-2" role="radiogroup" aria-labelledby="density-label" aria-label="Toast Density">
-                  {(['relaxed', 'compact'] as ToastDensity[]).map((d) => (
+          {/* Empty State */}
+          {state === 'empty' && (
+            <div className="p-6">
+              <SettingsEmptyState
+                title="No Settings Available"
+                description="Your account doesn't have any custom settings yet. Defaults will be applied."
+              />
+            </div>
+          )}
+
+          {/* Error State */}
+          {state === 'error' && error && (
+            <div className="p-6">
+              <SettingsErrorState
+                error={error}
+                onRetry={() => retry()}
+                retryLabel="Reload Settings"
+              />
+            </div>
+          )}
+
+          {/* Success State - Settings Form */}
+          {state === 'success' && (
+            <div ref={contentRef} className="p-6 space-y-8">
+              {/* Appearance Section */}
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wider">Appearance</h3>
+                
+                <div className="space-y-4">
+                  <div>
+                    <label id="theme-label" className="block text-sm font-medium mb-2 text-[var(--foreground)]">Theme</label>
+                    <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-labelledby="theme-label" aria-label="Theme">
+                      {(['light', 'dark', 'system'] as Theme[]).map((t) => (
+                        <button
+                          key={t}
+                          onClick={() => updatePreference('theme', t)}
+                          role="radio"
+                          aria-checked={preferences.theme === t}
+                          className={`px-3 py-2 text-sm rounded-md border capitalize transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ${
+                            preferences.theme === t 
+                              ? 'border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]' 
+                              : 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]'
+                          }`}
+                        >
+                          {t}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div>
+                    <label id="currency-label" className="block text-sm font-medium mb-2 text-[var(--foreground)]">Currency Display</label>
+                    <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-labelledby="currency-label" aria-label="Currency Display">
+                      {(['usd', 'ngn', 'compact'] as AmountFormat[]).map((f) => (
+                        <button
+                          key={f}
+                          onClick={() => updatePreference('amountFormat', f)}
+                          role="radio"
+                          aria-checked={preferences.amountFormat === f}
+                          className={`px-3 py-2 text-sm rounded-md border uppercase transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ${
+                            preferences.amountFormat === f 
+                              ? 'border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]' 
+                              : 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]'
+                          }`}
+                        >
+                          {f}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              {/* Notifications Section */}
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wider">Notifications</h3>
+                
+                <div className="space-y-4">
+                  <div>
+                    <label id="density-label" className="block text-sm font-medium mb-2 text-[var(--foreground)]">Toast Density</label>
+                    <div className="grid grid-cols-2 gap-2" role="radiogroup" aria-labelledby="density-label" aria-label="Toast Density">
+                      {(['relaxed', 'compact'] as ToastDensity[]).map((d) => (
+                        <button
+                          key={d}
+                          onClick={() => updatePreference('toastDensity', d)}
+                          role="radio"
+                          aria-checked={preferences.toastDensity === d}
+                          className={`px-3 py-2 text-sm rounded-md border capitalize transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ${
+                            preferences.toastDensity === d 
+                              ? 'border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]' 
+                              : 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]'
+                          }`}
+                        >
+                          {d}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <label id="quiet-mode-label" className="text-sm font-medium text-[var(--foreground)]">Quiet Mode</label>
+                      <p className="text-xs text-[var(--muted-foreground)]">Suppress success notifications</p>
+                    </div>
                     <button
-                      key={d}
-                      onClick={() => updatePreference('toastDensity', d)}
-                      role="radio"
-                      aria-checked={preferences.toastDensity === d}
-                      className={`px-3 py-2 text-sm rounded-md border capitalize transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ${
-                        preferences.toastDensity === d 
-                          ? 'border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]' 
-                          : 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]'
+                      onClick={() => updatePreference('quietMode', !preferences.quietMode)}
+                      role="switch"
+                      aria-checked={preferences.quietMode}
+                      aria-labelledby="quiet-mode-label"
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ${
+                        preferences.quietMode ? 'bg-[var(--primary)]' : 'bg-[var(--muted)]'
                       }`}
                     >
-                      {d}
+                      <span
+                        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                          preferences.quietMode ? 'translate-x-6' : 'translate-x-1'
+                        }`}
+                      />
                     </button>
-                  ))}
+                  </div>
                 </div>
-              </div>
-
-              <div className="flex items-center justify-between">
-                <div>
-                  <label id="quiet-mode-label" className="text-sm font-medium text-[var(--foreground)]">Quiet Mode</label>
-                  <p className="text-xs text-[var(--muted-foreground)]">Suppress success notifications</p>
-                </div>
-                <button
-                  onClick={() => updatePreference('quietMode', !preferences.quietMode)}
-                  role="switch"
-                  aria-checked={preferences.quietMode}
-                  aria-labelledby="quiet-mode-label"
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ${
-                    preferences.quietMode ? 'bg-[var(--primary)]' : 'bg-[var(--muted)]'
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                      preferences.quietMode ? 'translate-x-6' : 'translate-x-1'
-                    }`}
-                  />
-                </button>
-              </div>
+              </section>
             </div>
-          </section>
+          )}
         </div>
 
         <div className="p-6 border-t border-[var(--border)] bg-[var(--surface)]">

--- a/src/components/settings/SettingsStates.tsx
+++ b/src/components/settings/SettingsStates.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+export interface SettingsLoadingStateProps {
+  message?: string;
+}
+
+export interface SettingsEmptyStateProps {
+  title: string;
+  description: string;
+}
+
+export interface SettingsErrorStateProps {
+  error: Error;
+  onRetry: () => void | Promise<void>;
+  retryLabel?: string;
+}
+
+/**
+ * Loading state component with spinner and live region announcement.
+ * - Renders a spinning loader with message
+ * - Announces loading state via aria-live="polite" for assistive tech
+ */
+export const SettingsLoadingState: React.FC<SettingsLoadingStateProps> = ({
+  message = 'Loading your settings...',
+}) => {
+  return (
+    <div
+      className="flex flex-col items-center justify-center min-h-96 gap-4"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <div className="w-8 h-8 border-4 border-[var(--muted)] border-t-[var(--primary)] rounded-full animate-spin" />
+      <p className="text-sm text-[var(--muted-foreground)]">{message}</p>
+    </div>
+  );
+};
+
+/**
+ * Empty state component with focus management.
+ * - Renders when fetch succeeds but returns no data
+ * - Sets initial focus to the container for screen readers
+ * - Uses status role for polite announcements
+ */
+export const SettingsEmptyState: React.FC<SettingsEmptyStateProps> = ({
+  title,
+  description,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Focus the empty state container so screen readers announce it
+    ref.current?.focus();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className="flex flex-col items-center justify-center min-h-96 gap-4 p-6 text-center"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      tabIndex={-1}
+    >
+      <svg
+        className="w-12 h-12 text-[var(--muted)]"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+        />
+      </svg>
+      <div>
+        <h3 className="font-semibold text-[var(--foreground)] text-lg">
+          {title}
+        </h3>
+        <p className="text-[var(--muted-foreground)] text-sm mt-1">
+          {description}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Error state component with keyboard-accessible retry button.
+ * - Renders when fetch fails with an error
+ * - Shows error message and retry button
+ * - Retry button is keyboard-accessible with focus ring
+ * - Sets initial focus to container and uses role="alert" for urgent announcements
+ */
+export const SettingsErrorState: React.FC<SettingsErrorStateProps> = ({
+  error,
+  onRetry,
+  retryLabel = 'Try Again',
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Focus the error state container so screen readers announce it
+    ref.current?.focus();
+  }, []);
+
+  const handleRetryClick = () => {
+    const result = onRetry();
+    // Handle both sync and async retry functions
+    if (result instanceof Promise) {
+      result.catch((err) => {
+        console.error('Retry failed:', err);
+      });
+    }
+  };
+
+  const handleRetryKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    // Allow Enter and Space to trigger retry
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleRetryClick();
+    }
+  };
+
+  return (
+    <div
+      ref={ref}
+      className="flex flex-col items-center justify-center min-h-96 gap-4 p-6 text-center"
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      tabIndex={-1}
+    >
+      <svg
+        className="w-12 h-12 text-red-500"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 8v4m0 4v.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+      <div>
+        <h3 className="font-semibold text-[var(--foreground)] text-lg">
+          Unable to Load Settings
+        </h3>
+        <p className="text-[var(--muted-foreground)] text-sm mt-1">
+          {error.message || 'An unexpected error occurred. Please try again.'}
+        </p>
+      </div>
+      <button
+        onClick={handleRetryClick}
+        onKeyDown={handleRetryKeyDown}
+        className="mt-4 px-4 py-2 bg-[var(--primary)] text-[var(--primary-foreground)] rounded-md hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 transition-colors font-medium"
+        aria-label={retryLabel}
+      >
+        {retryLabel}
+      </button>
+    </div>
+  );
+};

--- a/src/components/settings/__tests__/SettingsPanel.test.tsx
+++ b/src/components/settings/__tests__/SettingsPanel.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render, screen, fireEvent, within } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import { SettingsPanel } from '../SettingsPanel';
 import { PreferencesProvider } from '@/lib/preferences';
 import { resetCache } from '@/lib/safeStorage';
 
+expect.extend(toHaveNoViolations);
 
 const renderWithProvider = (ui: React.ReactElement) => {
   return render(
@@ -27,25 +28,48 @@ describe('SettingsPanel', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders correctly when open', () => {
+  it('shows loading state initially when open', () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
-    expect(screen.getByText('Settings')).toBeDefined();
-    expect(screen.getByText('Appearance')).toBeDefined();
-    expect(screen.getByText('Notifications')).toBeDefined();
+    // Loading state should show
+    expect(screen.getByText(/Loading your settings/i)).toBeInTheDocument();
   });
 
-  it('calls onClose when close button is clicked', () => {
+  it('transitions to success state and renders settings form', async () => {
+    renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+    
+    // Initially shows loading
+    expect(screen.getByText(/Loading your settings/i)).toBeInTheDocument();
+    
+    // Wait for transition to success state
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+      expect(screen.getByText('Appearance')).toBeInTheDocument();
+      expect(screen.getByText('Notifications')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onClose when close button is clicked', async () => {
     const onClose = jest.fn();
     renderWithProvider(<SettingsPanel isOpen={true} onClose={onClose} />);
     
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+
     const closeButton = screen.getByRole('button', { name: /Close settings/i });
     fireEvent.click(closeButton);
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('updates theme preference when theme button is clicked', () => {
+  it('updates theme preference when theme button is clicked', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
     
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /dark/i })).toBeInTheDocument();
+    });
+
     const darkButton = screen.getByRole('radio', { name: /dark/i });
     fireEvent.click(darkButton);
     
@@ -54,17 +78,27 @@ describe('SettingsPanel', () => {
     expect(darkButton.className).toContain('bg-[var(--primary)]');
   });
 
-  it('updates currency preference when currency button is clicked', () => {
+  it('updates currency preference when currency button is clicked', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
     
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /ngn/i })).toBeInTheDocument();
+    });
+
     const ngnButton = screen.getByRole('radio', { name: /ngn/i });
     fireEvent.click(ngnButton);
     
     expect(ngnButton.getAttribute('aria-checked')).toBe('true');
   });
 
-  it('updates toast density preference', () => {
+  it('updates toast density preference', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('radiogroup', { name: /toast density/i })).toBeInTheDocument();
+    });
 
     // Scope to the Toast Density radiogroup to avoid collision with the
     // "compact" option that also exists in the Currency Display group.
@@ -75,9 +109,14 @@ describe('SettingsPanel', () => {
     expect(compactButton.getAttribute('aria-checked')).toBe('true');
   });
 
-  it('toggles quiet mode switch', () => {
+  it('toggles quiet mode switch', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
     
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: /Quiet Mode/i })).toBeInTheDocument();
+    });
+
     const quietSwitch = screen.getByRole('switch', { name: /Quiet Mode/i });
     expect(quietSwitch.getAttribute('aria-checked')).toBe('false');
     
@@ -85,8 +124,13 @@ describe('SettingsPanel', () => {
     expect(quietSwitch.getAttribute('aria-checked')).toBe('true');
   });
 
-  it('persists theme preference to localStorage when changed', () => {
+  it('persists theme preference to localStorage when changed', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /dark/i })).toBeInTheDocument();
+    });
 
     const darkButton = screen.getByRole('radio', { name: /dark/i });
     fireEvent.click(darkButton);
@@ -97,8 +141,13 @@ describe('SettingsPanel', () => {
     expect(saved.theme).toBe('dark');
   });
 
-  it('persists currency preference to localStorage when changed', () => {
+  it('persists currency preference to localStorage when changed', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /ngn/i })).toBeInTheDocument();
+    });
 
     const ngnButton = screen.getByRole('radio', { name: /ngn/i });
     fireEvent.click(ngnButton);
@@ -109,8 +158,13 @@ describe('SettingsPanel', () => {
     expect(saved.amountFormat).toBe('ngn');
   });
 
-  it('persists quietMode to localStorage when toggled', () => {
+  it('persists quietMode to localStorage when toggled', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('switch', { name: /Quiet Mode/i })).toBeInTheDocument();
+    });
 
     const quietSwitch = screen.getByRole('switch', { name: /Quiet Mode/i });
     fireEvent.click(quietSwitch);
@@ -121,8 +175,13 @@ describe('SettingsPanel', () => {
     expect(saved.quietMode).toBe(true);
   });
 
-  it('persists toastDensity preference to localStorage when changed', () => {
+  it('persists toastDensity preference to localStorage when changed', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('radiogroup', { name: /toast density/i })).toBeInTheDocument();
+    });
 
     const densityGroup = screen.getByRole('radiogroup', { name: /toast density/i });
     const compactButton = within(densityGroup).getByRole('radio', { name: /compact/i });
@@ -134,7 +193,7 @@ describe('SettingsPanel', () => {
     expect(saved.toastDensity).toBe('compact');
   });
 
-  it('restores preferences from localStorage on remount (simulated reload)', () => {
+  it('restores preferences from localStorage on remount (simulated reload)', async () => {
     // Pre-seed localStorage as if a previous session saved dark + NGN
     localStorage.setItem(
       'talenttrust-user-preferences',
@@ -142,6 +201,11 @@ describe('SettingsPanel', () => {
     );
 
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('radiogroup', { name: /theme/i })).toBeInTheDocument();
+    });
 
     // Theme: dark should be checked
     const themeGroup = screen.getByRole('radiogroup', { name: /theme/i });
@@ -160,11 +224,16 @@ describe('SettingsPanel', () => {
     expect(screen.getByRole('switch', { name: /quiet mode/i }).getAttribute('aria-checked')).toBe('true');
   });
 
-  it('closes when backdrop is clicked', () => {
+  it('closes when backdrop is clicked', async () => {
     const onClose = jest.fn();
     const { container } = renderWithProvider(
       <SettingsPanel isOpen={true} onClose={onClose} />
     );
+
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
 
     // The backdrop is the first child of the outer wrapper
     const backdrop = container.querySelector('.absolute.inset-0');
@@ -173,16 +242,26 @@ describe('SettingsPanel', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('closes when Done button is clicked', () => {
+  it('closes when Done button is clicked', async () => {
     const onClose = jest.fn();
     renderWithProvider(<SettingsPanel isOpen={true} onClose={onClose} />);
+
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /done/i })).toBeInTheDocument();
+    });
 
     fireEvent.click(screen.getByRole('button', { name: /done/i }));
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('all interactive controls are keyboard-accessible (have focus-visible ring classes)', () => {
+  it('all interactive controls are keyboard-accessible (have focus-visible ring classes)', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /close settings/i })).toBeInTheDocument();
+    });
 
     const focusableControls = [
       screen.getByRole('button', { name: /close settings/i }),
@@ -197,18 +276,33 @@ describe('SettingsPanel', () => {
 
   // --- Accessibility: dialog semantics ---
 
-  it('has role="dialog" when open', () => {
+  it('has role="dialog" when open', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
-    expect(screen.getByRole('dialog')).toBeDefined();
+    
+    // Wait for dialog to be rendered
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeDefined();
+    });
   });
 
-  it('has aria-modal="true" on the dialog', () => {
+  it('has aria-modal="true" on the dialog', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
-    expect(screen.getByRole('dialog').getAttribute('aria-modal')).toBe('true');
+    
+    // Wait for dialog to be rendered
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      expect(dialog.getAttribute('aria-modal')).toBe('true');
+    });
   });
 
-  it('aria-labelledby points to the "Settings" heading', () => {
+  it('aria-labelledby points to the "Settings" heading', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+    
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+
     const dialog = screen.getByRole('dialog');
     const labelId = dialog.getAttribute('aria-labelledby');
     expect(labelId).toBeTruthy();
@@ -219,22 +313,40 @@ describe('SettingsPanel', () => {
 
   // --- Accessibility: keyboard interactions ---
 
-  it('closes when Escape is pressed', () => {
+  it('closes when Escape is pressed', async () => {
     const onClose = jest.fn();
     renderWithProvider(<SettingsPanel isOpen={true} onClose={onClose} />);
+    
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('sets initial focus on the close button when opened', () => {
+  it('sets initial focus on the close button when opened', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+    
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+
     expect(document.activeElement).toBe(
       screen.getByRole('button', { name: /close settings/i })
     );
   });
 
-  it('Tab on the last focusable element wraps focus to the first', () => {
+  it('Tab on the last focusable element wraps focus to the first', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+    
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
     const dialog = screen.getByRole('dialog');
     const focusable = Array.from(
       dialog.querySelectorAll<HTMLElement>(
@@ -247,8 +359,14 @@ describe('SettingsPanel', () => {
     expect(document.activeElement).toBe(focusable[0]);
   });
 
-  it('Shift+Tab on the first focusable element wraps focus to the last', () => {
+  it('Shift+Tab on the first focusable element wraps focus to the last', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+    
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
     const dialog = screen.getByRole('dialog');
     const focusable = Array.from(
       dialog.querySelectorAll<HTMLElement>(
@@ -263,11 +381,16 @@ describe('SettingsPanel', () => {
 
   // --- Accessibility validation with jest-axe ---
 
-  it('passes accessibility audit with jest-axe when open', async () => {
+  it('passes accessibility audit with jest-axe when open and loaded', async () => {
     const { container } = renderWithProvider(
       <SettingsPanel isOpen={true} onClose={() => {}} />
     );
     
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
@@ -281,7 +404,15 @@ describe('SettingsPanel', () => {
     expect(results).toHaveNoViolations();
   });
 
-
+  it('passes accessibility audit with jest-axe in loading state', async () => {
+    const { container } = renderWithProvider(
+      <SettingsPanel isOpen={true} onClose={() => {}} />
+    );
+    
+    // Capture loading state before it transitions
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 
   // --- Edge cases for focus management ---
 
@@ -303,9 +434,14 @@ describe('SettingsPanel', () => {
 
   // --- Verify all preference controls are properly labeled ---
 
-  it('all preference controls have proper ARIA labels and roles', () => {
+  it('all preference controls have proper ARIA labels and roles', async () => {
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
     
+    // Wait for settings to load
+    await waitFor(() => {
+      expect(screen.getByRole('radiogroup', { name: /theme/i })).toBeInTheDocument();
+    });
+
     // Theme radiogroup
     const themeGroup = screen.getByRole('radiogroup', { name: /theme/i });
     expect(themeGroup).toBeInTheDocument();
@@ -328,5 +464,34 @@ describe('SettingsPanel', () => {
     expect(themeButtons[0]).toHaveAccessibleName('light');
     expect(themeButtons[1]).toHaveAccessibleName('dark');
     expect(themeButtons[2]).toHaveAccessibleName('system');
+  });
+
+  // --- New tests for state management ---
+
+  it('shows loading state when panel opens', () => {
+    renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+    
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText(/Loading your settings/i)).toBeInTheDocument();
+  });
+
+  it('transitions from loading to success state', async () => {
+    renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+    
+    // Initially loading
+    expect(screen.getByText(/Loading your settings/i)).toBeInTheDocument();
+    
+    // Then success
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+      expect(screen.queryByText(/Loading your settings/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('announces loading state to assistive tech', () => {
+    renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+    
+    const statusRegion = screen.getByRole('status');
+    expect(statusRegion).toHaveAttribute('aria-live', 'polite');
   });
 });

--- a/src/components/settings/__tests__/SettingsStates.test.tsx
+++ b/src/components/settings/__tests__/SettingsStates.test.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import {
+  SettingsLoadingState,
+  SettingsEmptyState,
+  SettingsErrorState,
+} from '../SettingsStates';
+
+expect.extend(toHaveNoViolations);
+
+describe('SettingsStates', () => {
+  describe('SettingsLoadingState', () => {
+    it('renders loading spinner and message', () => {
+      render(<SettingsLoadingState />);
+
+      expect(screen.getByText(/Loading your settings/i)).toBeInTheDocument();
+      const spinner = screen.getByRole('status');
+      expect(spinner).toBeInTheDocument();
+    });
+
+    it('announces loading state to assistive tech', () => {
+      render(<SettingsLoadingState />);
+
+      const statusRegion = screen.getByRole('status');
+      expect(statusRegion).toHaveAttribute('aria-live', 'polite');
+      expect(statusRegion).toHaveAttribute('aria-atomic', 'true');
+    });
+
+    it('uses custom message when provided', () => {
+      render(<SettingsLoadingState message="Fetching your preferences..." />);
+
+      expect(screen.getByText(/Fetching your preferences/i)).toBeInTheDocument();
+    });
+
+    it('passes accessibility audit', async () => {
+      const { container } = render(<SettingsLoadingState />);
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('SettingsEmptyState', () => {
+    it('renders empty state with title and description', () => {
+      render(
+        <SettingsEmptyState
+          title="No Settings"
+          description="Your account has no settings yet."
+        />
+      );
+
+      expect(screen.getByText(/No Settings/)).toBeInTheDocument();
+      expect(screen.getByText(/Your account has no settings yet/)).toBeInTheDocument();
+    });
+
+    it('announces empty state to assistive tech', () => {
+      render(
+        <SettingsEmptyState
+          title="No Settings"
+          description="Test description"
+        />
+      );
+
+      const statusRegion = screen.getByRole('status');
+      expect(statusRegion).toHaveAttribute('aria-live', 'polite');
+      expect(statusRegion).toHaveAttribute('aria-atomic', 'true');
+    });
+
+    it('sets focus to container for screen readers', () => {
+      render(
+        <SettingsEmptyState title="Empty" description="Description" />
+      );
+
+      const container = screen.getByRole('status');
+      expect(container).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('passes accessibility audit', async () => {
+      const { container } = render(
+        <SettingsEmptyState title="Empty" description="Description" />
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('SettingsErrorState', () => {
+    it('renders error message and retry button', () => {
+      const mockRetry = jest.fn();
+      render(
+        <SettingsErrorState
+          error={new Error('Network failed')}
+          onRetry={mockRetry}
+        />
+      );
+
+      expect(screen.getByText(/Unable to Load Settings/i)).toBeInTheDocument();
+      expect(screen.getByText(/Network failed/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Try Again/i })).toBeInTheDocument();
+    });
+
+    it('announces error state with alert role', () => {
+      render(
+        <SettingsErrorState
+          error={new Error('Test error')}
+          onRetry={jest.fn()}
+        />
+      );
+
+      const alertRegion = screen.getByRole('alert');
+      expect(alertRegion).toHaveAttribute('aria-live', 'assertive');
+      expect(alertRegion).toHaveAttribute('aria-atomic', 'true');
+    });
+
+    it('calls retry callback when button is clicked', async () => {
+      const mockRetry = jest.fn();
+      render(
+        <SettingsErrorState
+          error={new Error('Test error')}
+          onRetry={mockRetry}
+        />
+      );
+
+      const retryButton = screen.getByRole('button', { name: /Try Again/i });
+      fireEvent.click(retryButton);
+
+      await waitFor(() => {
+        expect(mockRetry).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('handles async retry function', async () => {
+      const mockRetry = jest.fn().mockResolvedValue(undefined);
+      render(
+        <SettingsErrorState
+          error={new Error('Test error')}
+          onRetry={mockRetry}
+        />
+      );
+
+      const retryButton = screen.getByRole('button', { name: /Try Again/i });
+      fireEvent.click(retryButton);
+
+      await waitFor(() => {
+        expect(mockRetry).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('retry button is keyboard-accessible with Enter key', async () => {
+      const mockRetry = jest.fn();
+      render(
+        <SettingsErrorState
+          error={new Error('Test error')}
+          onRetry={mockRetry}
+        />
+      );
+
+      const retryButton = screen.getByRole('button', { name: /Try Again/i });
+      retryButton.focus();
+
+      fireEvent.keyDown(retryButton, { key: 'Enter', code: 'Enter' });
+
+      await waitFor(() => {
+        expect(mockRetry).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('retry button is keyboard-accessible with Space key', async () => {
+      const mockRetry = jest.fn();
+      render(
+        <SettingsErrorState
+          error={new Error('Test error')}
+          onRetry={mockRetry}
+        />
+      );
+
+      const retryButton = screen.getByRole('button', { name: /Try Again/i });
+      retryButton.focus();
+
+      fireEvent.keyDown(retryButton, { key: ' ', code: 'Space' });
+
+      await waitFor(() => {
+        expect(mockRetry).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('retry button has keyboard focus styles', () => {
+      render(
+        <SettingsErrorState
+          error={new Error('Test error')}
+          onRetry={jest.fn()}
+        />
+      );
+
+      const retryButton = screen.getByRole('button', { name: /Try Again/i });
+      expect(retryButton.className).toMatch(/focus-visible/);
+    });
+
+    it('uses custom retry label when provided', () => {
+      render(
+        <SettingsErrorState
+          error={new Error('Test error')}
+          onRetry={jest.fn()}
+          retryLabel="Reload Settings"
+        />
+      );
+
+      expect(
+        screen.getByRole('button', { name: /Reload Settings/i })
+      ).toBeInTheDocument();
+    });
+
+    it('passes accessibility audit', async () => {
+      const { container } = render(
+        <SettingsErrorState
+          error={new Error('Test error')}
+          onRetry={jest.fn()}
+        />
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/src/hooks/__tests__/useFetchState.test.ts
+++ b/src/hooks/__tests__/useFetchState.test.ts
@@ -1,0 +1,300 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useFetchState } from '../useFetchState';
+
+describe('useFetchState', () => {
+  describe('Success State', () => {
+    it('transitions from idle to loading to success', async () => {
+      const mockData = { theme: 'dark' };
+      const fetchFn = jest.fn().mockResolvedValue(mockData);
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      expect(result.current.state).toBe('idle');
+      expect(result.current.isLoading).toBe(false);
+
+      act(() => {
+        result.current.retry();
+      });
+
+      // Should transition to success
+      await waitFor(() => {
+        expect(result.current.state).toBe('success');
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.data).toEqual(mockData);
+      });
+    });
+
+    it('calls onSuccess callback when data is fetched', async () => {
+      const mockData = { theme: 'light' };
+      const fetchFn = jest.fn().mockResolvedValue(mockData);
+      const onSuccess = jest.fn();
+
+      const { result } = renderHook(() => useFetchState(fetchFn, onSuccess));
+
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith(mockData);
+      });
+    });
+  });
+
+  describe('Empty State', () => {
+    it('transitions to empty state when null is returned', async () => {
+      const fetchFn = jest.fn().mockResolvedValue(null);
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('empty');
+        expect(result.current.isEmpty).toBe(true);
+        expect(result.current.data).toBeNull();
+      });
+    });
+
+    it('transitions to empty state when undefined is returned', async () => {
+      const fetchFn = jest.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('empty');
+        expect(result.current.isEmpty).toBe(true);
+      });
+    });
+
+    it('transitions to empty state when empty array is returned', async () => {
+      const fetchFn = jest.fn().mockResolvedValue([]);
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('empty');
+        expect(result.current.isEmpty).toBe(true);
+      });
+    });
+
+    it('does not call onSuccess for empty state', async () => {
+      const fetchFn = jest.fn().mockResolvedValue(null);
+      const onSuccess = jest.fn();
+
+      const { result } = renderHook(() => useFetchState(fetchFn, onSuccess));
+
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('empty');
+        expect(onSuccess).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Error State', () => {
+    it('transitions to error state when fetch throws', async () => {
+      const error = new Error('Network failed');
+      const fetchFn = jest.fn().mockRejectedValue(error);
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('error');
+        expect(result.current.isError).toBe(true);
+        expect(result.current.error?.message).toBe('Network failed');
+      });
+    });
+
+    it('calls onError callback when fetch fails', async () => {
+      const error = new Error('Test error');
+      const fetchFn = jest.fn().mockRejectedValue(error);
+      const onError = jest.fn();
+
+      const { result } = renderHook(() => useFetchState(fetchFn, undefined, onError));
+
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+        expect(onError.mock.calls[0][0].message).toBe('Test error');
+      });
+    });
+
+    it('converts non-Error throws to Error objects', async () => {
+      const fetchFn = jest.fn().mockRejectedValue('String error');
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('error');
+        expect(result.current.error).toBeInstanceOf(Error);
+        expect(result.current.error?.message).toBe('String error');
+      });
+    });
+  });
+
+  describe('Loading State', () => {
+    it('shows loading state during fetch', () => {
+      const fetchFn = jest.fn(() => new Promise(() => {})); // Never resolves
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      act(() => {
+        result.current.retry();
+      });
+
+      expect(result.current.state).toBe('loading');
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+
+  describe('State Exclusivity', () => {
+    it('clears data and error when retrying', async () => {
+      const fetchFn = jest
+        .fn()
+        .mockResolvedValueOnce({ data: 'first' })
+        .mockRejectedValueOnce(new Error('Failed'));
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      // First call succeeds
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('success');
+        expect(result.current.data).toEqual({ data: 'first' });
+      });
+
+      // Second call fails
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('error');
+        // Old data should be cleared
+        expect(result.current.data).toBeNull();
+      });
+    });
+
+    it('ensures only one state is true at a time', async () => {
+      const mockData = { test: 'data' };
+      const fetchFn = jest.fn().mockResolvedValue(mockData);
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        const activeStates = [
+          result.current.isLoading,
+          result.current.isError,
+          result.current.isEmpty,
+          result.current.isSuccess,
+        ].filter(Boolean);
+
+        expect(activeStates.length).toBe(1);
+        expect(result.current.isSuccess).toBe(true);
+      });
+    });
+  });
+
+  describe('Retry Functionality', () => {
+    it('refetches data when retry is called', async () => {
+      const fetchFn = jest
+        .fn()
+        .mockResolvedValueOnce({ attempt: 1 })
+        .mockResolvedValueOnce({ attempt: 2 });
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual({ attempt: 1 });
+      });
+
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual({ attempt: 2 });
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('transitions from error to success on successful retry', async () => {
+      const fetchFn = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('Failed'))
+        .mockResolvedValueOnce({ data: 'success' });
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      // First attempt fails
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('error');
+      });
+
+      // Retry succeeds
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.state).toBe('success');
+        expect(result.current.data).toEqual({ data: 'success' });
+      });
+    });
+  });
+
+  describe('Manual Data Setting', () => {
+    it('allows manual setData call', () => {
+      const fetchFn = jest.fn();
+
+      const { result } = renderHook(() => useFetchState(fetchFn));
+
+      const newData = { manual: 'data' };
+      act(() => {
+        result.current.setData(newData);
+      });
+
+      expect(result.current.data).toEqual(newData);
+    });
+  });
+});

--- a/src/hooks/useFetchState.ts
+++ b/src/hooks/useFetchState.ts
@@ -1,0 +1,74 @@
+import { useCallback, useState } from 'react';
+
+export type FetchState = 'idle' | 'loading' | 'success' | 'error' | 'empty';
+
+export interface UseFetchStateReturn<T> {
+  state: FetchState;
+  data: T | null;
+  error: Error | null;
+  retry: () => Promise<void>;
+  setData: (data: T | null) => void;
+  isLoading: boolean;
+  isError: boolean;
+  isEmpty: boolean;
+  isSuccess: boolean;
+}
+
+/**
+ * Hook for managing async data fetch states with distinct handling for:
+ * - loading: data is being fetched
+ * - empty: fetch succeeded but returned no data (null or empty array)
+ * - error: fetch failed with an error
+ * - success: fetch succeeded with data
+ *
+ * Ensures states are mutually exclusive for predictable UI rendering.
+ */
+export function useFetchState<T>(
+  fetchFn: () => Promise<T>,
+  onSuccess?: (data: T) => void,
+  onError?: (error: Error) => void
+): UseFetchStateReturn<T> {
+  const [state, setState] = useState<FetchState>('idle');
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetch = useCallback(async () => {
+    setState('loading');
+    setError(null);
+    setData(null);
+    try {
+      const result = await fetchFn();
+      // Determine if result is empty: null, undefined, or empty array
+      const isEmpty =
+        result === null ||
+        result === undefined ||
+        (Array.isArray(result) && result.length === 0);
+
+      if (isEmpty) {
+        setState('empty');
+        setData(null);
+      } else {
+        setState('success');
+        setData(result);
+        onSuccess?.(result);
+      }
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setState('error');
+      setError(error);
+      onError?.(error);
+    }
+  }, [fetchFn, onSuccess, onError]);
+
+  return {
+    state,
+    data,
+    error,
+    retry: fetch,
+    setData,
+    isLoading: state === 'loading',
+    isError: state === 'error',
+    isEmpty: state === 'empty',
+    isSuccess: state === 'success',
+  };
+}


### PR DESCRIPTION
## Description
add empty and error states to settings view

<!-- Summarize the changes in this PR and the motivation behind them. -->

- Add FetchState hook for consistent state management
- Implement SettingsLoadingState, SettingsEmptyState, and SettingsErrorState components
- Add keyboard-accessible retry functionality
- Ensure mutually exclusive states with assistive tech announcements
- Include comprehensive test coverage with accessibility audits

Closes #546 

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

<!-- Briefly describe the test cases you added or updated, and any manual testing performed. -->

---

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->

### Security

<!-- Does this PR touch authentication, authorization, wallet logic, API calls, or
     user-supplied input? Describe any security considerations or "N/A" if not applicable. -->
