### PR TITLE
refactor(dialogs): add error boundary with retry

### DIFF
--- a/src/app/contracts/__tests__/page.errorBoundary.test.tsx
+++ b/src/app/contracts/__tests__/page.errorBoundary.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ContractsPage from '../page';
+import * as repository from '@/lib/repository';
+import { setErrorReporter } from '@/lib/errorReporter';
+
+jest.mock('@/lib/repository', () => {
+  const actual = jest.requireActual('@/lib/repository');
+  return {
+    ...actual,
+    listContracts: jest.fn(actual.listContracts),
+    saveContract: jest.fn(actual.saveContract),
+  };
+});
+
+// The real ContractCreationForm is replaced with a controllable stand-in so
+// these tests can force it to throw during render without needing invalid
+// props or a real rendering bug.
+let mockShouldThrow = true;
+jest.mock('@/components/ContractCreationForm', () => ({
+  ContractCreationForm: () => {
+    if (mockShouldThrow) {
+      throw new Error('Simulated ContractCreationForm render failure');
+    }
+    return <div>Contract form rendered fine</div>;
+  },
+}));
+
+const mockListContracts = repository.listContracts as jest.MockedFunction<
+  typeof repository.listContracts
+>;
+
+describe('ContractsPage — dialog error boundary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockListContracts.mockReturnValue([]);
+    mockShouldThrow = true;
+    // Silence React's error-boundary console noise and the pluggable
+    // reporter's own console fallback for these deliberately-thrown tests.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    setErrorReporter(null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    setErrorReporter(null);
+  });
+
+  it('does not blank the whole page when the create-contract dialog throws', () => {
+    render(<ContractsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Contract' }));
+
+    // The page shell (heading) survives — only the dialog section is
+    // replaced by the boundary's fallback.
+    expect(screen.getByRole('heading', { name: 'Contracts' })).toBeInTheDocument();
+    expect(screen.getByText('This section failed to load.')).toBeInTheDocument();
+  });
+
+  it('shows an accessible, non-silent failure with a retry control', () => {
+    render(<ContractsPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Create Contract' }));
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('This section failed to load.');
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('logs the error via the shared error-reporting channel instead of swallowing it', () => {
+    const reporter = jest.fn();
+    setErrorReporter(reporter);
+
+    render(<ContractsPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Create Contract' }));
+
+    expect(reporter).toHaveBeenCalledWith(expect.any(Error), 'SafeBoundary', undefined, undefined);
+  });
+
+  it('recovers and renders the dialog normally after Retry once the underlying issue clears', () => {
+    render(<ContractsPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Create Contract' }));
+
+    expect(screen.getByText('This section failed to load.')).toBeInTheDocument();
+
+    // Simulate the transient condition clearing before the retry.
+    mockShouldThrow = false;
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    });
+
+    expect(screen.getByText('Contract form rendered fine')).toBeInTheDocument();
+    expect(screen.queryByText('This section failed to load.')).not.toBeInTheDocument();
+  });
+
+  it('renders the dialog normally when nothing throws (unaffected by the boundary)', () => {
+    mockShouldThrow = false;
+    render(<ContractsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Contract' }));
+
+    expect(screen.getByText('Contract form rendered fine')).toBeInTheDocument();
+    expect(screen.queryByText('This section failed to load.')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback } from 'react';
 import EmptyState from '../../components/EmptyState';
 import { ContractCreationForm } from '../../components/ContractCreationForm';
+import SafeBoundary from '@/components/SafeBoundary';
 import { listContracts, saveContract } from '@/lib/repository';
 import type { Contract } from '@/types/domain';
 
@@ -79,10 +80,12 @@ const ContractsPage: React.FC = () => {
       )}
 
       {showForm && (
-        <ContractCreationForm
-          onSubmit={handleSubmitContract}
-          onCancel={handleCancelForm}
-        />
+        <SafeBoundary>
+          <ContractCreationForm
+            onSubmit={handleSubmitContract}
+            onCancel={handleCancelForm}
+          />
+        </SafeBoundary>
       )}
     </main>
   );

--- a/src/app/milestones/__tests__/page.errorBoundary.test.tsx
+++ b/src/app/milestones/__tests__/page.errorBoundary.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import MilestonesPage from '../page';
+import { listMilestones, saveMilestone } from '@/lib/repository';
+import { setErrorReporter } from '@/lib/errorReporter';
+
+const mockSearchParams = {
+  get: jest.fn(() => null),
+  toString: jest.fn(() => ''),
+};
+const mockReplace = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ replace: mockReplace, push: jest.fn(), prefetch: jest.fn() }),
+}));
+
+jest.mock('@/lib/repository', () => ({
+  listMilestones: jest.fn(),
+  saveMilestone: jest.fn(),
+}));
+
+// The real MilestoneCreationForm is replaced with a controllable stand-in so
+// these tests can force it to throw during render without needing invalid
+// props or a real rendering bug.
+let mockShouldThrow = true;
+jest.mock('@/components/milestones/MilestoneCreationForm', () => ({
+  MilestoneCreationForm: () => {
+    if (mockShouldThrow) {
+      throw new Error('Simulated MilestoneCreationForm render failure');
+    }
+    return <div>Milestone form rendered fine</div>;
+  },
+}));
+
+const mockedListMilestones = jest.mocked(listMilestones);
+const mockedSaveMilestone = jest.mocked(saveMilestone);
+
+describe('MilestonesPage — dialog error boundary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockedListMilestones.mockReturnValue([
+      {
+        id: 'm-1',
+        title: 'Existing milestone',
+        status: 'Active',
+        payout: 1000,
+        currency: 'USD',
+      },
+    ]);
+    mockedSaveMilestone.mockImplementation(() => {});
+    mockShouldThrow = true;
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    setErrorReporter(null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    setErrorReporter(null);
+  });
+
+  it('does not blank the whole page when the add-milestone dialog throws', async () => {
+    render(<MilestonesPage />);
+
+    const addButtons = await screen.findAllByRole('button', { name: /add milestone/i });
+    fireEvent.click(addButtons[0]);
+
+    expect(screen.getByRole('heading', { name: /milestones/i, level: 1 })).toBeInTheDocument();
+    expect(screen.getByText('This section failed to load.')).toBeInTheDocument();
+  });
+
+  it('shows an accessible, non-silent failure with a retry control', async () => {
+    render(<MilestonesPage />);
+    const addButtons = await screen.findAllByRole('button', { name: /add milestone/i });
+    fireEvent.click(addButtons[0]);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('This section failed to load.');
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('logs the error via the shared error-reporting channel instead of swallowing it', async () => {
+    const reporter = jest.fn();
+    setErrorReporter(reporter);
+
+    render(<MilestonesPage />);
+    const addButtons = await screen.findAllByRole('button', { name: /add milestone/i });
+    fireEvent.click(addButtons[0]);
+
+    expect(reporter).toHaveBeenCalledWith(expect.any(Error), 'SafeBoundary', undefined, undefined);
+  });
+
+  it('recovers and renders the dialog normally after Retry once the underlying issue clears', async () => {
+    render(<MilestonesPage />);
+    const addButtons = await screen.findAllByRole('button', { name: /add milestone/i });
+    fireEvent.click(addButtons[0]);
+
+    expect(screen.getByText('This section failed to load.')).toBeInTheDocument();
+
+    mockShouldThrow = false;
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    });
+
+    expect(screen.getByText('Milestone form rendered fine')).toBeInTheDocument();
+    expect(screen.queryByText('This section failed to load.')).not.toBeInTheDocument();
+  });
+
+  it('renders the dialog normally when nothing throws (unaffected by the boundary)', async () => {
+    mockShouldThrow = false;
+    render(<MilestonesPage />);
+
+    const addButtons = await screen.findAllByRole('button', { name: /add milestone/i });
+    fireEvent.click(addButtons[0]);
+
+    expect(screen.getByText('Milestone form rendered fine')).toBeInTheDocument();
+    expect(screen.queryByText('This section failed to load.')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/milestones/page.tsx
+++ b/src/app/milestones/page.tsx
@@ -6,6 +6,7 @@ import EmptyState from '../../components/EmptyState';
 import MilestonesList from '../../components/MilestonesList';
 import MilestoneFilter, { type MilestoneStatusFilter } from '../../components/milestones/MilestoneFilter';
 import { MilestoneCreationForm } from '../../components/milestones/MilestoneCreationForm';
+import SafeBoundary from '@/components/SafeBoundary';
 import { listMilestones, saveMilestone } from '@/lib/repository';
 import { getItem, setItem } from '@/lib/safeStorage';
 import type { Milestone } from '@/types/domain';
@@ -226,10 +227,12 @@ const MilestonesContent: React.FC = () => {
       )}
 
       {showForm && (
-        <MilestoneCreationForm
-          onSubmit={handleSubmitMilestone}
-          onCancel={handleCancelForm}
-        />
+        <SafeBoundary>
+          <MilestoneCreationForm
+            onSubmit={handleSubmitMilestone}
+            onCancel={handleCancelForm}
+          />
+        </SafeBoundary>
       )}
     </main>
   );

--- a/src/components/SafeBoundary.tsx
+++ b/src/components/SafeBoundary.tsx
@@ -31,7 +31,11 @@ export default class SafeBoundary extends Component<Props, State> {
       if (this.props.fallback) return this.props.fallback;
 
       return (
-        <div className="flex flex-col items-center justify-center p-8 rounded-lg border border-red-200 bg-red-50 text-center space-y-4">
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="flex flex-col items-center justify-center p-8 rounded-lg border border-red-200 bg-red-50 text-center space-y-4"
+        >
           <p className="text-red-700 font-medium">
             This section failed to load.
           </p>


### PR DESCRIPTION
# Wrap the dialogs section in an error boundary with a retry

Unexpected render errors in dialog components cause a blank page. Implement an error boundary wrapper around the dialogs section that displays an accessible fallback UI with a retry mechanism, while logging errors through existing channels without suppressing them.

## Description

`SafeBoundary` already exists in this codebase, used on the contract detail page, and already does exactly what this issue asks for: an accessible fallback, a Retry button, and non-silent logging via `reportError`. It just wasn't wrapping the create-contract and create-milestone dialogs (`ContractCreationForm`, `MilestoneCreationForm`), so an unexpected render error inside either one would blank the whole page instead of just failing that section.

Closes #640

## Changes

* `src/app/contracts/page.tsx` and `src/app/milestones/page.tsx`: wrapped both dialog-rendering blocks in `SafeBoundary`, matching the pattern already used in `src/app/contracts/[id]/page.tsx`.
* `src/components/SafeBoundary.tsx`: added `role="alert"` and `aria-live="assertive"` to the default fallback so screen reader users are actually notified a section failed, rather than the failure being silently invisible to them. This was a real accessibility gap in the existing component, not something new.
* `src/app/contracts/__tests__/page.errorBoundary.test.tsx` and `src/app/milestones/__tests__/page.errorBoundary.test.tsx` (new, 5 tests each): a thrown error in the dialog leaves the rest of the page intact, the fallback is accessible with a working Retry control, the error reaches the shared error-reporting channel, Retry recovers once the underlying issue clears, and normal (non-throwing) rendering is unaffected.

## Verification

```bash
npx jest SafeBoundary contracts/__tests__/page milestones/__tests__/page

```

5 suites, 80 tests pass, no regressions.

```bash
npx jest

```

Full suite: 74 test suites, 1228 tests, all pass.

```bash
npx eslint src/app/contracts/page.tsx src/app/milestones/page.tsx src/components/SafeBoundary.tsx src/app/contracts/__tests__/page.errorBoundary.test.tsx src/app/milestones/__tests__/page.errorBoundary.test.tsx
npm run build

```

Both clean.

## Type of Change

* [x] Bug fix / refactor (non-breaking)

**Note:** the previously-flagged destructive commit history in this repo also deleted a separate `ContractsErrorBoundary.tsx` component along with its 403-line test file. I did not try to restore that one, since `SafeBoundary` already covers this issue's actual scope (the dialogs) cleanly; whether `ContractsErrorBoundary` served some other purpose is part of the broader investigation I flagged earlier.