### PR TITLE
refactor(contracts): add error boundary with retry

### DIFF
--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback } from 'react';
 import EmptyState from '../../components/EmptyState';
 import { ContractCreationForm } from '../../components/ContractCreationForm';
+import ContractsErrorBoundary from '../../components/ContractsErrorBoundary';
 import { listContracts, saveContract } from '@/lib/repository';
 import type { Contract } from '@/types/domain';
 
@@ -37,54 +38,56 @@ const ContractsPage: React.FC = () => {
   }, []);
 
   return (
-    <main className="min-h-screen p-8">
-      <h1 className="text-2xl font-bold mb-6">Contracts</h1>
+    <ContractsErrorBoundary>
+      <main className="min-h-screen p-8">
+        <h1 className="text-2xl font-bold mb-6">Contracts</h1>
 
-      {!showForm && contracts.length === 0 && (
-        <EmptyState
-          illustration="contracts"
-          title="No contracts found"
-          description="You haven't created any contracts yet. Start by creating your first contract to begin freelancing securely."
-          actionLabel="Create Contract"
-          onAction={handleCreateContract}
-        />
-      )}
+        {!showForm && contracts.length === 0 && (
+          <EmptyState
+            illustration="contracts"
+            title="No contracts found"
+            description="You haven't created any contracts yet. Start by creating your first contract to begin freelancing securely."
+            actionLabel="Create Contract"
+            onAction={handleCreateContract}
+          />
+        )}
 
-      {!showForm && contracts.length > 0 && (
-        <>
-          <div className="mb-4 flex justify-end">
-            <button
-              type="button"
-              onClick={handleCreateContract}
-              className="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-            >
-              Create Contract
-            </button>
-          </div>
-          {/* TODO: Replace with a proper ContractSummary list component. */}
-          <ul className="space-y-4">
-            {contracts.map((contract, idx) => (
-              <li
-                key={`${contract.contractName}-${idx}`}
-                className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm"
+        {!showForm && contracts.length > 0 && (
+          <>
+            <div className="mb-4 flex justify-end">
+              <button
+                type="button"
+                onClick={handleCreateContract}
+                className="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
               >
-                <p className="font-semibold text-slate-900">{contract.contractName}</p>
-                <p className="text-sm text-slate-500">
-                  {contract.status} · Created {contract.createdAt}
-                </p>
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
+                Create Contract
+              </button>
+            </div>
+            {/* TODO: Replace with a proper ContractSummary list component. */}
+            <ul className="space-y-4">
+              {contracts.map((contract, idx) => (
+                <li
+                  key={`${contract.contractName}-${idx}`}
+                  className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm"
+                >
+                  <p className="font-semibold text-slate-900">{contract.contractName}</p>
+                  <p className="text-sm text-slate-500">
+                    {contract.status} · Created {contract.createdAt}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
 
-      {showForm && (
-        <ContractCreationForm
-          onSubmit={handleSubmitContract}
-          onCancel={handleCancelForm}
-        />
-      )}
-    </main>
+        {showForm && (
+          <ContractCreationForm
+            onSubmit={handleSubmitContract}
+            onCancel={handleCancelForm}
+          />
+        )}
+      </main>
+    </ContractsErrorBoundary>
   );
 };
 

--- a/src/components/ContractsErrorBoundary.test.tsx
+++ b/src/components/ContractsErrorBoundary.test.tsx
@@ -1,0 +1,403 @@
+/**
+ * ContractsErrorBoundary — comprehensive test suite
+ *
+ * Covers:
+ *  - Normal render (children pass-through, no error)
+ *  - Fallback UI shown when a child throws
+ *  - Accessible attributes of the fallback (role=alert, aria-live)
+ *  - Custom fallback prop replaces the default UI
+ *  - Retry re-mounts children after the boundary resets
+ *  - Error is forwarded to the reportError seam (not swallowed)
+ *  - componentStack metadata is passed to the reporter
+ *  - Pluggable reporter receives the right arguments
+ *  - Go Home link navigates to '/'
+ *  - Multiple independent boundaries do not interfere
+ */
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ContractsErrorBoundary from './ContractsErrorBoundary';
+import { setErrorReporter } from '../lib/errorReporter';
+
+// ---------------------------------------------------------------------------
+// Suppress React error boundary noise in test output
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  setErrorReporter(null); // reset to default before each test
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  setErrorReporter(null);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A child that throws if shouldThrow is true, otherwise renders fine. */
+const Bomb = ({ shouldThrow }: { shouldThrow: boolean }) => {
+  if (shouldThrow) throw new Error('contracts render failure');
+  return <div>Contracts loaded</div>;
+};
+
+Bomb.displayName = 'Bomb';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ContractsErrorBoundary', () => {
+  // ── Normal render ─────────────────────────────────────────────────────────
+
+  describe('normal render (no error)', () => {
+    it('renders children when no error occurs', () => {
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={false} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(screen.getByText('Contracts loaded')).toBeInTheDocument();
+    });
+
+    it('does not render the fallback UI when children render successfully', () => {
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={false} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(
+        screen.queryByText(/the contracts section failed to load/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /retry/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Fallback UI ───────────────────────────────────────────────────────────
+
+  describe('fallback UI when a child throws', () => {
+    it('shows the default fallback message', () => {
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(
+        screen.getByText(/the contracts section failed to load/i),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the secondary help text', () => {
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(
+        screen.getByText(/an unexpected error occurred/i),
+      ).toBeInTheDocument();
+    });
+
+    it('renders a Retry button', () => {
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(
+        screen.getByRole('button', { name: /retry/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders a Go Home link pointing to "/"', () => {
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      const link = screen.getByRole('link', { name: /go home/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', '/');
+    });
+
+    it('does not render children when in error state', () => {
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(screen.queryByText('Contracts loaded')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Accessibility ─────────────────────────────────────────────────────────
+
+  describe('fallback accessibility', () => {
+    it('fallback container has role="alert"', () => {
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('fallback container has aria-live="assertive"', () => {
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveAttribute('aria-live', 'assertive');
+    });
+  });
+
+  // ── Custom fallback ───────────────────────────────────────────────────────
+
+  describe('custom fallback prop', () => {
+    it('renders the custom fallback when provided and a child throws', () => {
+      render(
+        <ContractsErrorBoundary fallback={<div>Custom error UI</div>}>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(screen.getByText('Custom error UI')).toBeInTheDocument();
+    });
+
+    it('does not render the default fallback when a custom fallback is provided', () => {
+      render(
+        <ContractsErrorBoundary fallback={<div>Custom error UI</div>}>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(
+        screen.queryByText(/the contracts section failed to load/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render the custom fallback when no error occurs', () => {
+      render(
+        <ContractsErrorBoundary fallback={<div>Custom error UI</div>}>
+          <Bomb shouldThrow={false} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(screen.queryByText('Custom error UI')).not.toBeInTheDocument();
+      expect(screen.getByText('Contracts loaded')).toBeInTheDocument();
+    });
+  });
+
+  // ── Retry ─────────────────────────────────────────────────────────────────
+
+  describe('retry behaviour', () => {
+    it('re-renders children after clicking Retry when the underlying issue is resolved', () => {
+      let shouldThrow = true;
+      const Child = () => <Bomb shouldThrow={shouldThrow} />;
+
+      const { rerender } = render(
+        <ContractsErrorBoundary>
+          <Child />
+        </ContractsErrorBoundary>,
+      );
+
+      // Boundary should be in error state
+      expect(
+        screen.getByText(/the contracts section failed to load/i),
+      ).toBeInTheDocument();
+
+      // Fix the root cause before retry
+      shouldThrow = false;
+
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+      });
+
+      rerender(
+        <ContractsErrorBoundary>
+          <Child />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(screen.getByText('Contracts loaded')).toBeInTheDocument();
+      expect(
+        screen.queryByText(/the contracts section failed to load/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows the fallback again if the child throws again after retry', () => {
+      // shouldThrow stays true — retry will fail again
+      const { rerender } = render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(
+        screen.getByText(/the contracts section failed to load/i),
+      ).toBeInTheDocument();
+
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+      });
+
+      // Child still throws — boundary must catch again
+      rerender(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(
+        screen.getByText(/the contracts section failed to load/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── Error logging / reporting ─────────────────────────────────────────────
+
+  describe('error logging', () => {
+    it('calls console.error in non-production when a child throws', () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      // The default reporter forwards to console.error with [ContractsErrorBoundary] prefix
+      expect(spy).toHaveBeenCalledWith(
+        '[ContractsErrorBoundary]',
+        expect.any(Error),
+        expect.any(Object), // meta: { componentStack }
+      );
+    });
+
+    it('does not swallow the error silently', () => {
+      const mockReporter = jest.fn();
+      setErrorReporter(mockReporter);
+
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(mockReporter).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('pluggable error reporter', () => {
+    it('invokes the injected reporter with the thrown error', () => {
+      const mockReporter = jest.fn();
+      setErrorReporter(mockReporter);
+
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(mockReporter).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'contracts render failure' }),
+        'ContractsErrorBoundary',
+        'error',
+        expect.any(Object),
+      );
+    });
+
+    it('passes componentStack metadata to the reporter', () => {
+      const mockReporter = jest.fn();
+      setErrorReporter(mockReporter);
+
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      const [, , , meta] = mockReporter.mock.calls[0];
+      expect(meta).toHaveProperty('componentStack');
+    });
+
+    it('uses context label "ContractsErrorBoundary"', () => {
+      const mockReporter = jest.fn();
+      setErrorReporter(mockReporter);
+
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      const [, context] = mockReporter.mock.calls[0];
+      expect(context).toBe('ContractsErrorBoundary');
+    });
+
+    it('reports with severity level "error"', () => {
+      const mockReporter = jest.fn();
+      setErrorReporter(mockReporter);
+
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={true} />
+        </ContractsErrorBoundary>,
+      );
+
+      const [, , level] = mockReporter.mock.calls[0];
+      expect(level).toBe('error');
+    });
+
+    it('does not call the reporter when children render without error', () => {
+      const mockReporter = jest.fn();
+      setErrorReporter(mockReporter);
+
+      render(
+        <ContractsErrorBoundary>
+          <Bomb shouldThrow={false} />
+        </ContractsErrorBoundary>,
+      );
+
+      expect(mockReporter).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Multiple independent boundaries ───────────────────────────────────────
+
+  describe('multiple independent boundaries', () => {
+    it('a throwing child in one boundary does not affect a sibling boundary', () => {
+      render(
+        <>
+          <ContractsErrorBoundary>
+            <Bomb shouldThrow={true} />
+          </ContractsErrorBoundary>
+          <ContractsErrorBoundary>
+            <Bomb shouldThrow={false} />
+          </ContractsErrorBoundary>
+        </>,
+      );
+
+      // First boundary shows fallback
+      expect(
+        screen.getAllByText(/the contracts section failed to load/i).length,
+      ).toBeGreaterThanOrEqual(1);
+
+      // Second boundary renders children
+      expect(screen.getByText('Contracts loaded')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ContractsErrorBoundary.tsx
+++ b/src/components/ContractsErrorBoundary.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React, { Component, ReactNode } from 'react';
+import Link from 'next/link';
+import { reportError } from '../lib/errorReporter';
+
+interface Props {
+  /** Content to guard. */
+  children: ReactNode;
+  /**
+   * Optional custom fallback UI.  When provided it replaces the default
+   * accessible fallback entirely; the retry button is the caller's
+   * responsibility.
+   */
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  /** The captured error, available to custom fallback renderers. */
+  error: Error | null;
+}
+
+/**
+ * ContractsErrorBoundary
+ *
+ * Wraps the contracts section so that an unexpected render error shows an
+ * accessible fallback with a Retry button instead of blanking the page.
+ *
+ * Errors are forwarded to the shared `reportError` seam so they can be
+ * routed to any configured error reporter (e.g. Sentry) without being
+ * swallowed silently.
+ *
+ * Usage:
+ * ```tsx
+ * <ContractsErrorBoundary>
+ *   <ContractsPage />
+ * </ContractsErrorBoundary>
+ * ```
+ */
+export default class ContractsErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    reportError(error, 'ContractsErrorBoundary', 'error', {
+      componentStack: info.componentStack ?? undefined,
+    });
+  }
+
+  /**
+   * Resets the error boundary state so the children are re-mounted on the
+   * next render.  Callers should fix the underlying cause before triggering
+   * this (e.g. by clearing stale data) so the retry attempt succeeds.
+   */
+  reset = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    const { hasError } = this.state;
+    const { children, fallback } = this.props;
+
+    if (!hasError) {
+      return children;
+    }
+
+    if (fallback) {
+      return fallback;
+    }
+
+    return (
+      <div
+        role="alert"
+        aria-live="assertive"
+        className="flex flex-col items-center justify-center rounded-2xl border border-red-200 bg-red-50 p-8 text-center space-y-4"
+      >
+        <p className="text-lg font-semibold text-red-700">
+          The contracts section failed to load.
+        </p>
+        <p className="text-sm text-red-600">
+          An unexpected error occurred. You can retry or go back to the home page.
+        </p>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={this.reset}
+            className="rounded-2xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-gray-800"
+          >
+            Retry
+          </button>
+          <Link
+            href="/"
+            className="rounded-2xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-gray-400"
+          >
+            Go Home
+          </Link>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Closes #615

An unexpected render error in the contracts section previously blanked the entire page with no recovery path for the user. This PR wraps the contracts section in a dedicated `ContractsErrorBoundary` that catches render failures, surfaces an accessible fallback with a **Retry** button, and forwards every captured error through the shared `reportError` seam so nothing is swallowed silently.

---

## Problem

When any component inside the contracts page tree threw during rendering, React unmounted the whole page and left users with a blank screen and no way to recover. There was no error boundary specific to the contracts section, and no accessible notification to inform assistive-technology users that something had gone wrong.

---

## Solution

### 1. New component — `src/components/ContractsErrorBoundary.tsx`

A React class component implementing the error boundary contract:

| Lifecycle / method | Behaviour |
|---|---|
| `getDerivedStateFromError(error)` | Captures the thrown error into `{ hasError: true, error }` state so the next render shows the fallback. |
| `componentDidCatch(error, info)` | Calls `reportError(error, 'ContractsErrorBoundary', 'error', { componentStack })` — routes through the existing pluggable `errorReporter.ts` seam (same pattern as `SafeBoundary`, `error.tsx`, and `global-error.tsx`). Errors are **never** swallowed silently. |
| `reset()` | Resets `hasError` and `error` to `false`/`null` so clicking Retry re-mounts the children. |
| `render()` | Returns children when healthy; returns the custom `fallback` prop if provided; otherwise renders the default accessible fallback. |

**Default fallback UI**
- Container carries `role="alert"` and `aria-live="assertive"` so screen readers announce the failure immediately.
- Primary message: "The contracts section failed to load."
- Secondary message: "An unexpected error occurred. You can retry or go back to the home page."
- **Retry** button calls `this.reset()` — resets boundary state so the child tree re-mounts on the next render cycle.
- **Go Home** link (`href="/"`) gives users a non-destructive escape route.
- All interactive elements have visible focus rings and meet WCAG 2.1 AA contrast requirements.

**Custom fallback prop**
Callers can pass `fallback={<MyFallback />}` to replace the default UI entirely (e.g. for page-level boundaries that want a full-screen error state).

### 2. Integration — `src/app/contracts/page.tsx`

The `ContractsPage` return value is now wrapped in `<ContractsErrorBoundary>`:

```tsx
return (
  <ContractsErrorBoundary>
    <main className="min-h-screen p-8">
      {/* ... existing contracts UI ... */}
    </main>
  </ContractsErrorBoundary>
);
```

This guards the empty-state path, the contract-list path, and the `ContractCreationForm` modal path with a single boundary. Any render failure in any of those sub-trees will now be caught and presented gracefully.

### 3. Error reporting integration

`ContractsErrorBoundary` uses the exact same `reportError` seam documented in `docs/error-reporting.md` and already used by:

- `src/components/SafeBoundary.tsx` → `reportError(error, 'SafeBoundary')`
- `src/app/error.tsx` → `reportError(error, 'Error Boundary')`
- `src/app/global-error.tsx` → `reportError(error, 'Global Error Boundary')`

This boundary extends the pattern with severity and metadata:

```ts
reportError(error, 'ContractsErrorBoundary', 'error', {
  componentStack: info.componentStack ?? undefined,
});
```

The `componentStack` field lets any injected reporter (Sentry, Rollbar, etc.) pinpoint the exact component that threw without any additional instrumentation.

---

## Tests — `src/components/ContractsErrorBoundary.test.tsx`

22 test cases, **100% statement / 100% function / 100% line coverage** on `ContractsErrorBoundary.tsx`.

```
PASS src/components/ContractsErrorBoundary.test.tsx
  ContractsErrorBoundary
    normal render (no error)
      ✓ renders children when no error occurs
      ✓ does not render the fallback UI when children render successfully
    fallback UI when a child throws
      ✓ shows the default fallback message
      ✓ shows the secondary help text
      ✓ renders a Retry button
      ✓ renders a Go Home link pointing to "/"
      ✓ does not render children when in error state
    fallback accessibility
      ✓ fallback container has role="alert"
      ✓ fallback container has aria-live="assertive"
    custom fallback prop
      ✓ renders the custom fallback when provided and a child throws
      ✓ does not render the default fallback when a custom fallback is provided
      ✓ does not render the custom fallback when no error occurs
    retry behaviour
      ✓ re-renders children after clicking Retry when the underlying issue is resolved
      ✓ shows the fallback again if the child throws again after retry
    error logging
      ✓ calls console.error in non-production when a child throws
      ✓ does not swallow the error silently
    pluggable error reporter
      ✓ invokes the injected reporter with the thrown error
      ✓ passes componentStack metadata to the reporter
      ✓ uses context label "ContractsErrorBoundary"
      ✓ reports with severity level "error"
      ✓ does not call the reporter when children render without error
    multiple independent boundaries
      ✓ a throwing child in one boundary does not affect a sibling boundary

Tests:    22 passed, 22 total
Coverage: 100% Stmts | 100% Funcs | 100% Lines
```

**Edge cases covered:**
- Child throws → fallback shown, children unmounted
- Retry → children re-mounted if root cause resolved
- Retry → fallback re-shown if child still throws
- Custom `fallback` prop → default UI suppressed
- Normal render → reporter never called, no fallback rendered
- Two independent boundaries → one erroring does not affect the other
- Pluggable reporter receives correct `(error, context, level, meta)` signature

---

## Full test output

```
Test Suites: 72 passed (plus 1 pre-existing failure in milestones filter test unrelated to this PR)
Tests:       1236 passed, 4 failed (pre-existing)
```

The 4 pre-existing failures are in `src/app/milestones/__tests__/page.test.tsx` — confirmed present on the baseline branch (`55ac248`) before any changes from this PR were applied.

---

## Pre-flight checklist

- [x] `npm run lint` — clean, exit 0
- [x] `npm test` — 1236 / 1240 pass; 4 failures are pre-existing and unrelated to this PR
- [x] `npm run build` — pre-existing environment failure (`@tailwindcss/oxide` native binding absent in this codespace); confirmed identical error on the baseline before this PR; TypeScript `tsc --noEmit` is clean
- [x] No merge conflicts — rebased directly onto `upstream/main` (`b38990a`)
- [x] 95%+ test coverage for impacted module — 100% achieved
- [x] Accessibility: `role="alert"`, `aria-live="assertive"`, visible focus rings on all interactive elements
- [x] Security: no secrets, no new dependencies, no external network calls introduced
- [x] Error not swallowed: every thrown error forwarded via `reportError` with context label and componentStack metadata

---

## Files changed

| File | Change |
|---|---|
| `src/components/ContractsErrorBoundary.tsx` | **New** — error boundary component (105 lines) |
| `src/components/ContractsErrorBoundary.test.tsx` | **New** — 22-case test suite (403 lines) |
| `src/app/contracts/page.tsx` | **Modified** — import + wrapper around page return |

---

## Related

- Follows the same pattern as `SafeBoundary` (`src/components/SafeBoundary.tsx`) and the per-section boundaries already used on the contract detail page (`src/app/contracts/[id]/page.tsx`).
- Uses the error reporting seam documented in `docs/error-reporting.md`.
- Issue: https://github.com/Talenttrust/Talenttrust-Frontend/issues/615

Closes #615
