### PR TITLE
feat(milestones): add empty and error states

### DIFF
--- a/src/app/__tests__/milestones-error-state.test.tsx
+++ b/src/app/__tests__/milestones-error-state.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * Tests for the milestones view's distinct empty and error states.
+ *
+ * Coverage targets:
+ *  - Error state renders when the repository read throws, distinct from the
+ *    empty state and the loaded list.
+ *  - Error state is announced to assistive tech via role="alert" and
+ *    aria-live="assertive".
+ *  - Empty state is announced to assistive tech via role="status" and
+ *    aria-live="polite".
+ *  - Retry is a native, keyboard-operable button that re-invokes the load
+ *    and clears the error on success.
+ *  - Loading/empty/error/success states are mutually exclusive.
+ *  - Accessibility: axe checks for both the empty and error states.
+ */
+
+import React from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import MilestonesPage, { SAMPLE_DISMISSED_KEY } from '../milestones/page';
+import { listMilestones, saveMilestone } from '@/lib/repository';
+import type { Milestone } from '@/types/domain';
+
+// ---------------------------------------------------------------------------
+// Navigation mocks
+// ---------------------------------------------------------------------------
+
+const mockSearchParams = {
+  get: jest.fn(() => null),
+  toString: jest.fn(() => ''),
+};
+const mockReplace = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ replace: mockReplace, push: jest.fn(), prefetch: jest.fn() }),
+}));
+
+jest.mock('@/lib/repository', () => ({
+  listMilestones: jest.fn(),
+  saveMilestone: jest.fn(),
+}));
+
+const mockedListMilestones = jest.mocked(listMilestones);
+const mockedSaveMilestone = jest.mocked(saveMilestone);
+
+const persistedMilestones: Milestone[] = [
+  {
+    id: 'repo-1',
+    title: 'Repository Kickoff',
+    status: 'Pending',
+    payout: 1800,
+    currency: 'USD',
+    dueDate: '2026-07-01',
+  },
+];
+
+async function renderPage() {
+  const result = render(<MilestonesPage />);
+  await act(async () => {});
+  return result;
+}
+
+beforeEach(() => {
+  mockedListMilestones.mockReset();
+  mockedSaveMilestone.mockReset();
+  mockedSaveMilestone.mockImplementation(() => {});
+  window.localStorage.clear();
+  mockSearchParams.get.mockReturnValue(null);
+  mockSearchParams.toString.mockReturnValue('');
+  mockReplace.mockReset();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  window.localStorage.clear();
+});
+
+// ===========================================================================
+// Error state rendering
+// ===========================================================================
+
+describe('MilestonesPage — error state', () => {
+  it('renders a distinct error state when loading milestones throws', async () => {
+    mockedListMilestones.mockImplementation(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    await renderPage();
+
+    expect(screen.getByTestId('milestones-error')).toBeInTheDocument();
+    expect(screen.getByText('Failed to load milestones')).toBeInTheDocument();
+    expect(screen.getAllByText('Storage unavailable').length).toBeGreaterThan(0);
+  });
+
+  it('falls back to a generic message when the thrown value is not an Error', async () => {
+    mockedListMilestones.mockImplementation(() => {
+      throw 'boom';
+    });
+
+    await renderPage();
+
+    expect(screen.getByTestId('milestones-error')).toBeInTheDocument();
+    expect(screen.getAllByText('Failed to load milestones.').length).toBeGreaterThan(0);
+  });
+
+  it('does not render the milestones list, empty state, or sample banner while errored', async () => {
+    mockedListMilestones.mockImplementation(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    await renderPage();
+
+    expect(screen.queryByText('No milestones tracked')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sample-data-banner')).not.toBeInTheDocument();
+    expect(screen.queryByRole('radiogroup')).not.toBeInTheDocument();
+    expect(screen.queryByText('Repository Kickoff')).not.toBeInTheDocument();
+  });
+
+  it('announces the error for assistive tech via role="alert" and aria-live="assertive"', async () => {
+    mockedListMilestones.mockImplementation(() => {
+      throw new Error('Network down');
+    });
+
+    await renderPage();
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveTextContent('Network down');
+  });
+
+  it('renders a keyboard-operable Retry button with an accessible name', async () => {
+    mockedListMilestones.mockImplementation(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    await renderPage();
+
+    const retryButton = screen.getByRole('button', { name: /retry loading milestones/i });
+    expect(retryButton).toBeInTheDocument();
+    expect(retryButton.tagName).toBe('BUTTON');
+    expect(retryButton).toHaveAttribute('type', 'button');
+  });
+
+  it('re-fetches and clears the error when Retry is clicked and the retry succeeds', async () => {
+    mockedListMilestones
+      .mockImplementationOnce(() => {
+        throw new Error('Storage unavailable');
+      })
+      .mockReturnValue(persistedMilestones);
+
+    const user = userEvent.setup();
+    await renderPage();
+
+    expect(screen.getByTestId('milestones-error')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /retry loading milestones/i }));
+
+    expect(screen.queryByTestId('milestones-error')).not.toBeInTheDocument();
+    expect(screen.getByText('Repository Kickoff')).toBeInTheDocument();
+    expect(mockedListMilestones).toHaveBeenCalledTimes(2);
+  });
+
+  it('is operable via the keyboard (Enter key) and re-fetches', async () => {
+    mockedListMilestones
+      .mockImplementationOnce(() => {
+        throw new Error('Storage unavailable');
+      })
+      .mockReturnValue(persistedMilestones);
+
+    await renderPage();
+
+    const retryButton = screen.getByRole('button', { name: /retry loading milestones/i });
+    retryButton.focus();
+    fireEvent.keyDown(retryButton, { key: 'Enter', code: 'Enter' });
+    fireEvent.click(retryButton); // native <button> activates on Enter via click in jsdom/user-event
+
+    expect(screen.getByText('Repository Kickoff')).toBeInTheDocument();
+  });
+
+  it('remains in the error state if a retry attempt also fails', async () => {
+    mockedListMilestones.mockImplementation(() => {
+      throw new Error('Still down');
+    });
+
+    const user = userEvent.setup();
+    await renderPage();
+
+    await user.click(screen.getByRole('button', { name: /retry loading milestones/i }));
+
+    expect(screen.getByTestId('milestones-error')).toBeInTheDocument();
+    expect(screen.getAllByText('Still down').length).toBeGreaterThan(0);
+    expect(mockedListMilestones).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes axe checks in the error state', async () => {
+    mockedListMilestones.mockImplementation(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    const { container } = await renderPage();
+    expect(await axe(container)).toHaveNoViolations();
+  }, 20000);
+});
+
+// ===========================================================================
+// Empty state — accessible announcement
+// ===========================================================================
+
+describe('MilestonesPage — empty state announcement', () => {
+  it('announces "No milestones tracked" via role="status" and aria-live="polite"', async () => {
+    window.localStorage.setItem(SAMPLE_DISMISSED_KEY, 'true');
+    mockedListMilestones.mockReturnValue([]);
+
+    await renderPage();
+
+    const announcer = screen.getByRole('status');
+    expect(announcer).toHaveAttribute('aria-live', 'polite');
+    expect(announcer).toHaveTextContent('No milestones tracked');
+  });
+
+  it('does not render the error state while empty', async () => {
+    window.localStorage.setItem(SAMPLE_DISMISSED_KEY, 'true');
+    mockedListMilestones.mockReturnValue([]);
+
+    await renderPage();
+
+    expect(screen.queryByTestId('milestones-error')).not.toBeInTheDocument();
+  });
+
+  it('passes axe checks in the empty state', async () => {
+    window.localStorage.setItem(SAMPLE_DISMISSED_KEY, 'true');
+    mockedListMilestones.mockReturnValue([]);
+
+    const { container } = await renderPage();
+    expect(await axe(container)).toHaveNoViolations();
+  }, 20000);
+});
+
+// ===========================================================================
+// Success state — accessible announcement
+// ===========================================================================
+
+describe('MilestonesPage — success state announcement', () => {
+  it('announces the loaded milestone count via role="status" and aria-live="polite"', async () => {
+    mockedListMilestones.mockReturnValue(persistedMilestones);
+
+    await renderPage();
+
+    expect(screen.getByText('1 milestone loaded')).toBeInTheDocument();
+  });
+
+  it('uses the plural form when more than one milestone is loaded', async () => {
+    mockedListMilestones.mockReturnValue([
+      ...persistedMilestones,
+      { id: 'repo-2', title: 'Second', status: 'Pending', payout: 100, currency: 'USD', dueDate: '2026-08-01' },
+    ]);
+
+    await renderPage();
+
+    expect(screen.getByText('2 milestones loaded')).toBeInTheDocument();
+  });
+});
+
+// ===========================================================================
+// State exclusivity
+// ===========================================================================
+
+describe('MilestonesPage — fetch-state exclusivity', () => {
+  it('shows only the error state, never the empty state, when the load fails with no data', async () => {
+    mockedListMilestones.mockImplementation(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    await renderPage();
+
+    expect(screen.getByTestId('milestones-error')).toBeInTheDocument();
+    expect(screen.queryByText('No milestones tracked')).not.toBeInTheDocument();
+  });
+
+  it('shows only the loaded content, never an error, when the load succeeds', async () => {
+    mockedListMilestones.mockReturnValue(persistedMilestones);
+
+    await renderPage();
+
+    expect(screen.queryByTestId('milestones-error')).not.toBeInTheDocument();
+    expect(screen.getByText('Repository Kickoff')).toBeInTheDocument();
+  });
+});

--- a/src/app/__tests__/milestones-sample-banner.test.tsx
+++ b/src/app/__tests__/milestones-sample-banner.test.tsx
@@ -219,7 +219,7 @@ describe('"Start from scratch" dismissal', () => {
 
     await user.click(screen.getByTestId('start-from-scratch-btn'));
 
-    expect(screen.getByText('No milestones tracked')).toBeInTheDocument();
+    expect(screen.getAllByText('No milestones tracked').length).toBeGreaterThan(0);
     expect(screen.queryByText('Project Kickoff & Discovery')).not.toBeInTheDocument();
   });
 
@@ -265,7 +265,7 @@ describe('close (×) button dismissal', () => {
 
     await user.click(screen.getByRole('button', { name: /dismiss sample data notice/i }));
 
-    expect(screen.getByText('No milestones tracked')).toBeInTheDocument();
+    expect(screen.getAllByText('No milestones tracked').length).toBeGreaterThan(0);
   });
 });
 
@@ -412,7 +412,7 @@ describe('interaction with existing page behaviour', () => {
 
     await user.click(screen.getByTestId('start-from-scratch-btn'));
 
-    expect(screen.getByText('No milestones tracked')).toBeInTheDocument();
+    expect(screen.getAllByText('No milestones tracked').length).toBeGreaterThan(0);
     expect(
       screen.getByText(/track your progress by adding milestones/i),
     ).toBeInTheDocument();

--- a/src/app/milestones/__tests__/page.test.tsx
+++ b/src/app/milestones/__tests__/page.test.tsx
@@ -159,7 +159,16 @@ describe('MilestonesPage — core rendering', () => {
     window.localStorage.setItem(SAMPLE_DISMISSED_KEY, 'true');
     await renderPage();
 
-    expect(screen.getByText('No milestones tracked')).toBeInTheDocument();
+    expect(screen.getAllByText('No milestones tracked').length).toBeGreaterThan(0);
+  });
+
+  it('announces the empty state for assistive tech via role="status" and aria-live="polite"', async () => {
+    window.localStorage.setItem(SAMPLE_DISMISSED_KEY, 'true');
+    await renderPage();
+
+    const announcer = screen.getByRole('status');
+    expect(announcer).toHaveAttribute('aria-live', 'polite');
+    expect(announcer).toHaveTextContent('No milestones tracked');
   });
 });
 

--- a/src/app/milestones/page.tsx
+++ b/src/app/milestones/page.tsx
@@ -9,6 +9,7 @@ import { MilestoneCreationForm } from '../../components/milestones/MilestoneCrea
 import { listMilestones, saveMilestone } from '@/lib/repository';
 import { getItem, setItem } from '@/lib/safeStorage';
 import type { Milestone } from '@/types/domain';
+import type { FetchState } from '@/hooks/useFetchState';
 
 export const SAMPLE_DISMISSED_KEY = 'talenttrust-milestones-sample-dismissed';
 
@@ -133,6 +134,7 @@ const MilestonesContent: React.FC = () => {
   const [statusFilter, setStatusFilter] = useState<MilestoneStatusFilter>(initialStatus);
   const [sortBy, setSortBy] = useState<MilestoneSortOption>(DEFAULT_PREFERENCES.sort);
   const [showForm, setShowForm] = useState(false);
+  const [loadError, setLoadError] = useState<Error | null>(null);
 
   // Sync state if searchParams change externally (e.g. back/forward navigation)
   useEffect(() => {
@@ -150,6 +152,34 @@ const MilestonesContent: React.FC = () => {
     }
   }, [statusFilter, router, searchParams]);
 
+  /**
+   * Loads persisted milestones from the repository. Reused on mount and as the
+   * keyboard-operable "Retry" action in the error state — `listMilestones` is
+   * documented as never throwing, but the repository read is wrapped here so a
+   * future storage failure (or a thrown error in tests) surfaces as a distinct,
+   * announced error state instead of leaving the page blank.
+   */
+  const loadMilestonesData = useCallback(() => {
+    try {
+      const persisted = listMilestones();
+      setLoadError(null);
+      if (persisted.length > 0) {
+        setMilestones(persisted);
+        setIsDismissed(true);
+      } else {
+        try {
+          const dismissed = getItem(SAMPLE_DISMISSED_KEY) === 'true';
+          setIsDismissed(dismissed);
+        } catch {
+          setIsDismissed(true);
+        }
+        setMilestones(SAMPLE_MILESTONES);
+      }
+    } catch (err) {
+      setLoadError(err instanceof Error ? err : new Error('Failed to load milestones.'));
+    }
+  }, []);
+
   // Rehydrate from localStorage after the client mounts to avoid SSR mismatches.
   useEffect(() => {
     // Load preferences
@@ -166,20 +196,12 @@ const MilestonesContent: React.FC = () => {
       setSortBy('dueDate-asc');
     }
 
-    const persisted = listMilestones();
-    if (persisted.length > 0) {
-      setMilestones(persisted);
-      setIsDismissed(true);
-    } else {
-      try {
-        const dismissed = getItem(SAMPLE_DISMISSED_KEY) === 'true';
-        setIsDismissed(dismissed);
-      } catch {
-        setIsDismissed(true);
-      }
-      setMilestones(SAMPLE_MILESTONES);
-    }
+    loadMilestonesData();
   }, []);
+
+  const handleRetry = useCallback(() => {
+    loadMilestonesData();
+  }, [loadMilestonesData]);
 
   // Persist preferences to storage on state change
   const isMounted = useRef(false);
@@ -222,6 +244,13 @@ const MilestonesContent: React.FC = () => {
   const isUsingSampleData = milestones === SAMPLE_MILESTONES;
   const showSampleBanner = isUsingSampleData && !isDismissed;
   const displayMilestones = isUsingSampleData && isDismissed ? [] : milestones;
+
+  // Fetch-state model shared with other views (see hooks/useFetchState.ts):
+  // 'error' takes precedence, then 'empty', then 'success' — mutually exclusive
+  // so exactly one state renders at a time.
+  const pageState: FetchState = loadError ? 'error' : displayMilestones.length === 0 ? 'empty' : 'success';
+  const loadErrorMessage =
+    loadError?.message || 'Failed to load milestones. Please check your connection and try again.';
 
   const filtered = useMemo(() => {
     if (statusFilter === 'All') return displayMilestones;
@@ -276,7 +305,52 @@ const MilestonesContent: React.FC = () => {
     <main className="min-h-screen p-8">
       <h1 className="text-2xl font-bold mb-6">Milestones</h1>
 
-      {showSampleBanner && (
+      {pageState === 'error' ? (
+        <>
+          <div role="alert" aria-live="assertive" aria-atomic="true" className="sr-only">
+            {loadErrorMessage}
+          </div>
+          <div
+            data-testid="milestones-error"
+            className="flex flex-col items-center justify-center rounded-3xl border border-red-200 bg-red-50 p-8 text-center shadow-sm max-w-2xl mx-auto my-8"
+          >
+            <div
+              className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-2xl bg-red-100 text-red-600 ring-1 ring-red-200"
+              aria-hidden="true"
+            >
+              <svg
+                className="h-8 w-8"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+            </div>
+            <h2 className="mb-2 text-xl font-semibold text-red-950">
+              Failed to load milestones
+            </h2>
+            <p className="mb-6 max-w-md text-sm leading-6 text-red-800">
+              {loadErrorMessage}
+            </p>
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="rounded-xl bg-red-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-red-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-red-900"
+              aria-label="Retry loading milestones"
+            >
+              Retry
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          {showSampleBanner && (
         <div
           data-testid="sample-data-banner"
           role="status"
@@ -313,16 +387,24 @@ const MilestonesContent: React.FC = () => {
         </div>
       )}
 
-      {displayMilestones.length === 0 ? (
-        <EmptyState
-          illustration="milestones"
-          title="No milestones tracked"
-          description="Track your progress by adding milestones to your contracts. Milestones help you stay organized and ensure timely delivery."
-          actionLabel="Add Milestone"
-          onAction={handleAddMilestone}
-        />
+      {pageState === 'empty' ? (
+        <>
+          <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+            No milestones tracked
+          </div>
+          <EmptyState
+            illustration="milestones"
+            title="No milestones tracked"
+            description="Track your progress by adding milestones to your contracts. Milestones help you stay organized and ensure timely delivery."
+            actionLabel="Add Milestone"
+            onAction={handleAddMilestone}
+          />
+        </>
       ) : (
         <>
+          <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+            {`${displayMilestones.length} milestone${displayMilestones.length === 1 ? '' : 's'} loaded`}
+          </div>
           <div className="mb-4 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
             <div className="flex flex-wrap items-center gap-4">
               <MilestoneFilter
@@ -370,6 +452,8 @@ const MilestonesContent: React.FC = () => {
             <MilestonesList milestones={sortedAndFiltered} />
           )}
         </>
+      )}
+      </>
       )}
 
       {showForm && (


### PR DESCRIPTION
## Summary

- Adds a distinct, accessible **error state** (with keyboard-operable Retry) to the milestones view, alongside the existing empty state — previously a failed load left the page blank with no guidance.
- Reuses the app's existing fetch-state model (`FetchState` from `src/hooks/useFetchState.ts`), matching the pattern already used on the reputation and settings pages: `pageState` resolves to `'error' | 'empty' | 'success'` and drives mutually-exclusive rendering.
- Both the error and empty states are announced to assistive tech via paired `sr-only` live regions (`role="alert"`/`aria-live="assertive"` for errors, `role="status"`/`aria-live="polite"` for empty/loaded), mirroring `src/app/reputation/page.tsx`.
- The milestone load (`listMilestones()`) is now wrapped in try/catch and extracted into a reusable `loadMilestonesData` callback, invoked on mount and by the Retry button — a native `<button type="button">`, so it's keyboard-operable by default.

## Changes

- `src/app/milestones/page.tsx`
  - New `loadError` state + `loadMilestonesData`/`handleRetry` callbacks.
  - New `pageState` (`error` / `empty` / `success`) computed with error taking precedence.
  - New error-state UI (red card, warning icon, message, Retry button) with an `sr-only` `role="alert"` announcement.
  - Added `sr-only` `role="status"` announcements for the empty state and the loaded-count success state (previously unannounced).
- `src/app/__tests__/milestones-error-state.test.tsx` (new) — 16 tests covering: error rendering, generic-message fallback for non-Error throws, error hides list/empty/banner, `role="alert"`/`aria-live="assertive"` announcement, keyboard-operable Retry with accessible name, retry re-fetch on success and on repeated failure, empty/success `role="status"` announcements, state exclusivity, and axe accessibility checks for both states.
- `src/app/milestones/__tests__/page.test.tsx`, `src/app/__tests__/milestones-sample-banner.test.tsx` — updated `getByText('No milestones tracked')` assertions to `getAllByText(...)` since the new `sr-only` announcement now renders that text a second time (same convention already used in the reputation page's tests), plus one new test asserting the empty-state announcement.

## Test plan

- [x] `npm run lint` — clean on all touched files. (Repo-wide `npm run lint` reports 2 pre-existing errors in `src/components/__tests__/Navbar.test.tsx`, unrelated to this change and present on `main` before this branch — confirmed via `git stash`.)
- [x] `npm test` — full suite: `1622 passed / 25 failed` (same 25 pre-existing failures as on `main`, confirmed unrelated via `git stash` — mostly test-isolation flakiness in unrelated files). Milestones-scoped suite: `107 passed / 2 failed`, the 2 failures are the same pre-existing flaky tests in `page.test.tsx` (`Verifies sorting...`, `announces correct count...`) that already fail on `main` in isolated runs but pass in the full suite (25/25 matches baseline exactly).
- [x] `npm run build` — succeeds, `/milestones` still prerenders as static.
- [x] New `milestones-error-state.test.tsx` — 16/16 passing, including empty vs error vs loading exclusivity and retry re-fetch on both success and repeated failure.
- [x] Manually verified in a running instance (production `next start` build): default sample-data view renders correctly, and clicking "Start from scratch" correctly dismisses the banner and shows the new-announced "No milestones tracked" empty state with no console errors.

### Full test output (milestones-scoped)

```
PASS src/app/__tests__/milestones-sample-banner.test.tsx
PASS src/app/__tests__/milestones-error-state.test.tsx
PASS src/app/__tests__/milestones-filter-url.test.tsx
PASS src/app/milestones/__tests__/page.ssr.test.tsx
FAIL src/app/milestones/__tests__/page.test.tsx (pre-existing, unrelated flaky tests — see note above)

Test Suites: 1 failed, 4 passed, 5 total
Tests:       2 failed, 107 passed, 109 total
```

### Full suite (matches main's baseline exactly)

```
Test Suites: 4 failed, 79 passed, 83 total
Tests:       25 failed, 1622 passed, 1647 total
```

Closes Talenttrust/Talenttrust-Frontend#521

🤖 Generated with [Claude Code](https://claude.com/claude-code)