### PR TITLE
feat(forms): add command-palette entry for forms

### DIFF
--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -7,6 +7,7 @@ import RootLayout from '../layout';
 // Mock next/navigation for RouteAnnouncer's usePathname call.
 jest.mock('next/navigation', () => ({
   usePathname: jest.fn().mockReturnValue('/'),
+  useRouter: () => ({ push: jest.fn() }),
 }));
 
 function renderLayout() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,6 +52,7 @@ import { WalletProvider } from '@/contexts/WalletContext';
 import RouteAnnouncer from '@/components/RouteAnnouncer';
 import Navbar from '@/components/Navbar';
 import HeaderActions from '@/components/HeaderActions';
+import CommandPalette from '@/components/CommandPalette';
 
 export default function RootLayout({
   children,
@@ -88,6 +89,7 @@ export default function RootLayout({
                 </main>
               </div>
               <SettingsTrigger />
+              <CommandPalette />
             </WalletProvider>
           </ToastProvider>
         </PreferencesProvider>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface PaletteEntry {
+  id: string;
+  label: string;
+  keywords: string[];
+  href: string;
+}
+
+const PALETTE_ENTRIES: PaletteEntry[] = [
+  { id: 'new-contract', label: 'New Contract', keywords: ['create', 'contract', 'agreement', 'form'], href: '/contracts' },
+  { id: 'new-milestone', label: 'New Milestone', keywords: ['create', 'milestone', 'payment', 'progress', 'form'], href: '/milestones' },
+  { id: 'contracts', label: 'Go to Contracts', keywords: ['contract', 'list', 'all'], href: '/contracts' },
+  { id: 'milestones', label: 'Go to Milestones', keywords: ['milestone', 'list', 'all'], href: '/milestones' },
+  { id: 'reputation', label: 'Go to Reputation', keywords: ['reputation', 'score', 'profile'], href: '/reputation' },
+];
+
+export default function CommandPalette(): React.JSX.Element {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return PALETTE_ENTRIES;
+    const lower = query.toLowerCase();
+    return PALETTE_ENTRIES.filter(
+      (entry) =>
+        entry.label.toLowerCase().includes(lower) ||
+        entry.keywords.some((k) => k.includes(lower)),
+    );
+  }, [query]);
+
+  const handleOpen = useCallback(() => {
+    setIsOpen(true);
+    setQuery('');
+    setActiveIndex(0);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    setQuery('');
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  }, []);
+
+  const handleNavigate = useCallback(
+    (href: string) => {
+      router.push(href);
+      handleClose();
+    },
+    [router, handleClose],
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const isModK = (e.metaKey || e.ctrlKey) && e.key === 'k';
+      if (isModK) {
+        e.preventDefault();
+        if (isOpen) {
+          handleClose();
+        } else {
+          handleOpen();
+        }
+        return;
+      }
+      if (!isOpen) return;
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleClose();
+        return;
+      }
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIndex((prev) => (prev + 1) % filtered.length);
+        return;
+      }
+
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex((prev) => (prev - 1 + filtered.length) % filtered.length);
+        return;
+      }
+
+      if (e.key === 'Enter' && filtered.length > 0) {
+        e.preventDefault();
+        handleNavigate(filtered[activeIndex].href);
+        return;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, filtered, activeIndex, handleOpen, handleClose, handleNavigate]);
+
+  useEffect(() => {
+    if (isOpen) {
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  const activeDescendantId = filtered.length > 0 ? `command-${filtered[activeIndex].id}` : undefined;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={handleOpen}
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:right-2 focus:z-50 focus:rounded-lg focus:bg-blue-600 focus:px-4 focus:py-2 focus:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+        aria-label="Open command palette"
+      >
+        Open command palette (Ctrl+K)
+      </button>
+
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
+          role="presentation"
+        >
+          <div
+            className="fixed inset-0 bg-black/50 backdrop-blur-sm"
+            onClick={handleClose}
+            aria-hidden="true"
+          />
+
+          <div
+            className="relative w-full max-w-lg rounded-2xl border border-slate-200 bg-white shadow-2xl"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Command palette"
+          >
+            <div className="flex items-center border-b border-slate-200 px-4">
+              <svg
+                aria-hidden="true"
+                className="h-5 w-5 shrink-0 text-slate-400"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <path d="m21 21-4.35-4.35" />
+              </svg>
+              <input
+                ref={inputRef}
+                type="text"
+                role="combobox"
+                aria-expanded={filtered.length > 0}
+                aria-controls="command-palette-listbox"
+                aria-activedescendant={activeDescendantId}
+                aria-autocomplete="list"
+                aria-label="Search commands"
+                placeholder="Search commands..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="w-full border-none bg-transparent px-3 py-4 text-sm text-slate-900 placeholder-slate-400 focus:outline-none"
+              />
+              <kbd className="hidden shrink-0 rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-xs text-slate-400 sm:inline-block">
+                ESC
+              </kbd>
+            </div>
+
+            {filtered.length === 0 ? (
+              <div className="px-3 py-8 text-center text-sm text-slate-400">
+                No results found
+              </div>
+            ) : (
+              <ul
+                ref={listRef}
+                id="command-palette-listbox"
+                role="listbox"
+                aria-label="Commands"
+                className="max-h-80 overflow-y-auto p-2"
+              >
+                {filtered.map((entry, index) => {
+                  const isActive = index === activeIndex;
+                  return (
+                    <li
+                      key={entry.id}
+                      id={`command-${entry.id}`}
+                      role="option"
+                      aria-selected={isActive}
+                      onClick={() => handleNavigate(entry.href)}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      className={[
+                        'flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors',
+                        isActive
+                          ? 'bg-blue-600 text-white'
+                          : 'text-slate-700 hover:bg-slate-100',
+                      ].join(' ')}
+                    >
+                      <span className="font-medium">{entry.label}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,389 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import CommandPalette from '../CommandPalette';
+
+expect.extend(toHaveNoViolations);
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+function renderPalette() {
+  return render(<CommandPalette />);
+}
+
+function openPalette() {
+  fireEvent.keyDown(document, { key: 'k', metaKey: true, code: 'KeyK', bubbles: true });
+}
+
+beforeAll(() => {
+  jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    cb(0);
+    return 0;
+  });
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe('CommandPalette — trigger', () => {
+  it('renders a visually hidden trigger button', () => {
+    renderPalette();
+    const trigger = screen.getByRole('button', { name: /open command palette/i });
+    expect(trigger).toBeInTheDocument();
+    expect(trigger.className).toMatch(/sr-only/);
+  });
+});
+
+describe('CommandPalette — open / close', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens on Meta+K', () => {
+    renderPalette();
+    openPalette();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    const combobox = screen.getByRole('combobox');
+    expect(combobox).toBeInTheDocument();
+    expect(combobox).toHaveFocus();
+  });
+
+  it('opens on Ctrl+K', () => {
+    renderPalette();
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true, code: 'KeyK', bubbles: true });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    renderPalette();
+    openPalette();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape', bubbles: true });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('closes when clicking the backdrop', async () => {
+    renderPalette();
+    openPalette();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    const backdrop = document.querySelector('[aria-hidden="true"]');
+    expect(backdrop).toBeInTheDocument();
+    if (backdrop) fireEvent.click(backdrop);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+  });
+
+  it('Meta+K toggles closed when already open', () => {
+    renderPalette();
+    openPalette();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    openPalette();
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});
+
+describe('CommandPalette — entries', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists all palette entries when query is empty', () => {
+    renderPalette();
+    openPalette();
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(5);
+    expect(screen.getByText('New Contract')).toBeInTheDocument();
+    expect(screen.getByText('New Milestone')).toBeInTheDocument();
+    expect(screen.getByText('Go to Contracts')).toBeInTheDocument();
+    expect(screen.getByText('Go to Milestones')).toBeInTheDocument();
+    expect(screen.getByText('Go to Reputation')).toBeInTheDocument();
+  });
+
+  it('filters by label text', () => {
+    renderPalette();
+    openPalette();
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'reputation' } });
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(screen.getByText('Go to Reputation')).toBeInTheDocument();
+  });
+
+  it('filters by keyword', () => {
+    renderPalette();
+    openPalette();
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'agreement' } });
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(screen.getByText('New Contract')).toBeInTheDocument();
+  });
+
+  it('shows no results when no match', () => {
+    renderPalette();
+    openPalette();
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'zzznonexistent' } });
+
+    expect(screen.queryByRole('option')).toBeNull();
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+  });
+
+  it('the forms entries are searchable via the label', () => {
+    renderPalette();
+    openPalette();
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'New Contract' } });
+
+    expect(screen.getByText('New Contract')).toBeInTheDocument();
+    expect(screen.queryByText('New Milestone')).toBeNull();
+  });
+
+  it('the forms entries are searchable via the keyword "form"', () => {
+    renderPalette();
+    openPalette();
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'form' } });
+
+    expect(screen.getByText('New Contract')).toBeInTheDocument();
+    expect(screen.getByText('New Milestone')).toBeInTheDocument();
+    expect(screen.queryByText('Go to Reputation')).toBeNull();
+  });
+
+  it('has no duplicate entries', () => {
+    renderPalette();
+    openPalette();
+
+    const options = screen.getAllByRole('option');
+    const ids = options.map((o) => o.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('CommandPalette — navigation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('navigates on click', async () => {
+    renderPalette();
+    openPalette();
+
+    await userEvent.click(screen.getByText('New Contract'));
+
+    expect(mockPush).toHaveBeenCalledWith('/contracts');
+  });
+
+  it('closes after navigation on click', async () => {
+    renderPalette();
+    openPalette();
+
+    await userEvent.click(screen.getByText('New Contract'));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+  });
+
+  it('navigates with Enter on the active item', () => {
+    renderPalette();
+    openPalette();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Enter', code: 'Enter', bubbles: true });
+
+    expect(mockPush).toHaveBeenCalledWith('/contracts');
+  });
+
+  it('navigates to the correct item after arrow down', () => {
+    renderPalette();
+    openPalette();
+
+    fireEvent.keyDown(document, { key: 'ArrowDown', code: 'ArrowDown', bubbles: true });
+    fireEvent.keyDown(document, { key: 'Enter', code: 'Enter', bubbles: true });
+
+    expect(mockPush).toHaveBeenCalledWith('/milestones');
+  });
+
+  it('navigates to the correct item after arrow up', () => {
+    renderPalette();
+    openPalette();
+
+    fireEvent.keyDown(document, { key: 'ArrowUp', code: 'ArrowUp', bubbles: true });
+    fireEvent.keyDown(document, { key: 'Enter', code: 'Enter', bubbles: true });
+
+    expect(mockPush).toHaveBeenCalledWith('/reputation');
+  });
+
+  it('closes after navigation via Enter', () => {
+    renderPalette();
+    openPalette();
+
+    fireEvent.keyDown(document, { key: 'Enter', code: 'Enter', bubbles: true });
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});
+
+describe('CommandPalette — keyboard navigation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('first item is active by default', () => {
+    renderPalette();
+    openPalette();
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('ArrowDown moves active index forward', () => {
+    renderPalette();
+    openPalette();
+
+    fireEvent.keyDown(document, { key: 'ArrowDown', code: 'ArrowDown', bubbles: true });
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('ArrowDown wraps to first item', () => {
+    renderPalette();
+    openPalette();
+
+    for (let i = 0; i < 5; i++) {
+      fireEvent.keyDown(document, { key: 'ArrowDown', code: 'ArrowDown', bubbles: true });
+    }
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('ArrowUp wraps to last item', () => {
+    renderPalette();
+    openPalette();
+
+    fireEvent.keyDown(document, { key: 'ArrowUp', code: 'ArrowUp', bubbles: true });
+
+    const options = screen.getAllByRole('option');
+    expect(options[options.length - 1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('mouse hover selects an item', () => {
+    renderPalette();
+    openPalette();
+
+    fireEvent.mouseEnter(screen.getByText('Go to Reputation'));
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    expect(options[4]).toHaveAttribute('aria-selected', 'true');
+  });
+});
+
+describe('CommandPalette — ARIA attributes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('combobox has proper ARIA attributes', () => {
+    renderPalette();
+    openPalette();
+
+    const combobox = screen.getByRole('combobox');
+    expect(combobox).toHaveAttribute('aria-expanded', 'true');
+    expect(combobox).toHaveAttribute('aria-autocomplete', 'list');
+    expect(combobox).toHaveAttribute('aria-controls', 'command-palette-listbox');
+  });
+
+  it('listbox has proper role and label', () => {
+    renderPalette();
+    openPalette();
+
+    const listbox = screen.getByRole('listbox');
+    expect(listbox).toHaveAttribute('aria-label', 'Commands');
+  });
+
+  it('dialog has proper label', () => {
+    renderPalette();
+    openPalette();
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-label', 'Command palette');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+});
+
+describe('CommandPalette — accessibility', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('has no axe violations when open', async () => {
+    const { container } = renderPalette();
+    openPalette();
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no axe violations when closed', async () => {
+    const { container } = renderPalette();
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no axe violations after filter shows no results', async () => {
+    const { container } = renderPalette();
+    openPalette();
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'zzznonexistent' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('No results found')).toBeInTheDocument();
+    });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('CommandPalette — unmount', () => {
+  it('unmounts cleanly without throwing', () => {
+    const { unmount } = renderPalette();
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it('unmounts while open without throwing', () => {
+    const { unmount } = renderPalette();
+    openPalette();
+    expect(() => unmount()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Expose forms in the command palette so power users can quickly navigate to form-related pages via keyboard (Cmd+K / Ctrl+K).

Changes:
- New CommandPalette component with Cmd+K/Ctrl+K trigger, Escape to close, arrow-key navigation, Enter to select, and filter-as-you-type
- Registered forms entries: New Contract at /contracts and New Milestone at /milestones, both with keyword form for discoverability, plus general navigation entries for all routes
- ARIA combobox pattern with role=listbox, role=option, aria-activedescendant, and proper focus management
- Mounted CommandPalette in root layout (src/app/layout.tsx)
- 32 comprehensive tests covering open/close, filtering, keyboard navigation, click navigation, ARIA attributes, accessibility audits (jest-axe), no-duplicate-entries, and clean unmount
- Updated layout test mock to include useRouter

Closes #711 
