### PR TITLE
Fix: Add a loading skeleton to the settings view (Auto-Generated)

### DIFF
--- a/src/app/settings/__tests__/loading.test.tsx
+++ b/src/app/settings/__tests__/loading.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import SettingsLoading from '../loading';
+
+describe('SettingsLoading', () => {
+  it('renders the settings skeleton through the route loading boundary', () => {
+    render(<SettingsLoading />);
+
+    expect(screen.getByTestId('settings-loading-skeleton')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Loading settings' })).toHaveAttribute(
+      'aria-busy',
+      'true',
+    );
+  });
+});

--- a/src/app/settings/loading.tsx
+++ b/src/app/settings/loading.tsx
@@ -1,0 +1,5 @@
+import SettingsSkeleton from '@/components/SettingsSkeleton';
+
+export default function SettingsLoading() {
+  return <SettingsSkeleton />;
+}

--- a/src/components/SettingsSkeleton.tsx
+++ b/src/components/SettingsSkeleton.tsx
@@ -1,0 +1,87 @@
+function SkeletonBlock({ className }: { className: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`animate-pulse rounded-lg bg-slate-200 motion-reduce:animate-none ${className}`}
+    />
+  );
+}
+
+/**
+ * Content-shaped placeholder for the settings view.
+ *
+ * The loading region remains in the document flow with the same broad
+ * dimensions as the settings content, preventing layout shift while the
+ * route is loading. Placeholder content is hidden from assistive
+ * technologies, while aria-busy communicates the loading state on the region.
+ */
+export default function SettingsSkeleton() {
+  return (
+    <section aria-busy="true" aria-label="Loading settings">
+      <div
+        aria-hidden="true"
+        data-testid="settings-loading-skeleton"
+        className="mx-auto min-h-[640px] w-full max-w-4xl px-4 py-8 sm:px-6 lg:px-8"
+      >
+        <div className="space-y-8">
+          <header className="space-y-3">
+            <SkeletonBlock className="h-9 w-48" />
+            <SkeletonBlock className="h-5 w-full max-w-xl" />
+          </header>
+
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+            <aside className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+              <div className="space-y-4">
+                <SkeletonBlock className="h-6 w-32" />
+                <SkeletonBlock className="h-4 w-full" />
+                <SkeletonBlock className="h-4 w-4/5" />
+                <div className="space-y-3 pt-3">
+                  <SkeletonBlock className="h-10 w-full" />
+                  <SkeletonBlock className="h-10 w-full" />
+                  <SkeletonBlock className="h-10 w-full" />
+                </div>
+              </div>
+            </aside>
+
+            <div className="space-y-6">
+              <section className="min-h-[220px] rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+                <div className="space-y-5">
+                  <SkeletonBlock className="h-6 w-40" />
+                  <SkeletonBlock className="h-4 w-3/4" />
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <SkeletonBlock className="h-11 w-full" />
+                    <SkeletonBlock className="h-11 w-full" />
+                  </div>
+                  <SkeletonBlock className="h-11 w-32" />
+                </div>
+              </section>
+
+              <section className="min-h-[220px] rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+                <div className="space-y-5">
+                  <SkeletonBlock className="h-6 w-48" />
+                  <SkeletonBlock className="h-4 w-4/5" />
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between gap-4">
+                      <SkeletonBlock className="h-5 w-2/5" />
+                      <SkeletonBlock className="h-7 w-12 rounded-full" />
+                    </div>
+                    <div className="flex items-center justify-between gap-4">
+                      <SkeletonBlock className="h-5 w-1/2" />
+                      <SkeletonBlock className="h-7 w-12 rounded-full" />
+                    </div>
+                    <div className="flex items-center justify-between gap-4">
+                      <SkeletonBlock className="h-5 w-1/3" />
+                      <SkeletonBlock className="h-7 w-12 rounded-full" />
+                    </div>
+                  </div>
+                </div>
+              </section>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export { SettingsSkeleton };

--- a/src/components/__tests__/SettingsSkeleton.test.tsx
+++ b/src/components/__tests__/SettingsSkeleton.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import SettingsSkeleton from '../SettingsSkeleton';
+
+describe('SettingsSkeleton', () => {
+  it('renders a settings-shaped loading region', () => {
+    render(<SettingsSkeleton />);
+
+    expect(screen.getByRole('region', { name: 'Loading settings' })).toHaveAttribute(
+      'aria-busy',
+      'true',
+    );
+    expect(screen.getByTestId('settings-loading-skeleton')).toBeInTheDocument();
+  });
+
+  it('hides the decorative skeleton from assistive technologies', () => {
+    render(<SettingsSkeleton />);
+
+    const skeleton = screen.getByTestId('settings-loading-skeleton');
+
+    expect(skeleton).toHaveAttribute('aria-hidden', 'true');
+    expect(skeleton.querySelector('.animate-pulse')).toBeInTheDocument();
+  });
+
+  it('uses stable minimum dimensions to avoid layout shift', () => {
+    render(<SettingsSkeleton />);
+
+    const skeleton = screen.getByTestId('settings-loading-skeleton');
+    expect(skeleton).toHaveClass('min-h-[640px]');
+    expect(skeleton.querySelector('.min-h-\\[220px\\]')).toBeInTheDocument();
+  });
+
+  it('does not expose placeholder text as accessible content', () => {
+    render(<SettingsSkeleton />);
+
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<SettingsSkeleton />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
Closes #642

This PR was generated by the DripTide AI coder and scoped strictly to issue #642.

### Changes
Added a content-shaped, aria-hidden settings loading skeleton with an aria-busy loading region, wired it into the Next.js settings route loading boundary, and added accessibility and layout-stability tests for both the skeleton component and route boundary.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #642` so the Drips Wave bot resolves the issue on merge._