### PR TITLE
feat(dashboard): add active-work summary

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,9 @@ import { ToastDemo } from '@/components/toast/toast-demo';
 import { FormField } from '@/components/FormField';
 import { ErrorSummary } from '@/components/ErrorSummary';
 import { useToast } from '@/components/toast/toast-provider';
+import { DashboardWorkSummary } from '@/components/DashboardWorkSummary';
+import { listContracts, listMilestones } from '@/lib/repository';
+import type { Contract, Milestone } from '@/types/domain';
 import {
   MAX_EMAIL_LENGTH,
   MAX_PASSWORD_LENGTH,
@@ -23,6 +26,10 @@ export default function Home() {
   const [cooldownRemainingMs, setCooldownRemainingMs] = useState(0);
   const cooldownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const { showSuccess } = useToast();
+  const [workData, setWorkData] = useState<{ contracts: Contract[]; milestones: Milestone[] }>({
+    contracts: [],
+    milestones: [],
+  });
 
   const clearCooldownInterval = () => {
     if (cooldownIntervalRef.current !== null) {
@@ -52,6 +59,11 @@ export default function Home() {
       startCooldownCountdown();
     }
     return clearCooldownInterval;
+  }, []);
+
+  // The dashboard reuses the persisted client data; it does not make a network request.
+  useEffect(() => {
+    setWorkData({ contracts: listContracts(), milestones: listMilestones() });
   }, []);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -174,6 +186,11 @@ export default function Home() {
             </div>
           )}
         </form>
+
+        <DashboardWorkSummary
+          contracts={workData.contracts}
+          milestones={workData.milestones}
+        />
 
         <ToastDemo />
       </div>

--- a/src/components/DashboardWorkSummary.test.tsx
+++ b/src/components/DashboardWorkSummary.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { DashboardWorkSummary, getWorkSummary } from './DashboardWorkSummary';
+import type { Contract, Milestone } from '@/types/domain';
+
+const contracts: Contract[] = [
+  { contractName: 'Active project', parties: [], totalValue: 100, currency: 'USD', status: 'Active', createdAt: '2026-07-01', milestoneCount: 1 },
+  { contractName: 'Finished project', parties: [], totalValue: 100, currency: 'USD', status: 'Completed', createdAt: '2026-07-01', milestoneCount: 1 },
+];
+
+const milestones: Milestone[] = [
+  { id: 'due', title: 'Due soon', status: 'Pending', payout: 100, currency: 'USD', dueDate: '2026-07-28' },
+  { id: 'paid', title: 'Paid soon', status: 'Paid', payout: 100, currency: 'USD', dueDate: '2026-07-28' },
+  { id: 'later', title: 'Later', status: 'Pending', payout: 100, currency: 'USD', dueDate: '2026-08-01' },
+];
+
+describe('DashboardWorkSummary', () => {
+  it('counts active contracts and actionable milestones due within seven days', () => {
+    expect(getWorkSummary(contracts, milestones, new Date(2026, 6, 24))).toEqual({
+      activeContracts: 1,
+      upcomingMilestones: 1,
+    });
+  });
+
+  it('renders counts and links to the relevant lists', () => {
+    render(<DashboardWorkSummary contracts={contracts} milestones={[]} />);
+
+    expect(screen.getByRole('heading', { name: /your work at a glance/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /view contracts: 1 active/i })).toHaveAttribute('href', '/contracts');
+    expect(screen.getByRole('link', { name: /view milestones: 0 due soon/i })).toHaveAttribute('href', '/milestones');
+  });
+
+  it('handles an empty workload gracefully', () => {
+    render(<DashboardWorkSummary contracts={[]} milestones={[]} />);
+
+    expect(screen.getByText(/no active contracts right now/i)).toBeInTheDocument();
+    expect(screen.getByText(/nothing is due soon/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /view contracts: 0 active/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /view milestones: 0 due soon/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/DashboardWorkSummary.tsx
+++ b/src/components/DashboardWorkSummary.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import Link from 'next/link';
+import type { Contract, Milestone } from '@/types/domain';
+import { isDueSoon } from '@/lib/dueSoon';
+
+export const DUE_SOON_WINDOW_DAYS = 7;
+
+export type WorkSummary = {
+  activeContracts: number;
+  upcomingMilestones: number;
+};
+
+/**
+ * Produces the two dashboard counts from data the application has already loaded.
+ * Paid and completed milestones are intentionally omitted because they no longer
+ * require upcoming work.
+ */
+export function getWorkSummary(
+  contracts: Contract[],
+  milestones: Milestone[],
+  today = new Date(),
+): WorkSummary {
+  return {
+    activeContracts: contracts.filter((contract) => contract.status === 'Active').length,
+    upcomingMilestones: milestones.filter(
+      (milestone) =>
+        milestone.status !== 'Paid' &&
+        milestone.status !== 'Completed' &&
+        isDueSoon(milestone.dueDate, today, DUE_SOON_WINDOW_DAYS),
+    ).length,
+  };
+}
+
+type DashboardWorkSummaryProps = {
+  contracts: Contract[];
+  milestones: Milestone[];
+};
+
+export function DashboardWorkSummary({
+  contracts,
+  milestones,
+}: DashboardWorkSummaryProps): React.JSX.Element {
+  const { activeContracts, upcomingMilestones } = getWorkSummary(contracts, milestones);
+
+  return (
+    <section aria-labelledby="work-summary-title" className="mt-8 w-full max-w-3xl text-left">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 id="work-summary-title" className="text-xl font-semibold text-slate-900">
+          Your work at a glance
+        </h2>
+        <p className="text-sm text-slate-500">Upcoming means due within the next 7 days.</p>
+      </div>
+
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        <Link
+          href="/contracts"
+          aria-label={`View contracts: ${activeContracts} active`}
+          className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-emerald-300 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+        >
+          <p className="text-sm font-medium text-slate-600">Active contracts</p>
+          <p className="mt-2 text-3xl font-bold text-slate-900">{activeContracts}</p>
+          <p className="mt-2 text-sm text-emerald-700">
+            {activeContracts === 0 ? 'No active contracts right now.' : 'View all contracts'}
+          </p>
+        </Link>
+
+        <Link
+          href="/milestones"
+          aria-label={`View milestones: ${upcomingMilestones} due soon`}
+          className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-blue-300 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
+        >
+          <p className="text-sm font-medium text-slate-600">Milestones due soon</p>
+          <p className="mt-2 text-3xl font-bold text-slate-900">{upcomingMilestones}</p>
+          <p className="mt-2 text-sm text-blue-700">
+            {upcomingMilestones === 0 ? 'Nothing is due soon.' : 'View all milestones'}
+          </p>
+        </Link>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION

## Summary

Closes #500

- Adds a dashboard at-a-glance summary for active contracts and milestones due within 7 days.
- Reuses existing persisted client data; no additional network requests.
- Excludes paid and completed milestones from upcoming work.
- Provides accessible links to Contracts and Milestones, with clear empty states.

## Tests

- `npm test -- --runInBand src/components/DashboardWorkSummary.test.tsx`
  - 3 tests passed
- `npm run lint`
  - Passed
- `npm run build`
  - Passed
