### PR TITLE
refactor(toast): fix #655 by guarding toast rendering with an error boundary

### DIFF
--- a/src/components/toast/toast-provider.test.tsx
+++ b/src/components/toast/toast-provider.test.tsx
@@ -3,7 +3,8 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { StrictMode } from 'react';
 import { PreferencesProvider } from '@/lib/preferences';
-import { ToastProvider, useToast } from './toast-provider';
+import { ToastProvider, useToast, ToastErrorBoundary } from './toast-provider';
+import * as errorReporter from '@/lib/errorReporter';
 
 function ToastHarness() {
   const { showError, showSuccess } = useToast();
@@ -1372,5 +1373,68 @@ describe('toastDuration preference', () => {
     // Advance time — none should auto-dismiss (all persistent).
     act(() => { jest.advanceTimersByTime(60000); });
     expect(screen.getAllByRole('status')).toHaveLength(4);
+  });
+});
+
+describe('ToastErrorBoundary', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(errorReporter, 'reportError').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders children seamlessly when no error occurs', () => {
+    render(
+      <ToastErrorBoundary>
+        <div>Normal Content</div>
+      </ToastErrorBoundary>
+    );
+    expect(screen.getByText('Normal Content')).toBeInTheDocument();
+  });
+
+  it('catches render errors in toast viewport, logs them, and renders fallback', () => {
+    const ThrowingComponent = () => {
+      throw new Error('Toast render error');
+    };
+
+    render(
+      <ToastErrorBoundary>
+        <ThrowingComponent />
+      </ToastErrorBoundary>
+    );
+
+    expect(screen.getByText('Notifications failed to load')).toBeInTheDocument();
+    expect(errorReporter.reportError).toHaveBeenCalledWith(
+      expect.any(Error),
+      'ToastErrorBoundary',
+      'error',
+      expect.any(Object)
+    );
+  });
+
+  it('recovers when retry button is clicked', () => {
+    let shouldThrow = true;
+    const RecoverableComponent = () => {
+      if (shouldThrow) {
+        throw new Error('Temporary error');
+      }
+      return <div>Recovered!</div>;
+    };
+
+    render(
+      <ToastErrorBoundary>
+        <RecoverableComponent />
+      </ToastErrorBoundary>
+    );
+
+    expect(screen.getByText('Notifications failed to load')).toBeInTheDocument();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    expect(screen.getByText('Recovered!')).toBeInTheDocument();
   });
 });

--- a/src/components/toast/toast-provider.tsx
+++ b/src/components/toast/toast-provider.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import {
+  Component,
+  ErrorInfo,
+  ReactNode,
   createContext,
   useCallback,
   useContext,
@@ -9,6 +12,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { reportError } from '@/lib/errorReporter';
 import { usePreferences } from '@/lib/preferences';
 import type { ToastDuration } from '@/lib/preferences';
 
@@ -277,7 +281,48 @@ type ToastTimerState = {
  * action button. Clicking it fires `onClick` then immediately dismisses the
  * toast. The label is always rendered as a plain text node to prevent XSS.
  */
-export function ToastProvider({ children }: { children: React.ReactNode }) {
+export class ToastErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    reportError(error, 'ToastErrorBoundary', 'error', { info });
+  }
+
+  reset = () => this.setState({ hasError: false });
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="region"
+          aria-label="Notifications Fallback"
+          className="pointer-events-none fixed right-4 top-4 z-50 flex w-[min(24rem,calc(100vw-2rem))] flex-col gap-3"
+        >
+          <div className="pointer-events-auto overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] shadow-sm shadow-lg" role="alert">
+            <div className="h-1.5 w-full bg-rose-500" />
+            <div className="flex flex-col gap-2 p-4">
+              <p className="text-sm font-semibold">Notifications failed to load</p>
+              <button
+                type="button"
+                onClick={this.reset}
+                className="self-start rounded-md px-3 py-1 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-1 bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90"
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastRecord[]>([]);
   const toastTimersRef = useRef<Record<string, ToastTimerState>>({});
 
@@ -475,14 +520,16 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   return (
     <ToastContext.Provider value={value}>
       {children}
-      <ToastAnnouncer toasts={toasts} />
-      <ToastViewport
-        density={preferences.toastDensity}
-        onDismiss={dismissToast}
-        onPauseTimer={pauseToastTimer}
-        onResumeTimer={resumeToastTimer}
-        toasts={toasts}
-      />
+      <ToastErrorBoundary>
+        <ToastAnnouncer toasts={toasts} />
+        <ToastViewport
+          density={preferences.toastDensity}
+          onDismiss={dismissToast}
+          onPauseTimer={pauseToastTimer}
+          onResumeTimer={resumeToastTimer}
+          toasts={toasts}
+        />
+      </ToastErrorBoundary>
     </ToastContext.Provider>
   );
 }


### PR DESCRIPTION
closes #655 

# Sumarry
This change fixes issue #655, where an unexpected render failure in the toast area could crash the entire page. The toast system now uses a dedicated `ToastErrorBoundary` around the toast announcer and toast viewport only, so failures in toast rendering are isolated from the rest of the application.

Before this change, a rendering exception in the toast section could propagate upward and unmount the whole `ToastProvider` tree. That meant a toast-specific bug could blank the page or disrupt unrelated content. After this change, the boundary catches those render errors, reports them through the existing `reportError` seam, and shows a fixed-position accessible fallback that stays in the same top-right location as normal toasts.

The fallback UI includes a retry button. Clicking Retry clears the boundary state and re-attempts rendering the toast subtree. This gives users a way to recover without reloading the page, and it keeps the main app content outside the boundary so the rest of the application remains available even if toast rendering fails.

Implementation details:

- `ToastErrorBoundary` is a class-based React error boundary with `getDerivedStateFromError` and `componentDidCatch`.
- Errors are logged through `reportError(error, 'ToastErrorBoundary', 'error', { info })`.
- The fallback uses an alert-style toast-like panel with a retry control and accessible labels.
- `ToastProvider` now wraps only `ToastAnnouncer` and `ToastViewport` inside the boundary.
- Tests cover normal rendering, error capture with fallback display, and retry recovery.

Test results from the completed verification run:

```text
> talenttrust-frontend@0.1.0 lint
> eslint .

PASS

> talenttrust-frontend@0.1.0 test
> jest

Test Suites: 72 passed, 72 total
Tests:       1221 passed, 1221 total
Snapshots:   7 passed, 7 total
Time:        15.515 s, estimated 18 s
Ran all test suites.

# Changes Made

- Added `ToastErrorBoundary` in `src/components/toast/toast-provider.tsx` for issue #655.
- Logged toast render failures through the existing `reportError` pipeline with boundary context and React error info.
- Added an accessible fallback UI in the same toast overlay position with a Retry button.
- Wrapped only `ToastAnnouncer` and `ToastViewport` in the boundary so app content remains outside the failure domain.
- Added tests in `src/components/toast/toast-provider.test.tsx` for:
  - normal render behavior
  - thrown child render errors
  - retry-driven recovery and re-render