### PR TITLE
feat: add client-side validation to toast inputs

### DIFF
--- a/src/components/toast/__tests__/toast-demo.test.tsx
+++ b/src/components/toast/__tests__/toast-demo.test.tsx
@@ -1,0 +1,100 @@
+/// <reference types="jest" />
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ToastDemo } from '../toast-demo';
+import { ToastProvider } from '../toast-provider';
+import { PreferencesProvider } from '@/lib/preferences';
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(
+    <PreferencesProvider>
+      <ToastProvider>{ui}</ToastProvider>
+    </PreferencesProvider>
+  );
+};
+
+describe('ToastDemo validation', () => {
+  it('renders with default valid values', () => {
+    renderWithProviders(<ToastDemo />);
+    expect(screen.getByLabelText(/title/i)).toHaveValue('Milestone released');
+    expect(screen.getByLabelText(/description/i)).toHaveValue('Funds are on the way to the freelancer wallet.');
+  });
+
+  it('shows error and blocks submit when title is empty', () => {
+    renderWithProviders(<ToastDemo />);
+    const titleInput = screen.getByLabelText(/title/i);
+    
+    // Clear title
+    fireEvent.change(titleInput, { target: { value: '   ' } });
+    
+    // Try to submit
+    const successBtn = screen.getByRole('button', { name: /show success/i });
+    fireEvent.click(successBtn);
+    
+    // Validation error should appear
+    expect(screen.getByRole('alert')).toHaveTextContent('Title is required');
+    expect(titleInput).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('shows error when title is out of range', () => {
+    renderWithProviders(<ToastDemo />);
+    const titleInput = screen.getByLabelText(/title/i);
+    
+    // Set a very long title
+    const longTitle = 'a'.repeat(51);
+    fireEvent.change(titleInput, { target: { value: longTitle } });
+    
+    fireEvent.click(screen.getByRole('button', { name: /show success/i }));
+    
+    expect(screen.getByRole('alert')).toHaveTextContent('Title must be 50 characters or less');
+  });
+
+  it('shows error when description is out of range', () => {
+    renderWithProviders(<ToastDemo />);
+    const descInput = screen.getByLabelText(/description/i);
+    
+    // Set a very long description
+    const longDesc = 'a'.repeat(201);
+    fireEvent.change(descInput, { target: { value: longDesc } });
+    
+    fireEvent.click(screen.getByRole('button', { name: /show success/i }));
+    
+    expect(screen.getByRole('alert')).toHaveTextContent('Description must be 200 characters or less');
+  });
+
+  it('shows error when duration is invalid format or out of range', () => {
+    renderWithProviders(<ToastDemo />);
+    const durationInput = screen.getByLabelText(/duration/i);
+    
+    // Set invalid duration
+    fireEvent.change(durationInput, { target: { value: '500' } });
+    fireEvent.click(screen.getByRole('button', { name: /show success/i }));
+    
+    expect(screen.getByRole('alert')).toHaveTextContent('Duration must be between 1000 and 60000 ms');
+  });
+
+  it('submits valid input successfully and clears errors', () => {
+    renderWithProviders(<ToastDemo />);
+    const titleInput = screen.getByLabelText(/title/i);
+    
+    // Trigger an error first
+    fireEvent.change(titleInput, { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /show success/i }));
+    
+    // In our implementation we used standard `alert` role for form errors
+    // Since FormField sets `role="alert"` for the error, there should be one
+    expect(screen.getAllByRole('alert').length).toBeGreaterThan(0);
+    
+    // Fix the error
+    fireEvent.change(titleInput, { target: { value: 'Valid Title' } });
+    fireEvent.click(screen.getByRole('button', { name: /show error/i }));
+    
+    // Error should be gone (the validation error text shouldn't be there)
+    expect(screen.queryByText('Title is required')).not.toBeInTheDocument();
+    
+    // The error toast itself acts as an alert for the notification.
+    // The previous error was a validation alert. The new one is the toast itself.
+    // The toast contains the title text.
+    expect(screen.getByText('Valid Title')).toBeInTheDocument();
+  });
+});

--- a/src/components/toast/toast-demo.tsx
+++ b/src/components/toast/toast-demo.tsx
@@ -1,36 +1,115 @@
 'use client';
 
+import { useState } from 'react';
 import { useToast } from './toast-provider';
+import { FormField } from '../FormField';
 
 export function ToastDemo() {
   const { showError, showSuccess } = useToast();
+  
+  const [title, setTitle] = useState('Milestone released');
+  const [description, setDescription] = useState('Funds are on the way to the freelancer wallet.');
+  const [duration, setDuration] = useState('');
+  const [errors, setErrors] = useState<{ fieldId: string; message: string }[]>([]);
+
+  const validate = () => {
+    const newErrors: { fieldId: string; message: string }[] = [];
+    
+    if (!title.trim()) {
+      newErrors.push({ fieldId: 'title', message: 'Title is required' });
+    } else if (title.length > 50) {
+      newErrors.push({ fieldId: 'title', message: 'Title must be 50 characters or less' });
+    }
+
+    if (description && description.length > 200) {
+      newErrors.push({ fieldId: 'description', message: 'Description must be 200 characters or less' });
+    }
+    
+    if (duration) {
+      const durationMs = parseInt(duration, 10);
+      if (isNaN(durationMs) || durationMs < 1000 || durationMs > 60000) {
+        newErrors.push({ fieldId: 'duration', message: 'Duration must be between 1000 and 60000 ms' });
+      }
+    }
+
+    setErrors(newErrors);
+    return newErrors.length === 0;
+  };
+
+  const handleSubmit = (variant: 'success' | 'error') => {
+    if (!validate()) return;
+    
+    const toastData = {
+      title: title.trim(),
+      description: description.trim() || undefined,
+      duration: duration ? parseInt(duration, 10) : undefined,
+    };
+
+    if (variant === 'success') {
+      showSuccess(toastData);
+    } else {
+      showError(toastData);
+    }
+  };
+
+  const getError = (fieldId: string) => errors.find((e) => e.fieldId === fieldId)?.message;
 
   return (
-    <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-      <button
-        className="rounded-full bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-400"
-        onClick={() =>
-          showSuccess({
-            title: 'Milestone released',
-            description: 'Funds are on the way to the freelancer wallet.',
-          })
-        }
-        type="button"
+    <div className="mt-8 flex flex-col items-center justify-center gap-6 w-full max-w-md mx-auto">
+      <form
+        className="w-full bg-white p-6 rounded-xl border border-slate-200 shadow-sm"
+        onSubmit={(e) => { e.preventDefault(); handleSubmit('success'); }}
+        noValidate
       >
-        Show success toast
-      </button>
-      <button
-        className="rounded-full border border-rose-200 bg-white px-5 py-3 text-sm font-semibold text-rose-700 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-300"
-        onClick={() =>
-          showError({
-            title: 'Wallet not connected',
-            description: 'Connect a wallet before approving this release.',
-          })
-        }
-        type="button"
-      >
-        Show error toast
-      </button>
+        <h3 className="text-lg font-semibold text-slate-900 mb-4">Test Notifications</h3>
+        
+        <FormField label="Title" id="title" error={getError('title')} required>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg border border-slate-200 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500"
+          />
+        </FormField>
+        
+        <FormField label="Description" id="description" error={getError('description')}>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg border border-slate-200 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500"
+            rows={2}
+          />
+        </FormField>
+        
+        <FormField label="Duration (ms)" id="duration" error={getError('duration')} helperText="Optional. Overrides default duration.">
+          <input
+            type="number"
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg border border-slate-200 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500"
+            placeholder="e.g. 5000"
+          />
+        </FormField>
+
+        <div className="flex gap-3 mt-6">
+          <button
+            type="button"
+            onClick={() => handleSubmit('success')}
+            
+            className="flex-1 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-400 disabled:opacity-50"
+          >
+            Show Success
+          </button>
+          <button
+            type="button"
+            onClick={() => handleSubmit('error')}
+            
+            className="flex-1 rounded-full border border-rose-200 bg-white px-4 py-2 text-sm font-semibold text-rose-700 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-300 disabled:opacity-50"
+          >
+            Show Error
+          </button>
+        </div>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
**What was done**
- Converted `ToastDemo` into an interactive form with inputs for Title, Description, and Duration.
- Implemented client-side validation rules (required fields, max length for strings, and numeric ranges).
- Added accessible inline error messaging using the native `FormField` component (`aria-describedby` and `role="alert"`).
- Blocked form submission entirely when the input data is invalid.
- Added comprehensive unit tests in `toast-demo.test.tsx` to guarantee robust validation coverage.

**Why it was done**
Previously, the toast inputs accepted invalid values silently. By adding robust client-side validation and accessible inline errors, we prevent layout-breaking toast notifications and provide users with immediate, accessible feedback when they input invalid data, fulfilling the requirements for issue #654.

**How it was verified**
- Verified locally that empty inputs trigger an immediate inline error.
- Verified that exceeding the character limit (50 for title, 200 for description) properly blocks submission.
- Achieved passing tests covering all validation edge cases (empty, out-of-range, and valid submit) in `src/components/toast/__tests__/toast-demo.test.tsx`.
- Ran `npm run lint`, `npm test`, and `npm run build` with full success and zero regressions.

Closes #654
