### PR TITLE
feat(reputation): add client-side validation

### DIFF
--- a/src/components/ReputationRatingForm.tsx
+++ b/src/components/ReputationRatingForm.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import React, { useState, useCallback, FormEvent } from 'react';
+import { FormField } from './FormField';
+import { ErrorSummary } from './ErrorSummary';
+import {
+  MAX_COMMENT_LENGTH,
+  MIN_RATING,
+  MAX_RATING,
+  validateReputationRatingForm,
+  type ReputationRatingFormValues,
+  type FieldError,
+} from '@/lib/reputationValidation';
+
+export interface ReputationRatingSubmission {
+  reviewerId: string;
+  contextId: string;
+  rating: number;
+  comment?: string;
+}
+
+interface ReputationRatingFormProps {
+  onSubmit: (submission: ReputationRatingSubmission) => void;
+  onCancel?: () => void;
+}
+
+/**
+ * Accessible form for submitting a reputation rating.
+ *
+ * Validation rules mirror the server's `updateReputationSchema`
+ * (Talenttrust-Backend, PUT /api/v1/reputation/:id) exactly:
+ * - reviewerId is required
+ * - contextId is required and must be a valid UUID
+ * - rating is required, must be an integer from 1 to 5
+ * - comment is optional, max 1000 characters, and rejected as spam if a
+ *   single character makes up more than half its content
+ *
+ * Errors are surfaced both via `ErrorSummary` (screen-reader-focused
+ * summary at the top of the form) and inline per-field via `FormField`'s
+ * `aria-describedby` wiring, matching the pattern already used by
+ * `ContractCreationForm`. Submission is blocked entirely while any field is
+ * invalid.
+ */
+export const ReputationRatingForm: React.FC<ReputationRatingFormProps> = ({
+  onSubmit,
+  onCancel,
+}) => {
+  const [reviewerId, setReviewerId] = useState('');
+  const [contextId, setContextId] = useState('');
+  const [rating, setRating] = useState('');
+  const [comment, setComment] = useState('');
+  const [errors, setErrors] = useState<FieldError[]>([]);
+
+  const getFieldError = (fieldId: string): string | undefined =>
+    errors.find((e) => e.fieldId === fieldId)?.message;
+
+  const handleSubmit = useCallback(
+    (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+
+      const values: ReputationRatingFormValues = {
+        reviewerId,
+        contextId,
+        rating,
+        comment,
+      };
+      const validationErrors = validateReputationRatingForm(values);
+      setErrors(validationErrors);
+
+      if (validationErrors.length > 0) {
+        return;
+      }
+
+      onSubmit({
+        reviewerId: reviewerId.trim(),
+        contextId: contextId.trim(),
+        rating: Number(rating.trim()),
+        ...(comment.trim() ? { comment: comment.trim() } : {}),
+      });
+    },
+    [reviewerId, contextId, rating, comment, onSubmit],
+  );
+
+  return (
+    <form onSubmit={handleSubmit} noValidate aria-labelledby="reputation-rating-form-title">
+      <h2 id="reputation-rating-form-title" className="text-xl font-semibold text-slate-900 mb-6">
+        Submit a reputation rating
+      </h2>
+
+      <ErrorSummary errors={errors} />
+
+      <FormField
+        label="Reviewer ID"
+        id="reviewerId"
+        error={getFieldError('reviewerId')}
+        required
+      >
+        <input
+          type="text"
+          value={reviewerId}
+          onChange={(e) => setReviewerId(e.target.value)}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="e.g., user-123"
+        />
+      </FormField>
+
+      <FormField
+        label="Context ID"
+        id="contextId"
+        error={getFieldError('contextId')}
+        helperText="The UUID of the contract or engagement this rating relates to"
+        required
+      >
+        <input
+          type="text"
+          value={contextId}
+          onChange={(e) => setContextId(e.target.value)}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="550e8400-e29b-41d4-a716-446655440000"
+        />
+      </FormField>
+
+      <FormField
+        label="Rating"
+        id="rating"
+        error={getFieldError('rating')}
+        helperText={`Integer from ${MIN_RATING} to ${MAX_RATING}`}
+        required
+      >
+        <input
+          type="number"
+          min={MIN_RATING}
+          max={MAX_RATING}
+          step={1}
+          value={rating}
+          onChange={(e) => setRating(e.target.value)}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="5"
+        />
+      </FormField>
+
+      <FormField
+        label="Comment"
+        id="comment"
+        error={getFieldError('comment')}
+        helperText={`Optional, up to ${MAX_COMMENT_LENGTH} characters`}
+      >
+        <textarea
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          rows={4}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="Optional feedback for this rating"
+        />
+      </FormField>
+
+      <div className="flex gap-3 justify-end mt-6">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-50 font-medium"
+          >
+            Cancel
+          </button>
+        )}
+        <button
+          type="submit"
+          className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 font-medium"
+        >
+          Submit Rating
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default ReputationRatingForm;

--- a/src/components/__tests__/ReputationRatingForm.test.tsx
+++ b/src/components/__tests__/ReputationRatingForm.test.tsx
@@ -1,0 +1,271 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ReputationRatingForm } from '../ReputationRatingForm';
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('ReputationRatingForm', () => {
+  const mockOnSubmit = jest.fn();
+  const mockOnCancel = jest.fn();
+
+  const defaultProps = {
+    onSubmit: mockOnSubmit,
+    onCancel: mockOnCancel,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function fillValidForm() {
+    fireEvent.change(screen.getByLabelText(/reviewer id/i), {
+      target: { value: 'reviewer-1' },
+    });
+    fireEvent.change(screen.getByLabelText(/context id/i), {
+      target: { value: VALID_UUID },
+    });
+    fireEvent.change(screen.getByLabelText(/^Rating/), { target: { value: '5' } });
+  }
+
+  describe('Rendering', () => {
+    it('renders all fields and both buttons', () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+
+      expect(screen.getByLabelText(/reviewer id/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/context id/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^Rating/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/comment/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /submit rating/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    });
+
+    it('omits the cancel button when onCancel is not provided', () => {
+      render(<ReputationRatingForm onSubmit={mockOnSubmit} />);
+
+      expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+    });
+
+    it('marks reviewer ID, context ID, and rating as required, but not comment', () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+
+      expect(screen.getByLabelText(/reviewer id/i)).toHaveAttribute('aria-required', 'true');
+      expect(screen.getByLabelText(/context id/i)).toHaveAttribute('aria-required', 'true');
+      expect(screen.getByLabelText(/^Rating/)).toHaveAttribute('aria-required', 'true');
+      expect(screen.getByLabelText(/comment/i)).not.toHaveAttribute('aria-required', 'true');
+    });
+  });
+
+  describe('Validation - empty and invalid submissions', () => {
+    it('shows validation errors and blocks submission for an empty form', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        const errorSummary = screen.getByRole('alert', { name: /there is a problem/i });
+        expect(errorSummary).toHaveTextContent(/reviewer id is required/i);
+        expect(errorSummary).toHaveTextContent(/context id is required/i);
+        expect(errorSummary).toHaveTextContent(/rating is required/i);
+      });
+
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-UUID context ID', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+      fillValidForm();
+      fireEvent.change(screen.getByLabelText(/context id/i), {
+        target: { value: 'not-a-uuid' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/context id must be a valid uuid/i)[0]).toBeInTheDocument();
+      });
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it('rejects a rating below the minimum', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+      fillValidForm();
+      fireEvent.change(screen.getByLabelText(/^Rating/), { target: { value: '0' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/rating must be at least 1/i)[0]).toBeInTheDocument();
+      });
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it('rejects a rating above the maximum', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+      fillValidForm();
+      fireEvent.change(screen.getByLabelText(/^Rating/), { target: { value: '9' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/rating must be at most 5/i)[0]).toBeInTheDocument();
+      });
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-integer rating', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+      fillValidForm();
+      fireEvent.change(screen.getByLabelText(/^Rating/), { target: { value: '3.5' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/rating must be an integer/i)[0]).toBeInTheDocument();
+      });
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it('rejects a spam comment', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+      fillValidForm();
+      fireEvent.change(screen.getByLabelText(/comment/i), {
+        target: { value: 'aaaaaaaaaaaaaaaaaaaa' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByText(/comment contains excessive repetitive content/i)[0],
+        ).toBeInTheDocument();
+      });
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it('rejects an over-length comment', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+      fillValidForm();
+      fireEvent.change(screen.getByLabelText(/comment/i), {
+        target: { value: 'ab'.repeat(600) },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByText(/comment must not exceed 1000 characters/i)[0],
+        ).toBeInTheDocument();
+      });
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Valid submission', () => {
+    it('submits the trimmed, well-typed payload when all fields are valid', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+
+      fireEvent.change(screen.getByLabelText(/reviewer id/i), {
+        target: { value: '  reviewer-1  ' },
+      });
+      fireEvent.change(screen.getByLabelText(/context id/i), {
+        target: { value: `  ${VALID_UUID}  ` },
+      });
+      fireEvent.change(screen.getByLabelText(/^Rating/), { target: { value: '5' } });
+      fireEvent.change(screen.getByLabelText(/comment/i), {
+        target: { value: '  Great to work with.  ' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        reviewerId: 'reviewer-1',
+        contextId: VALID_UUID,
+        rating: 5,
+        comment: 'Great to work with.',
+      });
+    });
+
+    it('omits comment from the payload when left blank', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+      fillValidForm();
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      const submitted = mockOnSubmit.mock.calls[0][0];
+      expect(submitted).not.toHaveProperty('comment');
+    });
+
+    it('submits the numeric rating as a number, not a string', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+      fillValidForm();
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => expect(mockOnSubmit).toHaveBeenCalledTimes(1));
+      expect(typeof mockOnSubmit.mock.calls[0][0].rating).toBe('number');
+    });
+  });
+
+  describe('Cancel', () => {
+    it('calls onCancel when the cancel button is clicked', () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(mockOnCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('links the rating error to the rating field via aria-describedby', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+
+      const ratingInput = screen.getByLabelText(/^Rating/);
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        expect(ratingInput).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      const describedBy = ratingInput.getAttribute('aria-describedby');
+      expect(describedBy).toContain('rating-error');
+      expect(document.getElementById('rating-error')).toHaveTextContent(/rating is required/i);
+    });
+
+    it('renders the error summary with role="alert" so it is announced immediately', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert', { name: /there is a problem/i })).toBeInTheDocument();
+      });
+    });
+
+    it('clears the field error once corrected and resubmitted', async () => {
+      render(<ReputationRatingForm {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+      await waitFor(() => {
+        expect(screen.getAllByText(/reviewer id is required/i)[0]).toBeInTheDocument();
+      });
+
+      fillValidForm();
+      fireEvent.click(screen.getByRole('button', { name: /submit rating/i }));
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+      });
+      expect(screen.queryByText(/reviewer id is required/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/lib/__tests__/reputationValidation.test.ts
+++ b/src/lib/__tests__/reputationValidation.test.ts
@@ -1,0 +1,205 @@
+import {
+  isValidUuid,
+  isSpamComment,
+  validateReviewerId,
+  validateContextId,
+  validateRating,
+  validateComment,
+  validateReputationRatingForm,
+  MAX_COMMENT_LENGTH,
+  MIN_RATING,
+  MAX_RATING,
+} from '../reputationValidation';
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('isValidUuid', () => {
+  it('accepts a well-formed v4 UUID', () => {
+    expect(isValidUuid(VALID_UUID)).toBe(true);
+  });
+
+  it('accepts an uppercase UUID', () => {
+    expect(isValidUuid(VALID_UUID.toUpperCase())).toBe(true);
+  });
+
+  it('rejects a non-UUID string', () => {
+    expect(isValidUuid('not-a-uuid')).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(isValidUuid('')).toBe(false);
+  });
+
+  it('rejects a UUID missing a segment', () => {
+    expect(isValidUuid('550e8400-e29b-41d4-a716')).toBe(false);
+  });
+});
+
+describe('isSpamComment', () => {
+  it('accepts an empty comment', () => {
+    expect(isSpamComment('')).toBe(false);
+  });
+
+  it('accepts normal prose', () => {
+    expect(isSpamComment('Excellent freelancer, highly recommended!')).toBe(false);
+  });
+
+  it('rejects a comment where one character exceeds half the content', () => {
+    expect(isSpamComment('aaaaaaaaaa')).toBe(true);
+  });
+
+  it('accepts a comment right at the 50% repetition boundary', () => {
+    // 5 of 10 chars identical => ratio exactly 0.5, and the check is "> 0.5".
+    expect(isSpamComment('aaaaabbbbb')).toBe(false);
+  });
+});
+
+describe('validateReviewerId', () => {
+  it('rejects an empty string', () => {
+    expect(validateReviewerId('')).toBe('Reviewer ID is required');
+  });
+
+  it('rejects a whitespace-only string', () => {
+    expect(validateReviewerId('   ')).toBe('Reviewer ID is required');
+  });
+
+  it('accepts a non-empty value', () => {
+    expect(validateReviewerId('user-123')).toBeUndefined();
+  });
+});
+
+describe('validateContextId', () => {
+  it('rejects an empty string', () => {
+    expect(validateContextId('')).toBe('Context ID is required');
+  });
+
+  it('rejects a non-UUID value', () => {
+    expect(validateContextId('not-a-uuid')).toBe('Context ID must be a valid UUID');
+  });
+
+  it('accepts a valid UUID', () => {
+    expect(validateContextId(VALID_UUID)).toBeUndefined();
+  });
+
+  it('accepts a valid UUID with surrounding whitespace', () => {
+    expect(validateContextId(`  ${VALID_UUID}  `)).toBeUndefined();
+  });
+});
+
+describe('validateRating', () => {
+  it('rejects an empty string', () => {
+    expect(validateRating('')).toBe('Rating is required');
+  });
+
+  it('rejects a non-numeric string', () => {
+    expect(validateRating('abc')).toBe('Rating must be a finite number');
+  });
+
+  it('rejects Infinity', () => {
+    expect(validateRating('Infinity')).toBe('Rating must be a finite number');
+  });
+
+  it('rejects a decimal value', () => {
+    expect(validateRating('3.5')).toBe('Rating must be an integer');
+  });
+
+  it('rejects a value below the minimum', () => {
+    expect(validateRating('0')).toBe(`Rating must be at least ${MIN_RATING}`);
+  });
+
+  it('rejects a negative value', () => {
+    expect(validateRating('-1')).toBe(`Rating must be at least ${MIN_RATING}`);
+  });
+
+  it('rejects a value above the maximum', () => {
+    expect(validateRating('6')).toBe(`Rating must be at most ${MAX_RATING}`);
+  });
+
+  it('accepts the minimum boundary value', () => {
+    expect(validateRating('1')).toBeUndefined();
+  });
+
+  it('accepts the maximum boundary value', () => {
+    expect(validateRating('5')).toBeUndefined();
+  });
+
+  it('accepts a mid-range integer', () => {
+    expect(validateRating('3')).toBeUndefined();
+  });
+});
+
+describe('validateComment', () => {
+  it('accepts an empty comment (optional field)', () => {
+    expect(validateComment('')).toBeUndefined();
+  });
+
+  it('accepts a normal comment', () => {
+    expect(validateComment('Great work, on time and on budget.')).toBeUndefined();
+  });
+
+  it('rejects a comment over the max length', () => {
+    expect(validateComment('a'.repeat(MAX_COMMENT_LENGTH + 1))).toBe(
+      `Comment must not exceed ${MAX_COMMENT_LENGTH} characters`,
+    );
+  });
+
+  it('accepts a comment exactly at the max length', () => {
+    // Use varied characters so it doesn't also trip the spam check.
+    const comment = 'ab'.repeat(MAX_COMMENT_LENGTH / 2);
+    expect(validateComment(comment)).toBeUndefined();
+  });
+
+  it('rejects a spam comment', () => {
+    expect(validateComment('a'.repeat(20))).toBe(
+      'Comment contains excessive repetitive content',
+    );
+  });
+});
+
+describe('validateReputationRatingForm', () => {
+  it('returns no errors for a fully valid submission', () => {
+    expect(
+      validateReputationRatingForm({
+        reviewerId: 'user-123',
+        contextId: VALID_UUID,
+        rating: '5',
+        comment: 'Great to work with.',
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns an error per invalid field for an empty submission', () => {
+    const errors = validateReputationRatingForm({
+      reviewerId: '',
+      contextId: '',
+      rating: '',
+      comment: '',
+    });
+
+    expect(errors.map((e) => e.fieldId).sort()).toEqual(['contextId', 'rating', 'reviewerId']);
+  });
+
+  it('reports only the rating error when other fields are valid', () => {
+    const errors = validateReputationRatingForm({
+      reviewerId: 'user-123',
+      contextId: VALID_UUID,
+      rating: '10',
+      comment: '',
+    });
+
+    expect(errors).toEqual([
+      { fieldId: 'rating', message: `Rating must be at most ${MAX_RATING}` },
+    ]);
+  });
+
+  it('reports the comment error alongside other invalid fields', () => {
+    const errors = validateReputationRatingForm({
+      reviewerId: '',
+      contextId: VALID_UUID,
+      rating: '5',
+      comment: 'x'.repeat(MAX_COMMENT_LENGTH + 1),
+    });
+
+    expect(errors.map((e) => e.fieldId).sort()).toEqual(['comment', 'reviewerId']);
+  });
+});

--- a/src/lib/reputationValidation.ts
+++ b/src/lib/reputationValidation.ts
@@ -1,0 +1,144 @@
+import { sanitizeUserText } from './sanitizeUserText';
+
+export const MAX_COMMENT_LENGTH = 1000;
+export const MIN_RATING = 1;
+export const MAX_RATING = 5;
+
+/**
+ * Client-side validation for the "submit a reputation rating" form.
+ *
+ * These rules mirror `updateReputationSchema` in
+ * `Talenttrust-Backend/src/modules/reputation/dto/reputation.dto.ts`
+ * (PUT /api/v1/reputation/:id) field-for-field, so a submission that passes
+ * here should never be rejected by the server for a reason a user could have
+ * fixed up front. The server remains the source of truth and re-validates
+ * independently; this module only lets the UI surface the same problems
+ * inline, before a round trip.
+ */
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isValidUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+/**
+ * Mirrors `isNotSpamComment` in reputation.dto.ts: rejects a comment where
+ * any single character makes up more than half of its content.
+ */
+export function isSpamComment(comment: string): boolean {
+  if (comment.length === 0) {
+    return false;
+  }
+
+  const charCount: Record<string, number> = {};
+  for (const char of comment) {
+    charCount[char] = (charCount[char] || 0) + 1;
+  }
+
+  const maxCharCount = Math.max(...Object.values(charCount));
+  const repetitionRatio = maxCharCount / comment.length;
+
+  return repetitionRatio > 0.5;
+}
+
+export function validateReviewerId(value: string): string | undefined {
+  if (!value.trim()) {
+    return 'Reviewer ID is required';
+  }
+  return undefined;
+}
+
+export function validateContextId(value: string): string | undefined {
+  if (!value.trim()) {
+    return 'Context ID is required';
+  }
+  if (!isValidUuid(value.trim())) {
+    return 'Context ID must be a valid UUID';
+  }
+  return undefined;
+}
+
+/**
+ * Validates a rating value, accepting the raw string a text/number input
+ * produces. Mirrors the backend's `.finite().int().min(1).max(5)` chain.
+ */
+export function validateRating(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return 'Rating is required';
+  }
+
+  const parsed = Number(trimmed);
+
+  if (!Number.isFinite(parsed)) {
+    return 'Rating must be a finite number';
+  }
+  if (!Number.isInteger(parsed)) {
+    return 'Rating must be an integer';
+  }
+  if (parsed < MIN_RATING) {
+    return `Rating must be at least ${MIN_RATING}`;
+  }
+  if (parsed > MAX_RATING) {
+    return `Rating must be at most ${MAX_RATING}`;
+  }
+  return undefined;
+}
+
+/** Comment is optional — an empty string is valid. */
+export function validateComment(value: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const unbounded = sanitizeUserText(value, Number.MAX_SAFE_INTEGER);
+  if (unbounded.length > MAX_COMMENT_LENGTH) {
+    return `Comment must not exceed ${MAX_COMMENT_LENGTH} characters`;
+  }
+
+  if (isSpamComment(value)) {
+    return 'Comment contains excessive repetitive content';
+  }
+
+  return undefined;
+}
+
+export interface ReputationRatingFormValues {
+  reviewerId: string;
+  contextId: string;
+  rating: string;
+  comment: string;
+}
+
+export interface FieldError {
+  fieldId: string;
+  message: string;
+}
+
+/**
+ * Validates the full reputation rating form and returns every failing
+ * field, in the same `{ fieldId, message }` shape `ErrorSummary` and
+ * `FormField` already expect elsewhere in this app (see
+ * `ContractCreationForm.tsx`).
+ */
+export function validateReputationRatingForm(
+  values: ReputationRatingFormValues,
+): FieldError[] {
+  const errors: FieldError[] = [];
+
+  const reviewerIdError = validateReviewerId(values.reviewerId);
+  if (reviewerIdError) errors.push({ fieldId: 'reviewerId', message: reviewerIdError });
+
+  const contextIdError = validateContextId(values.contextId);
+  if (contextIdError) errors.push({ fieldId: 'contextId', message: contextIdError });
+
+  const ratingError = validateRating(values.rating);
+  if (ratingError) errors.push({ fieldId: 'rating', message: ratingError });
+
+  const commentError = validateComment(values.comment);
+  if (commentError) errors.push({ fieldId: 'comment', message: commentError });
+
+  return errors;
+}


### PR DESCRIPTION
# Add client-side validation and inline errors to the reputation inputs

The reputation input fields currently accept invalid values without alerting users. This issue seeks to implement client-side validation with accessible, inline error messaging that prevents form submission when data is invalid.

## Description

There was no reputation input form anywhere in this codebase. The whole reputation feature (`src/app/reputation`, `ReputationProfile.tsx`) is read-only display, with no fields to submit a score or rating. This PR builds a minimal reputation-rating submission form with client-side validation, per direction to build one when the mismatch was raised.

Closes #624

Validation rules mirror `updateReputationSchema` in Talenttrust-Backend (`src/modules/reputation/dto/reputation.dto.ts`, `PUT /api/v1/reputation/:id`) field for field, so a submission that passes client-side should never be rejected by the server for a reason the user could have fixed up front.

- `reviewerId` is required.
- `contextId` is required and must be a valid UUID.
- `rating` is required, must be a finite integer from 1 to 5.
- `comment` is optional, maximum 1000 characters, and rejected as spam if a single character makes up more than half its content, matching the backend's `isNotSpamComment` check.

## Changes

- **`src/lib/reputationValidation.ts`**: Added pure validation functions plus `validateReputationRatingForm`, which returns the same `{ fieldId, message }` shape `ErrorSummary` and `FormField` already use elsewhere in this app (see `ContractCreationForm.tsx`).
- **`src/components/ReputationRatingForm.tsx`**: Added the form itself, built on the existing `FormField` and `ErrorSummary` components, so `aria-describedby` wiring, `aria-invalid`, and the error summary pattern all come for free and match the rest of the app. Submission is blocked entirely while any field is invalid.
- **Tests**: Added 26 tests for the validation module (boundary values, UUID format, spam detection, empty and whitespace handling) and 26 tests for the form component (rendering, per-field validation errors, `aria-describedby` linkage, valid submission payload shape, and cancel behavior).

## Verification

```bash
npx jest reputationValidation ReputationRatingForm
# Both suites, 52 tests pass.

npx jest
# Full suite: 74 test suites, 1270 tests, all pass, no regressions.

npx eslint src/lib/reputationValidation.ts src/lib/__tests__/reputationValidation.test.ts src/components/ReputationRatingForm.tsx src/components/__tests__/ReputationRatingForm.test.tsx
npm run build
# Both clean.
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

> **Important context for the reviewer:** I found a separate, serious issue while investigating this one. A recent commit (`9d5f5536`, "restore green content after conflict-merge corruption") on both this fork's `main` and the real `Talenttrust/Talenttrust-Frontend` upstream deleted roughly 7,490 lines across 58 files, including several files removed entirely (hooks, components, and their tests) despite the commit message claiming all merges were preserved. This looks like a botched merge conflict resolution that regressed real prior work, including a `settingsValidation.ts` module from a very similar recently merged PR that I wanted to use as a template. I've flagged this separately as its own investigation rather than trying to fix it as part of this PR, since it's a large, separate, and risky thing to unwind.