### PR TITLE
feat(navigation): add cmd+k command palette and register reputation e…

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,6 +52,7 @@ import { WalletProvider } from '@/contexts/WalletContext';
 import RouteAnnouncer from '@/components/RouteAnnouncer';
 import Navbar from '@/components/Navbar';
 import HeaderActions from '@/components/HeaderActions';
+import { CommandPalette } from '@/components/CommandPalette';
 
 export default function RootLayout({
   children,
@@ -88,6 +89,7 @@ export default function RootLayout({
                 </main>
               </div>
               <SettingsTrigger />
+              <CommandPalette />
             </WalletProvider>
           </ToastProvider>
         </PreferencesProvider>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import React, { useState, useEffect, useRef, useId } from 'react';
+import { useRouter } from 'next/navigation';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+interface CommandPaletteAction {
+  id: string;
+  label: string;
+  keywords: string[];
+  onSelect: () => void;
+}
+
+export function CommandPalette() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listboxRef = useRef<HTMLUListElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  
+  const router = useRouter();
+  const idPrefix = useId();
+  
+  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+
+  const actions: CommandPaletteAction[] = [
+    {
+      id: 'nav-contracts',
+      label: 'Contracts',
+      keywords: ['contracts', 'agreements'],
+      onSelect: () => router.push('/contracts'),
+    },
+    {
+      id: 'nav-milestones',
+      label: 'Milestones',
+      keywords: ['milestones', 'deliverables', 'tasks'],
+      onSelect: () => router.push('/milestones'),
+    },
+    {
+      id: 'nav-reputation',
+      label: 'Reputation',
+      keywords: ['reputation', 'profile', 'reviews'],
+      onSelect: () => router.push('/reputation'),
+    },
+  ];
+
+  const filteredActions = actions.filter((action) => {
+    if (!query) return true;
+    const lowerQuery = query.toLowerCase();
+    return (
+      action.label.toLowerCase().includes(lowerQuery) ||
+      action.keywords.some((k) => k.toLowerCase().includes(lowerQuery))
+    );
+  });
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setIsOpen((prev) => {
+          if (!prev) triggerRef.current = document.activeElement as HTMLElement;
+          return true;
+        });
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      inputRef.current.focus();
+    } else if (!isOpen && triggerRef.current) {
+      triggerRef.current.focus();
+    }
+  }, [isOpen]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setIsOpen(false);
+      return;
+    }
+    
+    if (filteredActions.length === 0) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((prev) => (prev + 1) % filteredActions.length);
+      scrollIntoView((activeIndex + 1) % filteredActions.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((prev) => (prev - 1 + filteredActions.length) % filteredActions.length);
+      scrollIntoView((activeIndex - 1 + filteredActions.length) % filteredActions.length);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const action = filteredActions[activeIndex];
+      if (action) {
+        action.onSelect();
+        setIsOpen(false);
+        setQuery('');
+      }
+    }
+  };
+
+  const scrollIntoView = (index: number) => {
+    if (!listboxRef.current) return;
+    const listbox = listboxRef.current;
+    const children = listbox.children;
+    if (children[index]) {
+      const element = children[index] as HTMLElement;
+      if (element.offsetTop < listbox.scrollTop) {
+        listbox.scrollTop = element.offsetTop;
+      } else if (element.offsetTop + element.offsetHeight > listbox.scrollTop + listbox.offsetHeight) {
+        listbox.scrollTop = element.offsetTop + element.offsetHeight - listbox.offsetHeight;
+      }
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh] px-4">
+      <div 
+        className={`fixed inset-0 bg-slate-900/40 backdrop-blur-sm ${prefersReducedMotion ? '' : 'transition-opacity'}`}
+        onClick={() => setIsOpen(false)}
+        aria-hidden="true"
+      />
+      <div 
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command Palette"
+        className={`relative z-10 w-full max-w-xl bg-white rounded-xl shadow-2xl overflow-hidden border border-slate-200 ${prefersReducedMotion ? '' : 'transform transition-all'}`}
+      >
+        <div className="p-4 border-b border-slate-100 flex items-center">
+          <svg className="w-5 h-5 text-slate-400 mr-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            role="combobox"
+            aria-expanded="true"
+            aria-controls={`${idPrefix}-listbox`}
+            aria-activedescendant={
+              filteredActions.length > 0 
+                ? `${idPrefix}-option-${filteredActions[activeIndex].id}`
+                : undefined
+            }
+            className="w-full bg-transparent text-slate-900 placeholder:text-slate-400 outline-none text-lg"
+            placeholder="Search commands..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+        </div>
+        <ul
+          id={`${idPrefix}-listbox`}
+          ref={listboxRef}
+          role="listbox"
+          className="max-h-80 overflow-y-auto py-2"
+        >
+          {filteredActions.length === 0 ? (
+            <li className="px-6 py-8 text-center text-slate-500">
+              No results found.
+            </li>
+          ) : (
+            filteredActions.map((action, index) => (
+              <li
+                key={action.id}
+                id={`${idPrefix}-option-${action.id}`}
+                role="option"
+                aria-selected={index === activeIndex}
+                className={`px-4 mx-2 py-3 rounded-lg flex items-center cursor-default ${
+                  index === activeIndex ? 'bg-blue-600 text-white' : 'text-slate-700 hover:bg-slate-50'
+                }`}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => {
+                  action.onSelect();
+                  setIsOpen(false);
+                  setQuery('');
+                }}
+              >
+                {action.label}
+              </li>
+            ))
+          )}
+        </ul>
+        <div className="p-3 border-t border-slate-100 bg-slate-50 text-xs text-slate-500 flex items-center justify-end space-x-4">
+           <span><kbd className="bg-white border border-slate-200 rounded px-1 text-slate-600">↑↓</kbd> to navigate</span>
+           <span><kbd className="bg-white border border-slate-200 rounded px-1 text-slate-600">Enter</kbd> to select</span>
+           <span><kbd className="bg-white border border-slate-200 rounded px-1 text-slate-600">esc</kbd> to close</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CommandPalette } from '../CommandPalette';
+import { useRouter } from 'next/navigation';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@/hooks/useMediaQuery', () => ({
+  useMediaQuery: jest.fn(),
+}));
+
+describe('CommandPalette', () => {
+  const pushMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({
+      push: pushMock,
+    });
+    (useMediaQuery as jest.Mock).mockReturnValue(false);
+  });
+
+  it('does not render when closed', () => {
+    render(<CommandPalette />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('opens on Cmd+K and closes on Escape', () => {
+    render(<CommandPalette />);
+    
+    // Trigger Cmd+K
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    
+    // Trigger Escape
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('opens on Ctrl+K', () => {
+    render(<CommandPalette />);
+    
+    // Trigger Ctrl+K
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('renders all default actions', () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(3);
+    
+    const textContent = options.map(opt => opt.textContent);
+    expect(textContent).toContain('Contracts');
+    expect(textContent).toContain('Milestones');
+    expect(textContent).toContain('Reputation');
+  });
+
+  it('filters actions by search query', () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'reputation' } });
+    
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Reputation');
+  });
+
+  it('shows no results message when query matches nothing', () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'invalid query' } });
+    
+    expect(screen.queryByRole('option')).toBeNull();
+    expect(screen.getByText('No results found.')).toBeInTheDocument();
+  });
+
+  it('navigates to /reputation when Reputation is activated via click', () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    
+    const reputationOption = screen.getByText('Reputation');
+    fireEvent.click(reputationOption);
+    
+    expect(pushMock).toHaveBeenCalledWith('/reputation');
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('navigates to /reputation when Reputation is activated via keyboard (ArrowDown + Enter)', () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    
+    const input = screen.getByRole('combobox');
+    
+    // Focus is initially on first option (Contracts).
+    // Arrow down twice to reach Reputation (index 2).
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // index 1
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // index 2
+    
+    const options = screen.getAllByRole('option');
+    expect(options[2]).toHaveAttribute('aria-selected', 'true');
+    
+    fireEvent.keyDown(input, { key: 'Enter' });
+    
+    expect(pushMock).toHaveBeenCalledWith('/reputation');
+    expect(screen.queryByRole('dialog')).toBeNull(); // it should close
+  });
+
+  it('wraps around keyboard navigation using ArrowUp and ArrowDown', () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    
+    const input = screen.getByRole('combobox');
+    
+    // Go up from 0 to last
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    let options = screen.getAllByRole('option');
+    expect(options[2]).toHaveAttribute('aria-selected', 'true');
+    
+    // Go down from last to 0
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    options = screen.getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('respects prefers-reduced-motion media query', () => {
+    (useMediaQuery as jest.Mock).mockReturnValue(true);
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    
+    const dialog = screen.getByRole('dialog');
+    // Shouldn't have transform transition-all classes
+    expect(dialog).not.toHaveClass('transform', 'transition-all');
+  });
+});


### PR DESCRIPTION
Closes #689 
Power users frequently access key routes (like Reputation) but were previously unable to do so without using the mouse or stepping through standard page navigation. This PR introduces a new accessible global CommandPalette component and registers an accessible palette entry for Reputation (along with Contracts and Milestones).

Changes Included:

Created src/components/CommandPalette.tsx providing a global Cmd+K / Ctrl+K keyboard shortcut.
Implemented accessible listbox/combobox semantics, including aria-activedescendant and arrow-key navigation.
Registered the /reputation route action inside the command palette with clear keywords (e.g. reputation, profile, reviews) to ensure fuzzy-filtering discovery.
Mounted the CommandPalette component globally in src/app/layout.tsx.
Ensured graceful motion handling via useMediaQuery('(prefers-reduced-motion: reduce)').
Verification & Testing:

Wrote a comprehensive Jest test suite (src/components/__tests__/CommandPalette.test.tsx) covering:
Registration of the Reputation route without duplicate entries.
Activation of the route via Enter key after keyboard arrow navigation.
Correct opening and closing via Cmd+K and Escape.
Proper fallbacks for empty search results.