### PR TITLE
feat(wallet): add client-side validation and inline errors to wallet inputs (#629)

### DIFF
--- a/src/components/WalletAddressInput.tsx
+++ b/src/components/WalletAddressInput.tsx
@@ -105,7 +105,7 @@ export function WalletAddressInput({
     [onChange, internalError, onValidation, id]
   );
 
-  const effectiveError = parentError ?? internalError;
+  const effectiveError = parentError ?? internalError ?? undefined;
 
   return (
     <FormField

--- a/src/components/WalletAddressInput.tsx
+++ b/src/components/WalletAddressInput.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { FormField } from './FormField';
+import { isValidStellarAddress, normalizeStellarAddress } from '@/lib/stellarAddress';
+
+/** A Stellar public key is always exactly 56 characters. */
+const STELLAR_ADDRESS_LENGTH = 56;
+
+/**
+ * Props for the `WalletAddressInput` component.
+ */
+export interface WalletAddressInputProps {
+  /** The unique identifier for the form control. */
+  id: string;
+  /** The text content for the label. */
+  label: string;
+  /** The current value of the input. */
+  value: string;
+  /** Called when the input value changes. */
+  onChange: (value: string) => void;
+  /**
+   * Optional inline error message from the parent form (e.g. from
+   * submit-time validation). When provided, it takes precedence over
+   * any internally tracked blur error.
+   */
+  error?: string;
+  /** Optional helper text displayed below the input. */
+  helperText?: string;
+  /** If true, marks the field as required visually and semantically. */
+  required?: boolean;
+  /** Placeholder text for the input. */
+  placeholder?: string;
+  /**
+   * Called after every blur event with the current validation result.
+   * The parent can use this callback to update its central errors state
+   * (e.g. for `ErrorSummary` aggregation).
+   */
+  onValidation?: (fieldId: string, error: string | null) => void;
+}
+
+/**
+ * `WalletAddressInput` — a client-side validated wallet address input.
+ *
+ * Wraps `FormField` and adds real-time Stellar address validation on blur,
+ * mirroring the server-side `isValidStellarAddress` checks:
+ *
+ * 1. **Empty** → "must be provided" (translated to required error)
+ * 2. **Format error** → "Must be a valid Stellar G... address"
+ * 3. **Valid** → no error
+ *
+ * Accessibility:
+ * - `FormField` wires `aria-invalid`, `aria-describedby`, and a
+ *   `role="alert"` error paragraph automatically.
+ * - The input normalizes the address to uppercase on blur for
+ *   consistency with on-chain representation.
+ */
+export function WalletAddressInput({
+  id,
+  label,
+  value,
+  onChange,
+  error: parentError,
+  helperText,
+  required,
+  placeholder = 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  onValidation,
+}: WalletAddressInputProps) {
+  const [internalError, setInternalError] = useState<string | null>(null);
+
+  const handleBlur = useCallback(() => {
+    const trimmed = value.trim();
+    let validationError: string | null = null;
+
+    if (!trimmed) {
+      validationError = required ? `${label} is required` : null;
+    } else if (!isValidStellarAddress(value)) {
+      validationError = `${label} must be a valid Stellar G... address`;
+    }
+
+    setInternalError(validationError);
+
+    // Normalize the address on blur (uppercase, trimmed) so the
+    // displayed value matches on-chain representation.
+    if (trimmed) {
+      const normalized = normalizeStellarAddress(value);
+      if (normalized !== value) {
+        onChange(normalized);
+      }
+    }
+
+    onValidation?.(id, validationError);
+  }, [value, required, label, onChange, onValidation, id]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      // Clear the internal error as the user types so the error
+      // doesn't persist while they are correcting the input.
+      if (internalError) {
+        setInternalError(null);
+        onValidation?.(id, null);
+      }
+      onChange(e.target.value);
+    },
+    [onChange, internalError, onValidation, id]
+  );
+
+  const effectiveError = parentError ?? internalError;
+
+  return (
+    <FormField
+      id={id}
+      label={label}
+      error={effectiveError}
+      helperText={helperText}
+      required={required}
+    >
+      <input
+        type="text"
+        value={value}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        placeholder={placeholder}
+        maxLength={STELLAR_ADDRESS_LENGTH}
+        autoComplete="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        className={
+          'w-full rounded-2xl border px-4 py-2.5 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition'
+        }
+      />
+    </FormField>
+  );
+}
+
+export default WalletAddressInput;

--- a/src/components/__tests__/WalletAddressInput.test.tsx
+++ b/src/components/__tests__/WalletAddressInput.test.tsx
@@ -1,0 +1,599 @@
+/**
+ * WalletAddressInput.test.tsx
+ *
+ * Tests for the WalletAddressInput component covering:
+ *   1. Rendering — label, input, helper text, required indicator
+ *   2. Real-time validation on blur — empty, invalid format, valid
+ *   3. aria-invalid and aria-describedby wiring
+ *   4. Normalization on blur (uppercase, trimmed)
+ *   5. Error clearing on change
+ *   6. onValidation callback integration
+ *   7. Parent error prop takes precedence over internal error
+ *   8. jest-axe accessibility audit
+ *   9. Edge cases: fast type/blur sequences, whitespace-only, special chars
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { WalletAddressInput } from '../WalletAddressInput';
+import { assertNoA11yViolations } from '@/test-utils/a11y';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const VALID_ADDRESS = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+const VALID_ADDRESS_LOWERCASE = VALID_ADDRESS.toLowerCase();
+const INVALID_TOO_SHORT = 'GABC';
+const INVALID_NO_G_PREFIX = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const INVALID_BAD_CHECKSUM = 'GAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQDZ7I';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderInput(props?: Partial<Parameters<typeof WalletAddressInput>[0]>) {
+  const onValidation = jest.fn();
+  const onChange = jest.fn();
+  const utils = render(
+    <WalletAddressInput
+      id="wallet-address"
+      label="Wallet address"
+      value=""
+      onChange={onChange}
+      onValidation={onValidation}
+      {...props}
+    />
+  );
+  return { ...utils, onValidation, onChange };
+}
+
+function getInput() {
+  return screen.getByLabelText(/wallet address/i) as HTMLInputElement;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Rendering
+// ---------------------------------------------------------------------------
+
+describe('WalletAddressInput – rendering', () => {
+  it('renders a labelled text input with placeholder', () => {
+    renderInput();
+    const input = getInput();
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('type', 'text');
+    expect(input).toHaveAttribute('id', 'wallet-address');
+    expect(input).toHaveAttribute('placeholder', 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
+  });
+
+  it('renders custom placeholder when provided', () => {
+    renderInput({ placeholder: 'GABC…' });
+    expect(getInput()).toHaveAttribute('placeholder', 'GABC…');
+  });
+
+  it('renders helper text when provided', () => {
+    renderInput({ helperText: '56-character public key' });
+    expect(screen.getByText('56-character public key')).toBeInTheDocument();
+  });
+
+  it('renders required indicator in the label when required is true', () => {
+    renderInput({ required: true });
+    const label = document.querySelector('label');
+    expect(label?.querySelector('[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it('does not render required indicator when required is false', () => {
+    renderInput({ required: false });
+    const label = document.querySelector('label');
+    expect(label?.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('does not render an error paragraph when there is no error', () => {
+    renderInput();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Validation on blur
+// ---------------------------------------------------------------------------
+
+describe('WalletAddressInput – onBlur validation', () => {
+  it('shows required error when blurring an empty input', () => {
+    const onValidation = jest.fn();
+    render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value=""
+        onChange={jest.fn()}
+        onValidation={onValidation}
+        required
+      />
+    );
+
+    fireEvent.blur(getInput());
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Wallet address is required');
+    expect(onValidation).toHaveBeenCalledWith('wallet-address', 'Wallet address is required');
+  });
+
+  it('does not show required error on blur when not required and empty', () => {
+    renderInput({ required: false });
+    fireEvent.blur(getInput());
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows format error when blurring an invalid address', () => {
+    renderInput({ value: INVALID_TOO_SHORT, required: true });
+
+    fireEvent.blur(getInput());
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Wallet address must be a valid Stellar G... address'
+    );
+  });
+
+  it('shows format error for an address with the wrong checksum', () => {
+    renderInput({ value: INVALID_BAD_CHECKSUM, required: true });
+
+    fireEvent.blur(getInput());
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Wallet address must be a valid Stellar G... address'
+    );
+  });
+
+  it('shows format error for an address without a G prefix', () => {
+    renderInput({ value: INVALID_NO_G_PREFIX, required: true });
+
+    fireEvent.blur(getInput());
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Wallet address must be a valid Stellar G... address'
+    );
+  });
+
+  it('shows no error when blurring a valid address', () => {
+    renderInput({ value: VALID_ADDRESS, required: true });
+
+    fireEvent.blur(getInput());
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows no error when blurring a valid lowercase address (normalized on blur)', () => {
+    renderInput({ value: VALID_ADDRESS_LOWERCASE, required: true });
+
+    fireEvent.blur(getInput());
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows no error when blurring a valid address with whitespace', () => {
+    const onChange = jest.fn();
+    render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value={`  ${VALID_ADDRESS_LOWERCASE}  `}
+        onChange={onChange}
+        required
+      />
+    );
+
+    fireEvent.blur(getInput());
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    // Should normalize: trim + uppercase
+    expect(onChange).toHaveBeenCalledWith(VALID_ADDRESS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Normalization on blur
+// ---------------------------------------------------------------------------
+
+describe('WalletAddressInput – normalization on blur', () => {
+  it('normalizes lowercase to uppercase on blur', () => {
+    const onChange = jest.fn();
+    render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value={VALID_ADDRESS_LOWERCASE}
+        onChange={onChange}
+        required
+      />
+    );
+
+    fireEvent.blur(getInput());
+
+    expect(onChange).toHaveBeenCalledWith(VALID_ADDRESS);
+  });
+
+  it('trims whitespace on blur', () => {
+    const onChange = jest.fn();
+    render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value={`   ${VALID_ADDRESS}   `}
+        onChange={onChange}
+        required
+      />
+    );
+
+    fireEvent.blur(getInput());
+    expect(onChange).toHaveBeenCalledWith(VALID_ADDRESS);
+  });
+
+  it('does not fire onChange on blur when value is already normalized', () => {
+    const onChange = jest.fn();
+    render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value={VALID_ADDRESS}
+        onChange={onChange}
+        required
+      />
+    );
+
+    fireEvent.blur(getInput());
+    // Already normalized — no change event
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onChange on blur when value is empty', () => {
+    const onChange = jest.fn();
+    render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value=""
+        onChange={onChange}
+        required
+      />
+    );
+
+    fireEvent.blur(getInput());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. aria-invalid and aria-describedby
+// ---------------------------------------------------------------------------
+
+describe('WalletAddressInput – accessible error linking', () => {
+  it('sets aria-invalid="false" when there is no error', () => {
+    renderInput({ value: VALID_ADDRESS });
+    fireEvent.blur(getInput());
+    expect(getInput()).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it('sets aria-invalid="true" when there is a blur error', () => {
+    renderInput({ value: INVALID_TOO_SHORT, required: true });
+    fireEvent.blur(getInput());
+    expect(getInput()).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('sets aria-invalid="true" when a parent error is passed', () => {
+    renderInput({ value: INVALID_TOO_SHORT, error: 'Parent says this is invalid' });
+    expect(getInput()).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('wires aria-describedby to the error element id on blur', () => {
+    renderInput({ value: INVALID_TOO_SHORT, required: true });
+    fireEvent.blur(getInput());
+    expect(getInput()).toHaveAttribute(
+      'aria-describedby',
+      expect.stringContaining('wallet-address-error')
+    );
+  });
+
+  it('wires aria-describedby to the helper text id', () => {
+    renderInput({ helperText: '56 characters starting with G' });
+    expect(getInput()).toHaveAttribute(
+      'aria-describedby',
+      expect.stringContaining('wallet-address-helper')
+    );
+  });
+
+  it('wires both error and helper IDs to aria-describedby when both are present', () => {
+    renderInput({ helperText: '56 characters starting with G', value: INVALID_TOO_SHORT, required: true });
+    fireEvent.blur(getInput());
+    const describedBy = getInput().getAttribute('aria-describedby') ?? '';
+    expect(describedBy).toContain('wallet-address-error');
+    expect(describedBy).toContain('wallet-address-helper');
+  });
+
+  it('error message element has role="alert"', () => {
+    renderInput({ value: INVALID_TOO_SHORT, required: true });
+    fireEvent.blur(getInput());
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Error clearing on change
+// ---------------------------------------------------------------------------
+
+describe('WalletAddressInput – error clearing on change', () => {
+  it('clears the blur error as soon as the user starts typing', () => {
+    const onValidation = jest.fn();
+    const TestHarness = () => {
+      const [value, setValue] = React.useState(INVALID_TOO_SHORT);
+      return (
+        <WalletAddressInput
+          id="wallet-address"
+          label="Wallet address"
+          value={value}
+          onChange={setValue}
+          onValidation={onValidation}
+          required
+        />
+      );
+    };
+
+    render(<TestHarness />);
+
+    // First blur triggers the error
+    fireEvent.blur(getInput());
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    // Now type to clear
+    fireEvent.change(getInput(), { target: { value: VALID_ADDRESS } });
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(onValidation).toHaveBeenLastCalledWith('wallet-address', null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. onValidation callback
+// ---------------------------------------------------------------------------
+
+describe('WalletAddressInput – onValidation callback', () => {
+  it('calls onValidation with null when blurring a valid address', () => {
+    const onValidation = jest.fn();
+    render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value={VALID_ADDRESS}
+        onChange={jest.fn()}
+        onValidation={onValidation}
+        required
+      />
+    );
+
+    fireEvent.blur(getInput());
+    expect(onValidation).toHaveBeenCalledWith('wallet-address', null);
+  });
+
+  it('calls onValidation with error message when blurring an invalid address', () => {
+    const onValidation = jest.fn();
+    render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value={INVALID_TOO_SHORT}
+        onChange={jest.fn()}
+        onValidation={onValidation}
+        required
+      />
+    );
+
+    fireEvent.blur(getInput());
+    expect(onValidation).toHaveBeenCalledWith(
+      'wallet-address',
+      'Wallet address must be a valid Stellar G... address'
+    );
+  });
+
+  it('calls onValidation with null on change after a previous error', () => {
+    const onValidation = jest.fn();
+    const TestHarness = () => {
+      const [value, setValue] = React.useState(INVALID_TOO_SHORT);
+      return (
+        <WalletAddressInput
+          id="wallet-address"
+          label="Wallet address"
+          value={value}
+          onChange={setValue}
+          onValidation={onValidation}
+          required
+        />
+      );
+    };
+
+    render(<TestHarness />);
+
+    // Blur triggers error
+    fireEvent.blur(getInput());
+    expect(onValidation).toHaveBeenCalledWith(
+      'wallet-address',
+      expect.any(String)
+    );
+
+    onValidation.mockClear();
+
+    // Change clears
+    fireEvent.change(getInput(), { target: { value: VALID_ADDRESS } });
+    expect(onValidation).toHaveBeenCalledWith('wallet-address', null);
+  });
+
+  it('handles rapid blur-then-change sequences without stale state', () => {
+    const onValidation = jest.fn();
+    const TestHarness = () => {
+      const [value, setValue] = React.useState(INVALID_TOO_SHORT);
+      return (
+        <WalletAddressInput
+          id="wallet-address"
+          label="Wallet address"
+          value={value}
+          onChange={setValue}
+          onValidation={onValidation}
+          required
+        />
+      );
+    };
+
+    render(<TestHarness />);
+
+    // Rapid blur → change → blur
+    fireEvent.blur(getInput());
+    fireEvent.change(getInput(), { target: { value: VALID_ADDRESS } });
+    fireEvent.blur(getInput());
+
+    // Final state: no error
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(onValidation).toHaveBeenLastCalledWith('wallet-address', null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Parent error takes precedence
+// ---------------------------------------------------------------------------
+
+describe('WalletAddressInput – parent error precedence', () => {
+  it('shows parent error even when internal blur error would differ', () => {
+    render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value={VALID_ADDRESS}
+        onChange={jest.fn()}
+        error="Submit-error: fix this address"
+        required
+      />
+    );
+
+    // Even with a valid value, parent error is displayed
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Submit-error: fix this address');
+  });
+
+  it('shows parent error even after a valid blur clears internal error', () => {
+    render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value={VALID_ADDRESS}
+        onChange={jest.fn()}
+        error="Still broken from submit"
+        required
+      />
+    );
+
+    fireEvent.blur(getInput());
+
+    // Internal validation passed, but parent error persists
+    expect(screen.getByRole('alert')).toHaveTextContent('Still broken from submit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Edge cases
+// ---------------------------------------------------------------------------
+
+describe('WalletAddressInput – edge cases', () => {
+  it('handles whitespace-only input on blur', () => {
+    renderInput({ value: '     ', required: true });
+
+    fireEvent.blur(getInput());
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Wallet address is required');
+  });
+
+  it('handles very long invalid input gracefully', () => {
+    const longInput = 'G' + 'A'.repeat(100);
+    renderInput({ value: longInput, required: true });
+
+    fireEvent.blur(getInput());
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Wallet address must be a valid Stellar G... address'
+    );
+  });
+
+  it('handles special characters in input', () => {
+    renderInput({ value: 'G!@#$%^&*()_+', required: true });
+
+    fireEvent.blur(getInput());
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Wallet address must be a valid Stellar G... address'
+    );
+  });
+
+  it('renders with custom label and id', () => {
+    render(
+      <WalletAddressInput
+        id="freelancerAddress"
+        label="Freelancer Stellar address"
+        value=""
+        onChange={jest.fn()}
+        required
+      />
+    );
+
+    expect(screen.getByLabelText(/freelancer stellar address/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/freelancer stellar address/i)).toHaveAttribute(
+      'id',
+      'freelancerAddress'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Accessibility — jest-axe audits
+// ---------------------------------------------------------------------------
+
+describe('WalletAddressInput – jest-axe audits', () => {
+  it('has no axe violations in default state', async () => {
+    const { container } = render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value=""
+        onChange={jest.fn()}
+        helperText="Must be a valid Stellar public key starting with G"
+        required
+      />
+    );
+    await assertNoA11yViolations(container);
+  });
+
+  it('has no axe violations with an error shown', async () => {
+    const { container } = render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value={INVALID_TOO_SHORT}
+        onChange={jest.fn()}
+        error="Wallet address must be a valid Stellar G... address"
+        required
+      />
+    );
+    await assertNoA11yViolations(container);
+  });
+
+  it('has no axe violations with a valid address', async () => {
+    const { container } = render(
+      <WalletAddressInput
+        id="wallet-address"
+        label="Wallet address"
+        value={VALID_ADDRESS}
+        onChange={jest.fn()}
+        helperText="56 characters starting with G"
+        required
+      />
+    );
+    await assertNoA11yViolations(container);
+  });
+});

--- a/src/components/contracts/CreateContractForm.tsx
+++ b/src/components/contracts/CreateContractForm.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { FormField } from '@/components/FormField';
 import { ErrorSummary } from '@/components/ErrorSummary';
+import { WalletAddressInput } from '@/components/WalletAddressInput';
 import { useToast } from '@/components/toast/toast-provider';
 import { saveContract } from '@/lib/repository';
 import { normalizeStellarAddress } from '@/lib/stellarAddress';
@@ -53,6 +54,23 @@ const CreateContractForm: React.FC<CreateContractFormProps> = ({ onSuccess, onCa
   const [totalValue, setTotalValue] = useState('');
   const [currency, setCurrency] = useState<string>(CURRENCY_OPTIONS[0]);
   const [errors, setErrors] = useState<ValidationError[]>([]);
+
+  /**
+   * Called by WalletAddressInput on blur to update the parent's errors
+   * state so ErrorSummary stays in sync with the inline error.
+   */
+  const handleWalletValidation = useCallback(
+    (fieldId: string, error: string | null) => {
+      setErrors((prev) => {
+        const filtered = prev.filter((e) => e.fieldId !== fieldId);
+        if (error) {
+          return [...filtered, { fieldId, message: error }];
+        }
+        return filtered;
+      });
+    },
+    []
+  );
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -128,22 +146,16 @@ const CreateContractForm: React.FC<CreateContractFormProps> = ({ onSuccess, onCa
           />
         </FormField>
 
-        <FormField
+        <WalletAddressInput
           id="freelancerAddress"
           label="Freelancer Stellar address"
           helperText="Must be a valid Stellar public key starting with G"
+          value={freelancerAddress}
+          onChange={setFreelancerAddress}
           error={errors.find((e) => e.fieldId === 'freelancerAddress')?.message}
           required
-        >
-          <input
-            type="text"
-            value={freelancerAddress}
-            onChange={(e) => setFreelancerAddress(e.target.value)}
-            placeholder="GABC…"
-            autoComplete="off"
-            className={`${inputClass} font-mono`}
-          />
-        </FormField>
+          onValidation={handleWalletValidation}
+        />
 
         <FormField
           id="totalValue"


### PR DESCRIPTION
## Description

This PR adds real-time client-side validation with accessible inline errors to wallet address inputs. It introduces a reusable `WalletAddressInput` component that validates Stellar addresses on blur, mirroring the server-side `isValidStellarAddress` checks.

### Changes

- **New: `src/components/WalletAddressInput.tsx`** - Reusable controlled component that wraps `FormField` with on-blur Stellar address validation.
  - Validates on blur: empty → "required" error, invalid format → "must be a valid Stellar G... address" error
  - Auto-normalizes addresses to uppercase on blur (trim + uppercase)
  - Clears errors as the user types to correct input
  - `onValidation` callback for parent form `ErrorSummary` sync
  - Parent `error` prop takes precedence over internal blur error
  - `maxLength={56}`, `autoCapitalize="off"`, `spellCheck={false}`
  - Accessible: `aria-invalid`, `aria-describedby` (links to error + helper text), `role="alert"`
- **Updated: `src/components/contracts/CreateContractForm.tsx`** - Replaced plain `FormField` + `input` for the freelancer address with `WalletAddressInput`. Added `handleWalletValidation` to sync blur errors with the central `errors` state for `ErrorSummary`.
- **New: `src/components/__tests__/WalletAddressInput.test.tsx`** - 39 comprehensive tests.

### Accessibility

- `aria-invalid="true"` when address is invalid, `"false"` when valid
- `aria-describedby` links the input to the inline error (`role="alert"`) and helper text
- `role="alert"` on error messages for immediate screen reader announcement
- `autoCapitalize="off"` prevents mobile browser interference
- jest-axe audits pass in default, error, and valid states

### Test Coverage — 39 new tests

```
PASS src/components/__tests__/WalletAddressInput.test.tsx
  WalletAddressInput – rendering
    ✓ renders a labelled text input with placeholder
    ✓ renders custom placeholder when provided
    ✓ renders helper text when provided
    ✓ renders required indicator in the label when required is true
    ✓ does not render required indicator when required is false
    ✓ does not render an error paragraph when there is no error
  WalletAddressInput – onBlur validation
    ✓ shows required error when blurring an empty input
    ✓ does not show required error on blur when not required and empty
    ✓ shows format error when blurring an invalid address
    ✓ shows format error for an address with the wrong checksum
    ✓ shows format error for an address without a G prefix
    ✓ shows no error when blurring a valid address
    ✓ shows no error when blurring a valid lowercase address (normalized on blur)
    ✓ shows no error when blurring a valid address with whitespace
  WalletAddressInput – normalization on blur
    ✓ normalizes lowercase to uppercase on blur
    ✓ trims whitespace on blur
    ✓ does not fire onChange on blur when value is already normalized
    ✓ does not fire onChange on blur when value is empty
  WalletAddressInput – accessible error linking
    ✓ sets aria-invalid="false" when there is no error
    ✓ sets aria-invalid="true" when there is a blur error
    ✓ sets aria-invalid="true" when a parent error is passed
    ✓ wires aria-describedby to the error element id on blur
    ✓ wires aria-describedby to the helper text id
    ✓ wires both error and helper IDs to aria-describedby when both are present
    ✓ error message element has role="alert"
  WalletAddressInput – error clearing on change
    ✓ clears the blur error as soon as the user starts typing
  WalletAddressInput – onValidation callback
    ✓ calls onValidation with null when blurring a valid address
    ✓ calls onValidation with error message when blurring an invalid address
    ✓ calls onValidation with null on change after a previous error
    ✓ handles rapid blur-then-change sequences without stale state
  WalletAddressInput – parent error precedence
    ✓ shows parent error even when internal blur error would differ
    ✓ shows parent error even after a valid blur clears internal error
  WalletAddressInput – edge cases
    ✓ handles whitespace-only input on blur
    ✓ handles very long invalid input gracefully
    ✓ handles special characters in input
    ✓ renders with custom label and id
  WalletAddressInput – jest-axe audits
    ✓ has no axe violations in default state
    ✓ has no axe violations with an error shown
    ✓ has no axe violations with a valid address
```

Existing `CreateContractForm` tests (10 tests) continue to pass unchanged.

---

## Full Test Output

```
npm test
Test Suites: 74 passed, 74 total
Tests:       1292 passed, 1292 total
Snapshots:   7 passed, 7 total
Time:        32.463 s
```

## Pre-flight Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures (1292/1292)
- [x] `npm run build` N/A — component-level changes, no build config changes

Closes #629