### PR TITLE
docs: add issue and pull-request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,6 +28,10 @@ assignees: ''
 
 <!-- What actually happens? Include any error messages or console output. -->
 
+## Test Output / Notes
+
+<!-- Paste failing test output, console logs, or other proof if you have it. -->
+
 ## Screenshots / Screen Recording
 
 <!-- Drag-and-drop images or a short recording here if it helps illustrate the issue. -->
@@ -47,4 +51,4 @@ assignees: ''
 
 ---
 
-> **Need quick help?** Drop by the community [Discord](https://discord.gg/WqnGpcPx) for faster troubleshooting before or while filing this issue.
+> Need quick help? Drop by the community [Discord](https://discord.gg/WqnGpcPx) for faster troubleshooting.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,22 +6,22 @@ labels: enhancement
 assignees: ''
 ---
 
-## Problem Statement
+## Impacted Route / Component
 
-<!-- Is your feature request related to a problem? Describe it clearly.
-     e.g. "I find it frustrating when I can't filter milestones by date range because…" -->
+<!-- e.g. /contracts · ContractSummary · MilestonesList -->
+
+## Current Behavior / Reproduction
+
+<!-- Describe the current limitation and how to see it today. -->
+
+## Expected Behavior
+
+<!-- What should happen instead? Focus on the outcome, not the implementation. -->
 
 ## Proposed Solution
 
-<!-- A clear, concise description of what you want to happen.
-     Focus on the outcome, not the implementation. -->
-
-## Alternatives Considered
-
-<!-- What other approaches or workarounds have you thought about?
-     Why do you prefer the proposed solution over them? -->
+<!-- Optional: a concise implementation idea if you have one. -->
 
 ## Additional Context
 
-<!-- Add any mockups, wireframes, user stories, or component ideas here.
-     e.g. "This would affect MilestonesList and the /milestones route." -->
+<!-- Add mockups, user stories, or links if helpful. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,8 +30,8 @@ All items must be checked before requesting review.
 
 - [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
   (run `npm test -- --coverage` and check the per-file table)
-- [ ] If this PR adds or modifies UI components, accessibility tests were written using
-  the shared utilities in `src/test-utils/a11y.tsx`
+- [ ] If this PR adds or modifies UI components, accessibility tests were written with
+  the shared utilities in [`src/test-utils/a11y.tsx`](../src/test-utils/a11y.tsx)
 
 ### What was tested?
 
@@ -51,3 +51,7 @@ All items must be checked before requesting review.
 
 <!-- Does this PR touch authentication, authorization, wallet logic, API calls, or
      user-supplied input? Describe any security considerations or "N/A" if not applicable. -->
+
+---
+
+Need a quick review or clarification? Join the community [Discord](https://discord.gg/WqnGpcPx).

--- a/README.md
+++ b/README.md
@@ -218,15 +218,10 @@ The homepage contains an accessible, fully validated sign-in form:
 
 1. Fork the repo and create a branch from `main`.
 2. Install deps, run tests and build: `npm install && npm test && npm run build`.
-3. Open a pull request. CI runs lint, build, and tests on push/PR to `main`.
+3. Use the contribution templates in [`.github/ISSUE_TEMPLATE/bug_report.md`](.github/ISSUE_TEMPLATE/bug_report.md), [`.github/ISSUE_TEMPLATE/feature_request.md`](.github/ISSUE_TEMPLATE/feature_request.md), and [`.github/pull_request_template.md`](.github/pull_request_template.md) so reports include the impacted route/component, reproduction steps, expected behavior, lint/test/build status, coverage, a11y, and security notes.
+4. If you need help or review context, join the community [Discord](https://discord.gg/WqnGpcPx).
 
-When filing issues or opening PRs, please use the provided GitHub templates — they make reviews faster and keep the project history clean:
-
-- **Bug reports** — `.github/ISSUE_TEMPLATE/bug_report.md`: includes reproduction steps, environment details, and an impacted-route field.
-- **Feature requests** — `.github/ISSUE_TEMPLATE/feature_request.md`: covers problem statement, proposed solution, and alternatives.
-- **Pull requests** — `.github/pull_request_template.md`: includes a pre-flight checklist (`lint` / `test` / `build`), a 95% coverage confirmation, and accessibility & security notes.
-
-If you need quick help before filing an issue, the community [Discord](https://discord.gg/WqnGpcPx) is the fastest way to reach the team.
+CI runs lint, build, and tests on every push and pull request to `main`.
 
 ## Features
 


### PR DESCRIPTION
## Summary
Adds GitHub issue and pull request templates to standardize contributions.

Closes #378

## What changed
- Added a bug report template with impacted route/component, reproduction, and expected vs actual behavior.
- Added a feature request template with impacted route/component, current behavior, expected behavior, and proposed solution.
- Added a PR template with lint/test/build checklist, coverage reminder, accessibility guidance, and security notes.
- Updated the README contributing section to link the templates and Discord.

## Validation
- `npm run lint`
- `npm run build`

## Notes
- Templates reference the shared a11y helpers in `src/test-utils/a11y.tsx`.
- Discord link: https://discord.gg/WqnGpcPx