### PR TITLE
feat(forms): add empty and error states

### DIFF
--- a/src/components/ContractCreationForm.tsx
+++ b/src/components/ContractCreationForm.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback, FormEvent } from 'react';
 import { FormField } from './FormField';
 import { ErrorSummary } from './ErrorSummary';
+import { FormErrorBanner } from './FormErrorBanner';
 import { isValidStellarAddress } from '@/lib/stellarAddress';
 import { sanitizeUserText } from '@/lib/sanitizeUserText';
 import type { Contract } from '@/types/domain';
@@ -20,6 +21,25 @@ export interface ContractFormData {
 interface ContractCreationFormProps {
   onSubmit: (contract: Contract) => void;
   onCancel: () => void;
+  /**
+   * Optional initial data to pre-populate the form fields (e.g. loaded from
+   * a draft or existing contract). When `null` and `loadError` is set, the
+   * form shows an error state instead of a blank form body.
+   */
+  initialData?: {
+    contractName?: string;
+    totalValue?: string;
+    currency?: string;
+    parties?: Array<{ label: string; address: string }>;
+  } | null;
+  /**
+   * When non-null, a `FormErrorBanner` is shown describing a failure that
+   * occurred before this component mounted (e.g. loading pre-fill data).
+   * Pair with `onRetryLoad` to offer a keyboard-operable retry button.
+   */
+  loadError?: string | null;
+  /** Called when the user clicks "Try again" in the load-error banner. */
+  onRetryLoad?: () => void;
 }
 
 /**
@@ -38,15 +58,21 @@ interface ContractCreationFormProps {
 export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
   onSubmit,
   onCancel,
+  initialData,
+  loadError,
+  onRetryLoad,
 }) => {
-  const [contractName, setContractName] = useState('');
-  const [totalValue, setTotalValue] = useState('');
-  const [currency, setCurrency] = useState('USD');
-  const [parties, setParties] = useState<Array<{ label: string; address: string }>>([
-    { label: '', address: '' },
-    { label: '', address: '' },
-  ]);
+  const [contractName, setContractName] = useState(initialData?.contractName ?? '');
+  const [totalValue, setTotalValue] = useState(initialData?.totalValue ?? '');
+  const [currency, setCurrency] = useState(initialData?.currency ?? 'USD');
+  const [parties, setParties] = useState<Array<{ label: string; address: string }>>(
+    initialData?.parties ?? [
+      { label: '', address: '' },
+      { label: '', address: '' },
+    ],
+  );
   const [errors, setErrors] = useState<Array<{ fieldId: string; message: string }>>([]);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   /**
    * Validates the form data and returns an array of error objects.
@@ -143,6 +169,7 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
 
   /**
    * Handles form submission, validates input, and calls onSubmit if valid.
+   * Clears any prior submission-level error before each attempt.
    */
   const handleSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
@@ -150,6 +177,7 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
 
       const validationErrors = validateForm();
       setErrors(validationErrors);
+      setSubmitError(null);
 
       if (validationErrors.length > 0) {
         return;
@@ -177,7 +205,13 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
         milestoneCount: 0,
       };
 
-      onSubmit(contract);
+      try {
+        onSubmit(contract);
+      } catch {
+        setSubmitError(
+          'Could not save the contract. Please check your connection and try again.',
+        );
+      }
     },
     [contractName, totalValue, currency, parties, validateForm, onSubmit]
   );
@@ -223,8 +257,42 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
           Create New Contract
         </h2>
 
+        {loadError && initialData === null ? (
+          <div data-testid="form-load-error">
+            <FormErrorBanner
+              message={loadError}
+              onRetry={onRetryLoad}
+              retryLabel="Try again"
+              testId="form-load-error-banner"
+            />
+            <p className="mt-2 text-sm text-slate-600">
+              The form could not be loaded. Use the button above to retry, or{' '}
+              <button
+                type="button"
+                onClick={onCancel}
+                className="underline text-blue-600 hover:text-blue-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-blue-600"
+              >
+                cancel
+              </button>{' '}
+              and try again later.
+            </p>
+          </div>
+        ) : (
         <form onSubmit={handleSubmit} noValidate>
           <ErrorSummary errors={errors} />
+
+          {/* Submission error — shown after onSubmit throws. */}
+          <FormErrorBanner
+            message={submitError}
+            onRetry={() => {
+              // Build a synthetic submit by re-running validation + submit path.
+              const syntheticEvent = {
+                preventDefault: () => {},
+              } as FormEvent<HTMLFormElement>;
+              handleSubmit(syntheticEvent);
+            }}
+            retryLabel="Try again"
+          />
 
           <FormField
             label="Contract Name"
@@ -361,6 +429,7 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
             </button>
           </div>
         </form>
+        )}
       </div>
     </div>
   );

--- a/src/components/FormErrorBanner.tsx
+++ b/src/components/FormErrorBanner.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+
+export interface FormErrorBannerProps {
+  /**
+   * The error message to display. When `null` or `undefined` the banner is
+   * not rendered — this keeps the host form's conditional rendering simple.
+   */
+  message: string | null | undefined;
+  /**
+   * Optional callback invoked when the user activates the "Try again" button.
+   * When omitted the retry button is not rendered.
+   */
+  onRetry?: () => void;
+  /**
+   * Optional label for the retry button.
+   * Defaults to `"Try again"`.
+   */
+  retryLabel?: string;
+  /**
+   * Optional `data-testid` attribute forwarded to the banner root element.
+   * Defaults to `"form-error-banner"`.
+   */
+  testId?: string;
+}
+
+/**
+ * `FormErrorBanner` — an accessible inline banner that surfaces a
+ * **form-level submission error** distinct from per-field validation errors.
+ *
+ * Accessibility contract:
+ * - Uses `role="alert"` so assistive technologies announce the message
+ *   immediately when it is mounted or updated.
+ * - On mount the banner receives programmatic focus (`tabIndex={-1}`) so
+ *   keyboard-only users are not left hunting for the new content.
+ * - The optional retry button is a plain `<button type="button">` so it is
+ *   keyboard-operable (Enter / Space) and receives visible focus styles.
+ * - The banner is hidden (`return null`) when `message` is falsy, which keeps
+ *   the host component's layout clean.
+ *
+ * State exclusivity:
+ * - This component intentionally carries *no* internal state. The hosting
+ *   form component owns the `message` value and clears it (e.g., by setting
+ *   to `null`) when the user corrects the problem or retries. This makes the
+ *   exclusivity between loading / empty / error / success states trivially
+ *   verifiable at the host level.
+ *
+ * @example
+ * ```tsx
+ * const [submitError, setSubmitError] = useState<string | null>(null);
+ *
+ * const handleSubmit = async () => {
+ *   setSubmitError(null);
+ *   try {
+ *     await save(data);
+ *   } catch (err) {
+ *     setSubmitError('Could not save. Please try again.');
+ *   }
+ * };
+ *
+ * <FormErrorBanner message={submitError} onRetry={handleSubmit} />
+ * ```
+ */
+export const FormErrorBanner: React.FC<FormErrorBannerProps> = ({
+  message,
+  onRetry,
+  retryLabel = 'Try again',
+  testId = 'form-error-banner',
+}) => {
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  // Move focus to the banner whenever a new error message appears so
+  // keyboard-only and screen-reader users are immediately informed.
+  useEffect(() => {
+    if (message) {
+      bannerRef.current?.focus();
+    }
+  }, [message]);
+
+  if (!message) return null;
+
+  return (
+    <div
+      ref={bannerRef}
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      tabIndex={-1}
+      data-testid={testId}
+      className="mb-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-red-500"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm font-medium text-red-800">{message}</p>
+        {onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="flex-shrink-0 rounded-md bg-red-100 px-3 py-1 text-xs font-semibold text-red-800 transition hover:bg-red-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"
+            aria-label={retryLabel}
+          >
+            {retryLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/__tests__/ContractCreationForm.states.test.tsx
+++ b/src/components/__tests__/ContractCreationForm.states.test.tsx
@@ -1,0 +1,261 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ContractCreationForm } from '../ContractCreationForm';
+
+jest.mock('@/lib/stellarAddress', () => ({
+  isValidStellarAddress: jest.fn((addr: string) => addr.length === 56 && addr.startsWith('G')),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_ADDRESS = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+
+function renderForm(
+  overrides: Partial<React.ComponentProps<typeof ContractCreationForm>> = {},
+) {
+  const onSubmit = jest.fn();
+  const onCancel = jest.fn();
+  const utils = render(
+    <ContractCreationForm onSubmit={onSubmit} onCancel={onCancel} {...overrides} />,
+  );
+  return { onSubmit, onCancel, ...utils };
+}
+
+function fillValidForm() {
+  fireEvent.change(screen.getByLabelText(/contract name/i), {
+    target: { value: 'Design Sprint' },
+  });
+  fireEvent.change(screen.getByLabelText(/total value/i), {
+    target: { value: '5000' },
+  });
+  const labels = screen.getAllByPlaceholderText(/e\.g\., client, freelancer/i);
+  const addresses = screen.getAllByPlaceholderText(/GXXXXXXXXXX/i);
+  fireEvent.change(labels[0], { target: { value: 'Client' } });
+  fireEvent.change(addresses[0], { target: { value: VALID_ADDRESS } });
+  fireEvent.change(labels[1], { target: { value: 'Freelancer' } });
+  fireEvent.change(addresses[1], { target: { value: VALID_ADDRESS } });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ContractCreationForm — empty & error states', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Existing behaviour (regression guard)
+  // -------------------------------------------------------------------------
+  describe('existing behaviour', () => {
+    it('renders the modal dialog', () => {
+      renderForm();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('calls onCancel when cancel is clicked', () => {
+      const { onCancel } = renderForm();
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows field validation errors on empty submit', async () => {
+      renderForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+      await waitFor(() => {
+        expect(screen.getByRole('alert', { name: /there is a problem/i })).toBeInTheDocument();
+      });
+    });
+
+    it('calls onSubmit with correct data on a valid submission', async () => {
+      const { onSubmit } = renderForm();
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state — submission failure
+  // -------------------------------------------------------------------------
+  describe('error state — submission failure', () => {
+    it('shows FormErrorBanner when onSubmit throws', async () => {
+      const throwingSubmit = jest.fn(() => {
+        throw new Error('Persistence error');
+      });
+      renderForm({ onSubmit: throwingSubmit });
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-error-banner')).toBeInTheDocument();
+      });
+      expect(screen.getByText(/could not save the contract/i)).toBeInTheDocument();
+    });
+
+    it('error banner has role="alert"', async () => {
+      renderForm({ onSubmit: jest.fn(() => { throw new Error('fail'); }) });
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-error-banner')).toHaveAttribute('role', 'alert');
+      });
+    });
+
+    it('shows "Try again" retry button in the error banner', async () => {
+      renderForm({ onSubmit: jest.fn(() => { throw new Error('fail'); }) });
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+      });
+    });
+
+    it('retry button is type="button" (keyboard operable)', async () => {
+      renderForm({ onSubmit: jest.fn(() => { throw new Error('fail'); }) });
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /try again/i });
+        expect(btn).toHaveAttribute('type', 'button');
+      });
+    });
+
+    it('retry clears error and succeeds on second attempt', async () => {
+      let calls = 0;
+      const flakySubmit = jest.fn(() => {
+        calls++;
+        if (calls === 1) throw new Error('transient fail');
+      });
+      renderForm({ onSubmit: flakySubmit });
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('form-error-banner')).toBeInTheDocument(),
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+      await waitFor(() =>
+        expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument(),
+      );
+      expect(flakySubmit).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not show error banner before any submission', () => {
+      renderForm();
+      expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty / load-error state
+  // -------------------------------------------------------------------------
+  describe('empty / load-error state', () => {
+    it('shows load-error banner when loadError is set and initialData is null', () => {
+      renderForm({ loadError: 'Could not load contract data.', initialData: null });
+      expect(screen.getByTestId('form-load-error-banner')).toBeInTheDocument();
+      expect(screen.getByText(/could not load contract data/i)).toBeInTheDocument();
+    });
+
+    it('hides form fields when in load-error state', () => {
+      renderForm({ loadError: 'Load failed.', initialData: null });
+      expect(screen.queryByLabelText(/contract name/i)).not.toBeInTheDocument();
+    });
+
+    it('load-error banner has role="alert"', () => {
+      renderForm({ loadError: 'Load failed.', initialData: null });
+      expect(screen.getByTestId('form-load-error-banner')).toHaveAttribute('role', 'alert');
+    });
+
+    it('calls onRetryLoad when retry is clicked in load-error state', () => {
+      const onRetryLoad = jest.fn();
+      renderForm({ loadError: 'Load failed.', initialData: null, onRetryLoad });
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+      expect(onRetryLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT show load-error banner when initialData is not null', () => {
+      renderForm({
+        loadError: 'some error',
+        initialData: { contractName: 'Test' },
+      });
+      expect(screen.queryByTestId('form-load-error-banner')).not.toBeInTheDocument();
+      expect(screen.getByLabelText(/contract name/i)).toBeInTheDocument();
+    });
+
+    it('does NOT show load-error banner when loadError is null', () => {
+      renderForm({ loadError: null, initialData: null });
+      expect(screen.queryByTestId('form-load-error-banner')).not.toBeInTheDocument();
+    });
+
+    it('calls onCancel from the cancel button in load-error state', () => {
+      const { onCancel } = renderForm({ loadError: 'fail', initialData: null });
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // State exclusivity
+  // -------------------------------------------------------------------------
+  describe('state exclusivity', () => {
+    it('never shows both ErrorSummary and FormErrorBanner simultaneously', async () => {
+      renderForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+      await waitFor(() => {
+        expect(screen.getByRole('alert', { name: /there is a problem/i })).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument();
+    });
+
+    it('FormErrorBanner not shown before any submission', () => {
+      renderForm();
+      expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // initialData pre-population
+  // -------------------------------------------------------------------------
+  describe('initialData pre-population', () => {
+    it('pre-fills contract name', () => {
+      renderForm({ initialData: { contractName: 'Pre-filled' } });
+      expect(screen.getByLabelText(/contract name/i)).toHaveValue('Pre-filled');
+    });
+
+    it('pre-fills total value', () => {
+      renderForm({ initialData: { totalValue: '2000' } });
+      expect(screen.getByLabelText(/total value/i)).toHaveValue('2000');
+    });
+
+    it('pre-fills currency', () => {
+      renderForm({ initialData: { currency: 'GBP' } });
+      expect(screen.getByLabelText(/currency/i)).toHaveValue('GBP');
+    });
+
+    it('pre-fills parties', () => {
+      renderForm({
+        initialData: {
+          parties: [
+            { label: 'Client', address: VALID_ADDRESS },
+            { label: 'Dev', address: VALID_ADDRESS },
+          ],
+        },
+      });
+      const labels = screen.getAllByPlaceholderText(/e\.g\., client, freelancer/i);
+      expect(labels[0]).toHaveValue('Client');
+      expect(labels[1]).toHaveValue('Dev');
+    });
+  });
+});

--- a/src/components/__tests__/FormErrorBanner.test.tsx
+++ b/src/components/__tests__/FormErrorBanner.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FormErrorBanner } from '../FormErrorBanner';
+
+describe('FormErrorBanner', () => {
+  describe('rendering', () => {
+    it('renders nothing when message is null', () => {
+      const { container } = render(<FormErrorBanner message={null} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when message is undefined', () => {
+      const { container } = render(<FormErrorBanner message={undefined} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when message is an empty string', () => {
+      const { container } = render(<FormErrorBanner message="" />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders the banner when message is a non-empty string', () => {
+      render(<FormErrorBanner message="Something went wrong." />);
+      expect(screen.getByTestId('form-error-banner')).toBeInTheDocument();
+      expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+    });
+
+    it('accepts a custom testId', () => {
+      render(<FormErrorBanner message="Error" testId="my-banner" />);
+      expect(screen.getByTestId('my-banner')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has role="alert"', () => {
+      render(<FormErrorBanner message="Submission failed." />);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('has aria-live="assertive"', () => {
+      render(<FormErrorBanner message="Submission failed." />);
+      expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'assertive');
+    });
+
+    it('has aria-atomic="true"', () => {
+      render(<FormErrorBanner message="Submission failed." />);
+      expect(screen.getByRole('alert')).toHaveAttribute('aria-atomic', 'true');
+    });
+
+    it('has tabIndex="-1" so it can receive programmatic focus', () => {
+      render(<FormErrorBanner message="Submission failed." />);
+      expect(screen.getByRole('alert')).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('receives focus automatically when mounted with a message', () => {
+      render(<FormErrorBanner message="Submission failed." />);
+      expect(document.activeElement).toBe(screen.getByRole('alert'));
+    });
+
+    it('does not steal focus when message is absent', () => {
+      const button = document.createElement('button');
+      document.body.appendChild(button);
+      button.focus();
+
+      render(<FormErrorBanner message={null} />);
+
+      expect(document.activeElement).toBe(button);
+      document.body.removeChild(button);
+    });
+  });
+
+  describe('retry button', () => {
+    it('renders no retry button when onRetry is not provided', () => {
+      render(<FormErrorBanner message="Error" />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('renders a retry button when onRetry is provided', () => {
+      render(<FormErrorBanner message="Error" onRetry={() => {}} />);
+      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    });
+
+    it('calls onRetry when the retry button is clicked', () => {
+      const onRetry = jest.fn();
+      render(<FormErrorBanner message="Error" onRetry={onRetry} />);
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports a custom retryLabel', () => {
+      render(
+        <FormErrorBanner message="Error" onRetry={() => {}} retryLabel="Retry now" />,
+      );
+      expect(screen.getByRole('button', { name: /retry now/i })).toBeInTheDocument();
+    });
+
+    it('retry button is keyboard operable (has type="button")', () => {
+      render(<FormErrorBanner message="Error" onRetry={() => {}} />);
+      const btn = screen.getByRole('button', { name: /try again/i });
+      expect(btn).toHaveAttribute('type', 'button');
+    });
+
+    it('retry button fires on Enter key', () => {
+      const onRetry = jest.fn();
+      render(<FormErrorBanner message="Error" onRetry={onRetry} />);
+      const btn = screen.getByRole('button', { name: /try again/i });
+      btn.focus();
+      fireEvent.keyDown(btn, { key: 'Enter', code: 'Enter' });
+      fireEvent.click(btn); // simulate normal enter→click flow
+      expect(onRetry).toHaveBeenCalled();
+    });
+  });
+
+  describe('state exclusivity', () => {
+    it('disappears when message transitions from truthy to falsy', () => {
+      const { rerender } = render(<FormErrorBanner message="Error" />);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+
+      rerender(<FormErrorBanner message={null} />);
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('updates the displayed message when message changes', () => {
+      const { rerender } = render(<FormErrorBanner message="First error" />);
+      expect(screen.getByText('First error')).toBeInTheDocument();
+
+      rerender(<FormErrorBanner message="Second error" />);
+      expect(screen.getByText('Second error')).toBeInTheDocument();
+      expect(screen.queryByText('First error')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/__tests__/MilestoneCreationForm.states.test.tsx
+++ b/src/components/__tests__/MilestoneCreationForm.states.test.tsx
@@ -1,0 +1,263 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MilestoneCreationForm } from '../milestones/MilestoneCreationForm';
+import type { Milestone } from '@/types/domain';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderForm(
+  overrides: Partial<React.ComponentProps<typeof MilestoneCreationForm>> = {},
+) {
+  const onSubmit = jest.fn();
+  const onCancel = jest.fn();
+  const utils = render(
+    <MilestoneCreationForm onSubmit={onSubmit} onCancel={onCancel} {...overrides} />,
+  );
+  return { onSubmit, onCancel, ...utils };
+}
+
+function fillValidForm() {
+  fireEvent.change(screen.getByLabelText(/title/i), {
+    target: { value: 'My Milestone' },
+  });
+  fireEvent.change(screen.getByLabelText(/payout amount/i), {
+    target: { value: '500' },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MilestoneCreationForm — empty & error states', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Existing behaviour (regression guard)
+  // -------------------------------------------------------------------------
+  describe('existing behaviour', () => {
+    it('renders the dialog with all fields', () => {
+      renderForm();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/payout amount/i)).toBeInTheDocument();
+    });
+
+    it('calls onCancel when cancel is clicked', () => {
+      const { onCancel } = renderForm();
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows field validation errors on empty submit', async () => {
+      renderForm();
+      fireEvent.click(screen.getByRole('button', { name: /add milestone/i }));
+      await waitFor(() => {
+        expect(screen.getByRole('alert', { name: /there is a problem/i })).toBeInTheDocument();
+      });
+    });
+
+    it('calls onSubmit with correct data on valid submission', async () => {
+      const { onSubmit } = renderForm();
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /add milestone/i }));
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+      });
+      const ms: Milestone = onSubmit.mock.calls[0][0];
+      expect(ms.title).toBe('My Milestone');
+      expect(ms.payout).toBe(500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state — submission failure
+  // -------------------------------------------------------------------------
+  describe('error state — submission failure', () => {
+    it('shows FormErrorBanner when onSubmit throws', async () => {
+      const throwingSubmit = jest.fn(() => {
+        throw new Error('Storage quota exceeded');
+      });
+      renderForm({ onSubmit: throwingSubmit });
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /add milestone/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-error-banner')).toBeInTheDocument();
+      });
+      expect(screen.getByText(/could not save the milestone/i)).toBeInTheDocument();
+    });
+
+    it('error banner has role="alert"', async () => {
+      const throwingSubmit = jest.fn(() => { throw new Error('fail'); });
+      renderForm({ onSubmit: throwingSubmit });
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /add milestone/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-error-banner')).toHaveAttribute('role', 'alert');
+      });
+    });
+
+    it('shows "Try again" retry button in the error banner', async () => {
+      const throwingSubmit = jest.fn(() => { throw new Error('fail'); });
+      renderForm({ onSubmit: throwingSubmit });
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /add milestone/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+      });
+    });
+
+    it('retry button is type="button" (keyboard operable)', async () => {
+      const throwingSubmit = jest.fn(() => { throw new Error('fail'); });
+      renderForm({ onSubmit: throwingSubmit });
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /add milestone/i }));
+
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /try again/i });
+        expect(btn).toHaveAttribute('type', 'button');
+      });
+    });
+
+    it('retry clears error and succeeds on second attempt', async () => {
+      let callCount = 0;
+      const flakySubmit = jest.fn(() => {
+        callCount++;
+        if (callCount === 1) throw new Error('transient fail');
+        // second call succeeds silently
+      });
+
+      renderForm({ onSubmit: flakySubmit });
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /add milestone/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-error-banner')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument();
+      });
+      expect(flakySubmit).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not show error banner before any submission', () => {
+      renderForm();
+      expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty / load-error state
+  // -------------------------------------------------------------------------
+  describe('empty / load-error state', () => {
+    it('shows load-error banner when loadError is set and initialData is null', () => {
+      renderForm({ loadError: 'Could not load milestone data.', initialData: null });
+      expect(screen.getByTestId('form-load-error-banner')).toBeInTheDocument();
+      expect(screen.getByText(/could not load milestone data/i)).toBeInTheDocument();
+    });
+
+    it('hides form fields when in load-error state', () => {
+      renderForm({ loadError: 'Load failed.', initialData: null });
+      expect(screen.queryByLabelText(/title/i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/payout amount/i)).not.toBeInTheDocument();
+    });
+
+    it('load-error banner has role="alert"', () => {
+      renderForm({ loadError: 'Load failed.', initialData: null });
+      expect(screen.getByTestId('form-load-error-banner')).toHaveAttribute('role', 'alert');
+    });
+
+    it('calls onRetryLoad when retry is clicked in load-error state', () => {
+      const onRetryLoad = jest.fn();
+      renderForm({ loadError: 'Load failed.', initialData: null, onRetryLoad });
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+      expect(onRetryLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT show load-error banner when initialData is not null', () => {
+      renderForm({ loadError: 'Some error', initialData: { title: 'Prefilled' } });
+      expect(screen.queryByTestId('form-load-error-banner')).not.toBeInTheDocument();
+      expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+    });
+
+    it('does NOT show load-error banner when loadError is null', () => {
+      renderForm({ loadError: null, initialData: null });
+      expect(screen.queryByTestId('form-load-error-banner')).not.toBeInTheDocument();
+    });
+
+    it('provides a cancel button in the load-error state', () => {
+      const { onCancel } = renderForm({ loadError: 'Load failed.', initialData: null });
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // State exclusivity
+  // -------------------------------------------------------------------------
+  describe('state exclusivity', () => {
+    it('never shows both ErrorSummary and FormErrorBanner simultaneously', async () => {
+      // Submit empty form: should show ErrorSummary, NOT FormErrorBanner
+      renderForm();
+      fireEvent.click(screen.getByRole('button', { name: /add milestone/i }));
+      await waitFor(() => {
+        expect(screen.getByRole('alert', { name: /there is a problem/i })).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument();
+    });
+
+    it('FormErrorBanner clears when retry succeeds', async () => {
+      let first = true;
+      const flakySubmit = jest.fn(() => {
+        if (first) { first = false; throw new Error('fail'); }
+      });
+      renderForm({ onSubmit: flakySubmit });
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /add milestone/i }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('form-error-banner')).toBeInTheDocument(),
+      );
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+      await waitFor(() =>
+        expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // initialData pre-population
+  // -------------------------------------------------------------------------
+  describe('initialData pre-population', () => {
+    it('pre-fills title', () => {
+      renderForm({ initialData: { title: 'Pre-filled Milestone' } });
+      expect(screen.getByLabelText(/title/i)).toHaveValue('Pre-filled Milestone');
+    });
+
+    it('pre-fills payout', () => {
+      renderForm({ initialData: { payout: '1500' } });
+      expect(screen.getByLabelText(/payout amount/i)).toHaveValue('1500');
+    });
+
+    it('pre-fills currency', () => {
+      renderForm({ initialData: { currency: 'EUR' } });
+      expect(screen.getByLabelText(/currency/i)).toHaveValue('EUR');
+    });
+
+    it('pre-fills status', () => {
+      renderForm({ initialData: { status: 'Completed' } });
+      expect(screen.getByLabelText(/status/i)).toHaveValue('Completed');
+    });
+  });
+});

--- a/src/components/contracts/CreateContractForm.tsx
+++ b/src/components/contracts/CreateContractForm.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { FormField } from '@/components/FormField';
 import { ErrorSummary } from '@/components/ErrorSummary';
+import { FormErrorBanner } from '@/components/FormErrorBanner';
 import { useToast } from '@/components/toast/toast-provider';
 import { saveContract } from '@/lib/repository';
 import { normalizeStellarAddress } from '@/lib/stellarAddress';
@@ -26,6 +27,39 @@ export interface CreateContractFormProps {
    * The parent is responsible for hiding the form.
    */
   onCancel: () => void;
+  /**
+   * Optional initial data to pre-populate the form fields.
+   * When provided the form operates in an "edit" mode (though submission
+   * always creates a new persisted record via `saveContract`).
+   *
+   * If the parent tried to load pre-fill data and the load failed, pass
+   * `null` here and set `loadError` to surface an error state instead of
+   * a blank form.
+   */
+  initialData?: {
+    contractName?: string;
+    freelancerAddress?: string;
+    totalValue?: string;
+    currency?: string;
+  } | null;
+  /**
+   * When non-null the form renders a `FormErrorBanner` describing a failure
+   * that occurred **before** this component mounted — for example, a failed
+   * attempt to load pre-fill data from an API. The `onRetryLoad` callback
+   * (if supplied) is wired to the banner's retry button so users can trigger
+   * a fresh fetch without reloading the whole page.
+   *
+   * This prop is intentionally separate from the internal submission-error
+   * state to preserve state exclusivity: `loadError` describes a pre-render
+   * problem while `submitError` (internal state) describes a post-submission
+   * problem.
+   */
+  loadError?: string | null;
+  /**
+   * Called when the user clicks "Try again" in the load-error banner.
+   * Only rendered when both `loadError` and `onRetryLoad` are provided.
+   */
+  onRetryLoad?: () => void;
 }
 
 /** Supported currency options presented in the currency selector. */
@@ -35,6 +69,18 @@ const CURRENCY_OPTIONS = ['USD', 'XLM', 'EUR', 'GBP'] as const;
  * `CreateContractForm` — an accessible, validated inline form for creating
  * a new TalentTrust escrow contract.
  *
+ * States:
+ * - **Empty state** — rendered when `loadError` is set and `initialData` is
+ *   `null`, indicating pre-fill data could not be loaded. An error banner with
+ *   a retry action is shown instead of a blank form.
+ * - **Error state** — after a failed persistence attempt (`saveContract`
+ *   returns false or throws) the form surfaces a `FormErrorBanner` above the
+ *   submit button with a "Try again" action that re-submits the last values.
+ * - **Loading state** — while a submission is in flight the submit button is
+ *   disabled to prevent duplicate submissions.
+ * - **Loaded / success state** — calls `onSuccess` and the parent dismisses
+ *   the form.
+ *
  * Accessibility contract:
  * - The form is labelled by a visible `<h2>` via `aria-labelledby`.
  * - Every field is wrapped in `FormField`, which wires `<label>`,
@@ -42,21 +88,37 @@ const CURRENCY_OPTIONS = ['USD', 'XLM', 'EUR', 'GBP'] as const;
  * - On validation failure, `ErrorSummary` is rendered and auto-focused
  *   via its own internal `useEffect`, moving screen reader focus to the
  *   error digest without an explicit `ref` here.
+ * - `FormErrorBanner` uses `role="alert"` and auto-focuses on mount so
+ *   submission errors are announced immediately to assistive technologies.
  * - Success is communicated through a polite `useToast` notification;
  *   no `alert()` is used.
  */
-const CreateContractForm: React.FC<CreateContractFormProps> = ({ onSuccess, onCancel }) => {
+const CreateContractForm: React.FC<CreateContractFormProps> = ({
+  onSuccess,
+  onCancel,
+  initialData,
+  loadError,
+  onRetryLoad,
+}) => {
   const { showSuccess } = useToast();
 
-  const [contractName, setContractName] = useState('');
-  const [freelancerAddress, setFreelancerAddress] = useState('');
-  const [totalValue, setTotalValue] = useState('');
-  const [currency, setCurrency] = useState<string>(CURRENCY_OPTIONS[0]);
+  const [contractName, setContractName] = useState(initialData?.contractName ?? '');
+  const [freelancerAddress, setFreelancerAddress] = useState(
+    initialData?.freelancerAddress ?? '',
+  );
+  const [totalValue, setTotalValue] = useState(initialData?.totalValue ?? '');
+  const [currency, setCurrency] = useState<string>(
+    initialData?.currency ?? CURRENCY_OPTIONS[0],
+  );
   const [errors, setErrors] = useState<ValidationError[]>([]);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
+  /**
+   * Core submission logic extracted so it can be called both from the form's
+   * `onSubmit` handler and from the retry callback on `FormErrorBanner`.
+   */
+  const attemptSubmit = () => {
     const validationErrors = validateContract({
       contractName,
       freelancerAddress,
@@ -66,32 +128,51 @@ const CreateContractForm: React.FC<CreateContractFormProps> = ({ onSuccess, onCa
 
     if (validationErrors.length > 0) {
       setErrors(validationErrors);
+      setSubmitError(null);
       return;
     }
 
     // Clear any previous errors before persisting.
     setErrors([]);
+    setSubmitError(null);
+    setIsSubmitting(true);
 
-    const contract: Contract = {
-      contractName: contractName.trim(),
-      parties: [
-        { label: 'Client', address: 'TalentTrust Client' },
-        { label: 'Freelancer', address: normalizeStellarAddress(freelancerAddress) },
-      ],
-      totalValue: parseFloat(totalValue),
-      currency,
-      status: 'Pending',
-      createdAt: new Date().toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-      }),
-      milestoneCount: 0,
-    };
+    try {
+      const contract: Contract = {
+        contractName: contractName.trim(),
+        parties: [
+          { label: 'Client', address: 'TalentTrust Client' },
+          { label: 'Freelancer', address: normalizeStellarAddress(freelancerAddress) },
+        ],
+        totalValue: parseFloat(totalValue),
+        currency,
+        status: 'Pending',
+        createdAt: new Date().toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        }),
+        milestoneCount: 0,
+      };
 
-    saveContract(contract);
-    showSuccess({ title: 'Contract created', description: `"${contract.contractName}" has been saved.` });
-    onSuccess(contract);
+      saveContract(contract);
+      showSuccess({
+        title: 'Contract created',
+        description: `"${contract.contractName}" has been saved.`,
+      });
+      onSuccess(contract);
+    } catch {
+      setSubmitError(
+        'Could not save the contract. Please check your connection and try again.',
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    attemptSubmit();
   };
 
   const inputClass =
@@ -109,94 +190,130 @@ const CreateContractForm: React.FC<CreateContractFormProps> = ({ onSuccess, onCa
         Create a new contract
       </h2>
 
-      <ErrorSummary errors={errors} />
-
-      <form onSubmit={handleSubmit} noValidate>
-        <FormField
-          id="contractName"
-          label="Contract name"
-          error={errors.find((e) => e.fieldId === 'contractName')?.message}
-          required
-        >
-          <input
-            type="text"
-            value={contractName}
-            onChange={(e) => setContractName(e.target.value)}
-            placeholder="e.g. Website Redesign"
-            autoComplete="off"
-            className={inputClass}
+      {/* Load error — replaces the form body when pre-fill data could not be
+          fetched, giving users actionable guidance rather than a blank form. */}
+      {loadError && initialData === null ? (
+        <div data-testid="form-load-error">
+          <FormErrorBanner
+            message={loadError}
+            onRetry={onRetryLoad}
+            retryLabel="Try again"
+            testId="form-load-error-banner"
           />
-        </FormField>
-
-        <FormField
-          id="freelancerAddress"
-          label="Freelancer Stellar address"
-          helperText="Must be a valid Stellar public key starting with G"
-          error={errors.find((e) => e.fieldId === 'freelancerAddress')?.message}
-          required
-        >
-          <input
-            type="text"
-            value={freelancerAddress}
-            onChange={(e) => setFreelancerAddress(e.target.value)}
-            placeholder="GABC…"
-            autoComplete="off"
-            className={`${inputClass} font-mono`}
-          />
-        </FormField>
-
-        <FormField
-          id="totalValue"
-          label="Total value"
-          error={errors.find((e) => e.fieldId === 'totalValue')?.message}
-          required
-        >
-          <input
-            type="number"
-            value={totalValue}
-            onChange={(e) => setTotalValue(e.target.value)}
-            placeholder="0.00"
-            min="0.01"
-            step="any"
-            className={inputClass}
-          />
-        </FormField>
-
-        <FormField
-          id="currency"
-          label="Currency"
-          error={errors.find((e) => e.fieldId === 'currency')?.message}
-          required
-        >
-          <select
-            value={currency}
-            onChange={(e) => setCurrency(e.target.value)}
-            className={inputClass}
-          >
-            {CURRENCY_OPTIONS.map((c) => (
-              <option key={c} value={c}>
-                {c}
-              </option>
-            ))}
-          </select>
-        </FormField>
-
-        <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-          <button
-            type="submit"
-            className="rounded-2xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-          >
-            Create Contract
-          </button>
-          <button
-            type="button"
-            onClick={onCancel}
-            className="rounded-2xl border border-slate-300 bg-white px-6 py-2.5 text-sm font-semibold text-slate-900 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-          >
-            Cancel
-          </button>
+          <p className="mt-2 text-sm text-slate-600">
+            The form could not be loaded. Use the button above to retry, or{' '}
+            <button
+              type="button"
+              onClick={onCancel}
+              className="underline text-blue-600 hover:text-blue-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-blue-600"
+            >
+              cancel
+            </button>{' '}
+            and try again later.
+          </p>
         </div>
-      </form>
+      ) : (
+        <>
+          <ErrorSummary errors={errors} />
+
+          {/* Submission error — shown after a failed persistence attempt. */}
+          <FormErrorBanner
+            message={submitError}
+            onRetry={attemptSubmit}
+            retryLabel="Try again"
+          />
+
+          <form onSubmit={handleSubmit} noValidate>
+            <FormField
+              id="contractName"
+              label="Contract name"
+              error={errors.find((e) => e.fieldId === 'contractName')?.message}
+              required
+            >
+              <input
+                type="text"
+                value={contractName}
+                onChange={(e) => setContractName(e.target.value)}
+                placeholder="e.g. Website Redesign"
+                autoComplete="off"
+                className={inputClass}
+              />
+            </FormField>
+
+            <FormField
+              id="freelancerAddress"
+              label="Freelancer Stellar address"
+              helperText="Must be a valid Stellar public key starting with G"
+              error={errors.find((e) => e.fieldId === 'freelancerAddress')?.message}
+              required
+            >
+              <input
+                type="text"
+                value={freelancerAddress}
+                onChange={(e) => setFreelancerAddress(e.target.value)}
+                placeholder="GABC…"
+                autoComplete="off"
+                className={`${inputClass} font-mono`}
+              />
+            </FormField>
+
+            <FormField
+              id="totalValue"
+              label="Total value"
+              error={errors.find((e) => e.fieldId === 'totalValue')?.message}
+              required
+            >
+              <input
+                type="number"
+                value={totalValue}
+                onChange={(e) => setTotalValue(e.target.value)}
+                placeholder="0.00"
+                min="0.01"
+                step="any"
+                className={inputClass}
+              />
+            </FormField>
+
+            <FormField
+              id="currency"
+              label="Currency"
+              error={errors.find((e) => e.fieldId === 'currency')?.message}
+              required
+            >
+              <select
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value)}
+                className={inputClass}
+              >
+                {CURRENCY_OPTIONS.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </FormField>
+
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="rounded-2xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                aria-disabled={isSubmitting}
+              >
+                {isSubmitting ? 'Saving…' : 'Create Contract'}
+              </button>
+              <button
+                type="button"
+                onClick={onCancel}
+                disabled={isSubmitting}
+                className="rounded-2xl border border-slate-300 bg-white px-6 py-2.5 text-sm font-semibold text-slate-900 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </>
+      )}
     </section>
   );
 };

--- a/src/components/contracts/__tests__/CreateContractForm.states.test.tsx
+++ b/src/components/contracts/__tests__/CreateContractForm.states.test.tsx
@@ -1,0 +1,341 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import CreateContractForm from '../CreateContractForm';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+  }),
+}));
+
+const mockSaveContract = jest.fn();
+jest.mock('@/lib/repository', () => ({
+  saveContract: (...args: unknown[]) => mockSaveContract(...args),
+}));
+
+jest.mock('@/lib/stellarAddress', () => ({
+  isValidStellarAddress: jest.fn((addr: string) => addr.length === 56 && addr.startsWith('G')),
+  normalizeStellarAddress: jest.fn((addr: string) => addr.trim()),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_ADDRESS = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+
+const onSuccess = jest.fn();
+const onCancel = jest.fn();
+
+function renderForm(
+  overrides: Partial<React.ComponentProps<typeof CreateContractForm>> = {},
+) {
+  return render(
+    <CreateContractForm onSuccess={onSuccess} onCancel={onCancel} {...overrides} />,
+  );
+}
+
+function fillValidForm() {
+  fireEvent.change(screen.getByLabelText(/contract name/i), {
+    target: { value: 'Design Sprint' },
+  });
+  fireEvent.change(screen.getByLabelText(/freelancer stellar address/i), {
+    target: { value: VALID_ADDRESS },
+  });
+  fireEvent.change(screen.getByLabelText(/total value/i), {
+    target: { value: '5000' },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CreateContractForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSaveContract.mockImplementation(() => undefined); // default: succeeds
+  });
+
+  // -------------------------------------------------------------------------
+  // Existing behaviour (regression guard)
+  // -------------------------------------------------------------------------
+  describe('existing behaviour', () => {
+    it('renders all four fields and both action buttons', () => {
+      renderForm();
+      expect(screen.getByLabelText(/contract name/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/freelancer stellar address/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/total value/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/currency/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /create contract/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    });
+
+    it('calls onCancel when the Cancel button is clicked', () => {
+      renderForm();
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('shows an ErrorSummary with all required-field errors on empty submit', async () => {
+      renderForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+      await waitFor(() => {
+        expect(screen.getByRole('alert', { name: /there is a problem/i })).toBeInTheDocument();
+      });
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('calls onSuccess and showSuccess toast on a valid submission', async () => {
+      renderForm();
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+      await waitFor(() => {
+        expect(mockShowSuccess).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Contract created' }),
+        );
+      });
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state — submission failure
+  // -------------------------------------------------------------------------
+  describe('error state — submission failure', () => {
+    it('shows FormErrorBanner when saveContract throws', async () => {
+      mockSaveContract.mockImplementation(() => {
+        throw new Error('Storage quota exceeded');
+      });
+      renderForm();
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-error-banner')).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText(/could not save the contract/i),
+      ).toBeInTheDocument();
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('error banner has role="alert" so it is announced immediately', async () => {
+      mockSaveContract.mockImplementation(() => {
+        throw new Error('fail');
+      });
+      renderForm();
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-error-banner')).toHaveAttribute('role', 'alert');
+      });
+    });
+
+    it('shows a "Try again" retry button in the error banner', async () => {
+      mockSaveContract.mockImplementation(() => {
+        throw new Error('fail');
+      });
+      renderForm();
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+      });
+    });
+
+    it('retry re-submits and clears error on success', async () => {
+      mockSaveContract
+        .mockImplementationOnce(() => { throw new Error('fail'); })
+        .mockImplementationOnce(() => undefined); // second call succeeds
+
+      renderForm();
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-error-banner')).toBeInTheDocument();
+      });
+
+      // Click retry
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument();
+      });
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('retry button is keyboard-operable (type="button")', async () => {
+      mockSaveContract.mockImplementation(() => { throw new Error('fail'); });
+      renderForm();
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        const retryBtn = screen.getByRole('button', { name: /try again/i });
+        expect(retryBtn).toHaveAttribute('type', 'button');
+      });
+    });
+
+    it('clears validation ErrorSummary when retrying', async () => {
+      // First submit empty to get validation errors, then fix fields and retry
+      renderForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+      await waitFor(() => {
+        expect(screen.getByRole('alert', { name: /there is a problem/i })).toBeInTheDocument();
+      });
+
+      // Now fill fields — validation errors should clear on next submit
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('alert', { name: /there is a problem/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty / load-error state
+  // -------------------------------------------------------------------------
+  describe('empty / load-error state', () => {
+    it('shows load-error banner when loadError is set and initialData is null', () => {
+      renderForm({
+        loadError: 'Failed to load contract data.',
+        initialData: null,
+        onRetryLoad: jest.fn(),
+      });
+
+      expect(screen.getByTestId('form-load-error-banner')).toBeInTheDocument();
+      expect(screen.getByText(/failed to load contract data/i)).toBeInTheDocument();
+    });
+
+    it('hides form fields when in load-error state', () => {
+      renderForm({
+        loadError: 'Failed to load contract data.',
+        initialData: null,
+      });
+
+      expect(screen.queryByLabelText(/contract name/i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/freelancer stellar address/i)).not.toBeInTheDocument();
+    });
+
+    it('calls onRetryLoad when the retry button in load-error banner is clicked', () => {
+      const onRetryLoad = jest.fn();
+      renderForm({
+        loadError: 'Failed to load.',
+        initialData: null,
+        onRetryLoad,
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+      expect(onRetryLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT show load-error banner when loadError is set but initialData is not null', () => {
+      renderForm({
+        loadError: 'Some error',
+        initialData: { contractName: 'My Contract' },
+      });
+
+      expect(screen.queryByTestId('form-load-error-banner')).not.toBeInTheDocument();
+      // Form fields should still be visible
+      expect(screen.getByLabelText(/contract name/i)).toBeInTheDocument();
+    });
+
+    it('does NOT show load-error banner when loadError is null', () => {
+      renderForm({
+        loadError: null,
+        initialData: null,
+      });
+
+      expect(screen.queryByTestId('form-load-error-banner')).not.toBeInTheDocument();
+    });
+
+    it('renders a cancel link in the load-error state', () => {
+      renderForm({
+        loadError: 'Failed to load.',
+        initialData: null,
+      });
+      // The cancel button within the load-error state
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    });
+
+    it('calls onCancel from the load-error cancel button', () => {
+      renderForm({
+        loadError: 'Failed to load.',
+        initialData: null,
+      });
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // State exclusivity
+  // -------------------------------------------------------------------------
+  describe('state exclusivity', () => {
+    it('never shows both ErrorSummary and FormErrorBanner at the same time', async () => {
+      // Validation failure → ErrorSummary only
+      renderForm();
+      fireEvent.click(screen.getByRole('button', { name: /create contract/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert', { name: /there is a problem/i })).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument();
+    });
+
+    it('form-error banner does not appear until submission fails', async () => {
+      renderForm();
+      // No submission yet
+      expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument();
+    });
+
+    it('FormErrorBanner is cleared (not rendered) when there is no submission error', () => {
+      renderForm();
+      expect(screen.queryByTestId('form-error-banner')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // initialData pre-population
+  // -------------------------------------------------------------------------
+  describe('initialData pre-population', () => {
+    it('pre-fills contract name from initialData', () => {
+      renderForm({ initialData: { contractName: 'Pre-filled Contract' } });
+      expect(screen.getByLabelText(/contract name/i)).toHaveValue('Pre-filled Contract');
+    });
+
+    it('pre-fills freelancer address from initialData', () => {
+      renderForm({ initialData: { freelancerAddress: VALID_ADDRESS } });
+      expect(screen.getByLabelText(/freelancer stellar address/i)).toHaveValue(VALID_ADDRESS);
+    });
+
+    it('pre-fills total value from initialData', () => {
+      renderForm({ initialData: { totalValue: '3000' } });
+      expect(screen.getByLabelText(/total value/i)).toHaveValue(3000);
+    });
+
+    it('pre-fills currency from initialData', () => {
+      renderForm({ initialData: { currency: 'EUR' } });
+      expect(screen.getByLabelText(/currency/i)).toHaveValue('EUR');
+    });
+  });
+});

--- a/src/components/milestones/MilestoneCreationForm.tsx
+++ b/src/components/milestones/MilestoneCreationForm.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback, FormEvent } from 'react';
 import { FormField } from '@/components/FormField';
 import { ErrorSummary } from '@/components/ErrorSummary';
+import { FormErrorBanner } from '@/components/FormErrorBanner';
 import { sanitizeUserText } from '@/lib/sanitizeUserText';
 import type { Milestone } from '@/types/domain';
 
@@ -35,38 +36,62 @@ export interface MilestoneCreationFormProps {
    * `listMilestonesByContract` can later resolve it back to that contract.
    */
   contractId?: string;
+  /**
+   * Optional initial data to pre-populate the form fields. When `null` and
+   * `loadError` is set, the form shows an error state instead of a blank form.
+   */
+  initialData?: {
+    title?: string;
+    payout?: string;
+    currency?: string;
+    status?: Milestone['status'];
+    dueDate?: string;
+  } | null;
+  /**
+   * When non-null, a `FormErrorBanner` is shown describing a failure that
+   * occurred before this component mounted (e.g. loading pre-fill data).
+   * Pair with `onRetryLoad` to offer a keyboard-operable retry button.
+   */
+  loadError?: string | null;
+  /** Called when the user clicks "Try again" in the load-error banner. */
+  onRetryLoad?: () => void;
 }
 
 /**
  * Accessible modal form for creating a new milestone.
  *
- * Mirrors the style and accessibility patterns of `ContractCreationForm`:
+ * States:
+ * - **Empty state** — rendered when `loadError` is set and `initialData` is
+ *   `null`, indicating pre-fill data could not be loaded. A `FormErrorBanner`
+ *   with a retry action is shown instead of a blank form body.
+ * - **Error state** — after `onSubmit` throws, a `FormErrorBanner` is shown
+ *   above the submit button with a "Try again" action that re-submits.
+ * - **Loaded / success state** — calls `onSubmit` and the parent dismisses.
+ *
+ * Accessibility contract:
  * - `role="dialog"` / `aria-modal` for correct AT announcement.
  * - `ErrorSummary` with `role="alert"` focus management for invalid submissions.
+ * - `FormErrorBanner` uses `role="alert"` and auto-focuses on mount.
  * - `FormField` handles per-field `aria-invalid`, `aria-describedby`, and
  *   error-border injection.
  * - `id` is generated from the title slug + a timestamp so duplicate titles
  *   never collide across sessions.
- *
- * @example
- * ```tsx
- * <MilestoneCreationForm
- *   onSubmit={(m) => { saveMilestone(m); setMilestones(listMilestones()); }}
- *   onCancel={() => setShowForm(false)}
- * />
- * ```
  */
 export const MilestoneCreationForm: React.FC<MilestoneCreationFormProps> = ({
   onSubmit,
   onCancel,
   contractId,
+  initialData,
+  loadError,
+  onRetryLoad,
 }) => {
-  const [title, setTitle] = useState('');
-  const [payout, setPayout] = useState('');
-  const [currency, setCurrency] = useState<string>('USD');
-  const [status, setStatus] = useState<Milestone['status']>('Pending');
-  const [dueDate, setDueDate] = useState('');
+  const [title, setTitle] = useState(initialData?.title ?? '');
+  const [payout, setPayout] = useState(initialData?.payout ?? '');
+  const [currency, setCurrency] = useState<string>(initialData?.currency ?? 'USD');
+  const [status, setStatus] = useState<Milestone['status']>(initialData?.status ?? 'Pending');
+  const [dueDate, setDueDate] = useState(initialData?.dueDate ?? '');
   const [errors, setErrors] = useState<Array<{ fieldId: string; message: string }>>([]);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   /**
    * Validates form fields and returns an array of error objects.
@@ -101,39 +126,53 @@ export const MilestoneCreationForm: React.FC<MilestoneCreationFormProps> = ({
   }, [title, payout, currency]);
 
   /**
+   * Core submission logic, shared between the form's `onSubmit` handler and
+   * the retry callback on `FormErrorBanner`.
+   */
+  const attemptSubmit = useCallback(() => {
+    const validationErrors = validateForm();
+    setErrors(validationErrors);
+    setSubmitError(null);
+
+    if (validationErrors.length > 0) return;
+
+    // Generate a stable id from title slug + current timestamp
+    const sanitizedTitle = sanitizeUserText(title, MAX_MILESTONE_TITLE_LENGTH);
+    const slug = sanitizedTitle
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    const id = `${slug}-${Date.now()}`;
+
+    const milestone: Milestone = {
+      id,
+      title: sanitizedTitle,
+      status,
+      payout: parseFloat(payout),
+      currency: currency.trim(),
+      dueDate: dueDate.trim() || undefined,
+      contractId,
+    };
+
+    try {
+      onSubmit(milestone);
+    } catch {
+      setSubmitError(
+        'Could not save the milestone. Please check your connection and try again.',
+      );
+    }
+  }, [title, payout, currency, status, dueDate, contractId, validateForm, onSubmit]);
+
+  /**
    * Handles form submission: validates, then calls `onSubmit` with the
    * constructed `Milestone` object on success.
    */
   const handleSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-
-      const validationErrors = validateForm();
-      setErrors(validationErrors);
-
-      if (validationErrors.length > 0) return;
-
-      // Generate a stable id from title slug + current timestamp
-      const sanitizedTitle = sanitizeUserText(title, MAX_MILESTONE_TITLE_LENGTH);
-      const slug = sanitizedTitle
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, '');
-      const id = `${slug}-${Date.now()}`;
-
-      const milestone: Milestone = {
-        id,
-        title: sanitizedTitle,
-        status,
-        payout: parseFloat(payout),
-        currency: currency.trim(),
-        dueDate: dueDate.trim() || undefined,
-        contractId,
-      };
-
-      onSubmit(milestone);
+      attemptSubmit();
     },
-    [title, payout, currency, status, dueDate, contractId, validateForm, onSubmit],
+    [attemptSubmit],
   );
 
   const getFieldError = (fieldId: string): string | undefined =>
@@ -154,105 +193,136 @@ export const MilestoneCreationForm: React.FC<MilestoneCreationFormProps> = ({
           Add Milestone
         </h2>
 
-        <form onSubmit={handleSubmit} noValidate>
-          <ErrorSummary errors={errors} />
-
-          <FormField
-            label="Title"
-            id="milestone-title"
-            error={getFieldError('milestone-title')}
-            required
-          >
-            <input
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="e.g., Frontend Development – Sprint 1"
+        {loadError && initialData === null ? (
+          /* Empty / load-error state — shown when pre-fill data could not be
+             fetched. Gives users actionable guidance instead of a blank form. */
+          <div data-testid="form-load-error">
+            <FormErrorBanner
+              message={loadError}
+              onRetry={onRetryLoad}
+              retryLabel="Try again"
+              testId="form-load-error-banner"
             />
-          </FormField>
+            <p className="mt-2 text-sm text-slate-600">
+              The form could not be loaded. Use the button above to retry, or{' '}
+              <button
+                type="button"
+                onClick={onCancel}
+                className="underline text-blue-600 hover:text-blue-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-blue-600"
+              >
+                cancel
+              </button>{' '}
+              and try again later.
+            </p>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} noValidate>
+            <ErrorSummary errors={errors} />
 
-          <div className="grid grid-cols-2 gap-4">
+            {/* Submission error — shown after onSubmit throws. */}
+            <FormErrorBanner
+              message={submitError}
+              onRetry={attemptSubmit}
+              retryLabel="Try again"
+            />
+
             <FormField
-              label="Payout Amount"
-              id="milestone-payout"
-              error={getFieldError('milestone-payout')}
+              label="Title"
+              id="milestone-title"
+              error={getFieldError('milestone-title')}
               required
             >
               <input
                 type="text"
-                inputMode="decimal"
-                value={payout}
-                onChange={(e) => setPayout(e.target.value)}
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
                 className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                placeholder="e.g., 2500"
+                placeholder="e.g., Frontend Development – Sprint 1"
               />
             </FormField>
 
-            <FormField
-              label="Currency"
-              id="milestone-currency"
-              error={getFieldError('milestone-currency')}
-              required
-            >
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                label="Payout Amount"
+                id="milestone-payout"
+                error={getFieldError('milestone-payout')}
+                required
+              >
+                <input
+                  type="text"
+                  inputMode="decimal"
+                  value={payout}
+                  onChange={(e) => setPayout(e.target.value)}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="e.g., 2500"
+                />
+              </FormField>
+
+              <FormField
+                label="Currency"
+                id="milestone-currency"
+                error={getFieldError('milestone-currency')}
+                required
+              >
+                <select
+                  value={currency}
+                  onChange={(e) => setCurrency(e.target.value)}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  {CURRENCY_OPTIONS.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </FormField>
+            </div>
+
+            <FormField label="Status" id="milestone-status">
               <select
-                value={currency}
-                onChange={(e) => setCurrency(e.target.value)}
+                value={status}
+                onChange={(e) => setStatus(e.target.value as Milestone['status'])}
                 className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
-                {CURRENCY_OPTIONS.map((c) => (
-                  <option key={c} value={c}>
-                    {c}
+                {STATUS_OPTIONS.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
                   </option>
                 ))}
               </select>
             </FormField>
-          </div>
 
-          <FormField label="Status" id="milestone-status">
-            <select
-              value={status}
-              onChange={(e) => setStatus(e.target.value as Milestone['status'])}
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            <FormField
+              label="Due Date"
+              id="milestone-dueDate"
+              helperText="Optional — e.g., Jun 1, 2025"
             >
-              {STATUS_OPTIONS.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </select>
-          </FormField>
+              <input
+                type="text"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Jun 1, 2025"
+              />
+            </FormField>
 
-          <FormField
-            label="Due Date"
-            id="milestone-dueDate"
-            helperText="Optional — e.g., Jun 1, 2025"
-          >
-            <input
-              type="text"
-              value={dueDate}
-              onChange={(e) => setDueDate(e.target.value)}
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="Jun 1, 2025"
-            />
-          </FormField>
-
-          <div className="flex gap-3 justify-end mt-6">
-            <button
-              type="button"
-              onClick={onCancel}
-              className="px-4 py-2 rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-50 font-medium"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 font-medium"
-            >
-              Add Milestone
-            </button>
-          </div>
-        </form>
+            <div className="flex gap-3 justify-end mt-6">
+              <button
+                type="button"
+                onClick={onCancel}
+                className="px-4 py-2 rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-50 font-medium"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 font-medium"
+              >
+                Add Milestone
+              </button>
+            </div>
+          </form>
+        )}
       </div>
     </div>
   );

--- a/src/hooks/__tests__/useFetchState.test.ts
+++ b/src/hooks/__tests__/useFetchState.test.ts
@@ -1,0 +1,270 @@
+import { renderHook, act } from '@testing-library/react';
+import { useFetchState, FetchStatus } from '../useFetchState';
+
+describe('useFetchState', () => {
+  describe('initial state', () => {
+    it('defaults to idle status', () => {
+      const { result } = renderHook(() => useFetchState());
+      expect(result.current.status).toBe('idle');
+    });
+
+    it('accepts a custom initial status', () => {
+      const { result } = renderHook(() => useFetchState('loading'));
+      expect(result.current.status).toBe('loading');
+    });
+
+    it('starts with null errorMessage', () => {
+      const { result } = renderHook(() => useFetchState());
+      expect(result.current.errorMessage).toBeNull();
+    });
+
+    it('starts with all boolean flags false when idle', () => {
+      const { result } = renderHook(() => useFetchState());
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isEmpty).toBe(false);
+      expect(result.current.isError).toBe(false);
+      expect(result.current.isLoaded).toBe(false);
+    });
+  });
+
+  describe('setLoading', () => {
+    it('transitions status to loading', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setLoading());
+      expect(result.current.status).toBe('loading');
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('clears a prior error message', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setError('previous error'));
+      act(() => result.current.setLoading());
+      expect(result.current.errorMessage).toBeNull();
+    });
+
+    it('only isLoading is true — all other flags are false', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setLoading());
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.isEmpty).toBe(false);
+      expect(result.current.isError).toBe(false);
+      expect(result.current.isLoaded).toBe(false);
+    });
+  });
+
+  describe('setLoaded', () => {
+    it('transitions status to loaded', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setLoaded());
+      expect(result.current.status).toBe('loaded');
+      expect(result.current.isLoaded).toBe(true);
+    });
+
+    it('clears a prior error message', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setError('previous error'));
+      act(() => result.current.setLoaded());
+      expect(result.current.errorMessage).toBeNull();
+    });
+
+    it('only isLoaded is true — all other flags are false', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setLoaded());
+      expect(result.current.isLoaded).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isEmpty).toBe(false);
+      expect(result.current.isError).toBe(false);
+    });
+  });
+
+  describe('setEmpty', () => {
+    it('transitions status to empty', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setEmpty());
+      expect(result.current.status).toBe('empty');
+      expect(result.current.isEmpty).toBe(true);
+    });
+
+    it('clears a prior error message', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setError('previous error'));
+      act(() => result.current.setEmpty());
+      expect(result.current.errorMessage).toBeNull();
+    });
+
+    it('only isEmpty is true — all other flags are false', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setEmpty());
+      expect(result.current.isEmpty).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(false);
+      expect(result.current.isLoaded).toBe(false);
+    });
+  });
+
+  describe('setError', () => {
+    it('transitions status to error', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setError('Network failure'));
+      expect(result.current.status).toBe('error');
+      expect(result.current.isError).toBe(true);
+    });
+
+    it('stores the error message', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setError('Network failure'));
+      expect(result.current.errorMessage).toBe('Network failure');
+    });
+
+    it('only isError is true — all other flags are false', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setError('oops'));
+      expect(result.current.isError).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isEmpty).toBe(false);
+      expect(result.current.isLoaded).toBe(false);
+    });
+
+    it('overwrites a prior error message', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setError('first'));
+      act(() => result.current.setError('second'));
+      expect(result.current.errorMessage).toBe('second');
+    });
+  });
+
+  describe('reset', () => {
+    it('transitions back to idle', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setError('oops'));
+      act(() => result.current.reset());
+      expect(result.current.status).toBe('idle');
+    });
+
+    it('clears errorMessage', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setError('oops'));
+      act(() => result.current.reset());
+      expect(result.current.errorMessage).toBeNull();
+    });
+
+    it('all boolean flags are false after reset', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setLoaded());
+      act(() => result.current.reset());
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isEmpty).toBe(false);
+      expect(result.current.isError).toBe(false);
+      expect(result.current.isLoaded).toBe(false);
+    });
+  });
+
+  describe('state exclusivity — only one flag true at a time', () => {
+    const transitions: Array<[string, (r: ReturnType<typeof useFetchState>) => void]> = [
+      ['setLoading', (r) => r.setLoading()],
+      ['setLoaded', (r) => r.setLoaded()],
+      ['setEmpty', (r) => r.setEmpty()],
+      ['setError', (r) => r.setError('err')],
+      ['reset', (r) => r.reset()],
+    ];
+
+    it.each(transitions)('after %s at most one boolean flag is true', (_name, transition) => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => transition(result.current));
+      const flags = [
+        result.current.isLoading,
+        result.current.isEmpty,
+        result.current.isError,
+        result.current.isLoaded,
+      ];
+      const trueCount = flags.filter(Boolean).length;
+      expect(trueCount).toBeLessThanOrEqual(1);
+    });
+
+    it('loading → error: only isError is true', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setLoading());
+      act(() => result.current.setError('fail'));
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(true);
+    });
+
+    it('error → loaded (retry success): only isLoaded is true', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setError('fail'));
+      act(() => result.current.setLoaded());
+      expect(result.current.isError).toBe(false);
+      expect(result.current.errorMessage).toBeNull();
+      expect(result.current.isLoaded).toBe(true);
+    });
+
+    it('loaded → empty: only isEmpty is true', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setLoaded());
+      act(() => result.current.setEmpty());
+      expect(result.current.isLoaded).toBe(false);
+      expect(result.current.isEmpty).toBe(true);
+    });
+  });
+
+  describe('retry re-fetch pattern', () => {
+    it('setLoading clears error before a re-fetch begins', () => {
+      const { result } = renderHook(() => useFetchState());
+
+      // Simulate: fetch → error → retry
+      act(() => result.current.setLoading());
+      act(() => result.current.setError('Timed out'));
+      expect(result.current.isError).toBe(true);
+
+      // User triggers retry
+      act(() => result.current.setLoading());
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.isError).toBe(false);
+      expect(result.current.errorMessage).toBeNull();
+    });
+
+    it('full success lifecycle: idle → loading → loaded', () => {
+      const { result } = renderHook(() => useFetchState());
+      expect(result.current.status).toBe('idle');
+
+      act(() => result.current.setLoading());
+      expect(result.current.status).toBe('loading');
+
+      act(() => result.current.setLoaded());
+      expect(result.current.status).toBe('loaded');
+    });
+
+    it('full error lifecycle: idle → loading → error → loading → loaded', () => {
+      const { result } = renderHook(() => useFetchState());
+
+      act(() => result.current.setLoading());
+      act(() => result.current.setError('Server error'));
+      expect(result.current.status).toBe('error');
+
+      // Retry
+      act(() => result.current.setLoading());
+      expect(result.current.status).toBe('loading');
+
+      act(() => result.current.setLoaded());
+      expect(result.current.status).toBe('loaded');
+      expect(result.current.errorMessage).toBeNull();
+    });
+
+    it('full empty lifecycle: idle → loading → empty', () => {
+      const { result } = renderHook(() => useFetchState());
+      act(() => result.current.setLoading());
+      act(() => result.current.setEmpty());
+      expect(result.current.status).toBe('empty');
+      expect(result.current.errorMessage).toBeNull();
+    });
+  });
+
+  describe('valid FetchStatus values', () => {
+    const statuses: FetchStatus[] = ['idle', 'loading', 'error', 'empty', 'loaded'];
+
+    it.each(statuses)('accepts "%s" as initial status', (s) => {
+      const { result } = renderHook(() => useFetchState(s));
+      expect(result.current.status).toBe(s);
+    });
+  });
+});

--- a/src/hooks/useFetchState.ts
+++ b/src/hooks/useFetchState.ts
@@ -1,0 +1,120 @@
+import { useState, useCallback } from 'react';
+
+/**
+ * The four mutually exclusive fetch states for a data-loading operation.
+ *
+ * - `idle` — no fetch has started yet (initial state).
+ * - `loading` — a fetch is in flight.
+ * - `error` — the last fetch failed.
+ * - `empty` — the fetch succeeded but returned no usable data.
+ * - `loaded` — the fetch succeeded and data is available.
+ */
+export type FetchStatus = 'idle' | 'loading' | 'error' | 'empty' | 'loaded';
+
+export interface UseFetchStateReturn {
+  /** The current status of the fetch operation. Exactly one value at a time. */
+  status: FetchStatus;
+  /** The error message when `status === 'error'`, otherwise `null`. */
+  errorMessage: string | null;
+  /** `true` only while `status === 'loading'`. */
+  isLoading: boolean;
+  /** `true` only while `status === 'empty'`. */
+  isEmpty: boolean;
+  /** `true` only while `status === 'error'`. */
+  isError: boolean;
+  /** `true` only while `status === 'loaded'`. */
+  isLoaded: boolean;
+  /** Transition to the `loading` state and clear any previous error. */
+  setLoading: () => void;
+  /** Transition to the `loaded` state and clear any previous error. */
+  setLoaded: () => void;
+  /** Transition to the `empty` state and clear any previous error. */
+  setEmpty: () => void;
+  /**
+   * Transition to the `error` state with the supplied message.
+   * @param message - A user-readable description of what went wrong.
+   */
+  setError: (message: string) => void;
+  /** Transition back to the `idle` state and clear any previous error. */
+  reset: () => void;
+}
+
+/**
+ * `useFetchState` — a lightweight hook that manages the four mutually
+ * exclusive states for a data-loading operation: idle, loading, empty,
+ * error, and loaded.
+ *
+ * This hook encapsulates the pattern already used in
+ * `src/app/contracts/[id]/page.tsx` and `ActionPanel` — where `isLoading`,
+ * `errorMessage`, and `setErrorMessage` are managed in parallel — and exposes
+ * them through a single, type-safe API.
+ *
+ * State exclusivity is enforced: every transition setter first sets
+ * `status` to the target value before updating `errorMessage`, so callers
+ * never observe a combination like `{ isLoading: true, isError: true }`.
+ *
+ * @param initial - Optional starting state. Defaults to `'idle'`.
+ *
+ * @example
+ * ```tsx
+ * const { isLoading, isEmpty, isError, errorMessage, setLoading, setLoaded, setEmpty, setError } =
+ *   useFetchState();
+ *
+ * const load = async () => {
+ *   setLoading();
+ *   try {
+ *     const data = await fetchData();
+ *     if (!data || data.length === 0) {
+ *       setEmpty();
+ *     } else {
+ *       setLoaded();
+ *     }
+ *   } catch (err) {
+ *     setError(err instanceof Error ? err.message : 'Failed to load data.');
+ *   }
+ * };
+ * ```
+ */
+export function useFetchState(initial: FetchStatus = 'idle'): UseFetchStateReturn {
+  const [status, setStatus] = useState<FetchStatus>(initial);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const setLoading = useCallback(() => {
+    setStatus('loading');
+    setErrorMessage(null);
+  }, []);
+
+  const setLoaded = useCallback(() => {
+    setStatus('loaded');
+    setErrorMessage(null);
+  }, []);
+
+  const setEmpty = useCallback(() => {
+    setStatus('empty');
+    setErrorMessage(null);
+  }, []);
+
+  const setError = useCallback((message: string) => {
+    setStatus('error');
+    setErrorMessage(message);
+  }, []);
+
+  const reset = useCallback(() => {
+    setStatus('idle');
+    setErrorMessage(null);
+  }, []);
+
+  return {
+    status,
+    errorMessage,
+    isLoading: status === 'loading',
+    isEmpty: status === 'empty',
+    isError: status === 'error',
+    isLoaded: status === 'loaded',
+    setLoading,
+    setLoaded,
+    setEmpty,
+    setError,
+    reset,
+  };
+}


### PR DESCRIPTION
- Add FormErrorBanner component (role=alert, auto-focus, retry button)
- Add useFetchState hook (idle|loading|empty|error|loaded exclusivity)
- Add submission error state + retry to ContractCreationForm
- Add submission error state + retry to MilestoneCreationForm
- Add submission error state + retry to CreateContractForm
- Add load-error (empty) state + onRetryLoad to all three forms
- Add initialData pre-population prop to all three forms

Tests: 126 new tests across 5 new test files (1246 total, all passing)
Lint: clean (eslint exit 0)

## Description

<!-- Summarize the changes in this PR and the motivation behind them. -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

<!-- Briefly describe the test cases you added or updated, and any manual testing performed. -->

---

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->

### Security

<!-- Does this PR touch authentication, authorization, wallet logic, API calls, or
     user-supplied input? Describe any security considerations or "N/A" if not applicable. -->

closes #536