### PR TITLE
test(contracts): add structural snapshot tests

### DIFF
--- a/src/app/contracts/__tests__/__snapshots__/page.test.tsx.snap
+++ b/src/app/contracts/__tests__/__snapshots__/page.test.tsx.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContractsPage Structure Snapshots matches snapshot for the empty state 1`] = `
+<main
+  class="min-h-screen p-8"
+>
+  <h1
+    class="text-2xl font-bold mb-6"
+  >
+    Contracts
+  </h1>
+  <div
+    aria-labelledby="_r_e_"
+    class="flex flex-col items-center justify-center px-4 py-8 text-center sm:px-8 sm:py-10"
+    role="region"
+  >
+    <div
+      aria-hidden="true"
+      class="mb-5 inline-flex h-24 w-24 items-center justify-center rounded-2xl ring-1 bg-blue-50 text-blue-700 ring-blue-100"
+    >
+      <svg
+        aria-hidden="true"
+        class="h-16 w-16"
+        fill="none"
+        viewBox="0 0 64 64"
+      >
+        <rect
+          height="44"
+          rx="6"
+          stroke="currentColor"
+          stroke-width="4"
+          width="36"
+          x="14"
+          y="12"
+        />
+        <path
+          d="M23 26h18M23 36h18M23 46h12"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="4"
+        />
+      </svg>
+    </div>
+    <h2
+      class="mb-2 max-w-xl text-xl font-semibold text-gray-950"
+      id="_r_e_"
+    >
+      No contracts found
+    </h2>
+    <p
+      class="mb-5 max-w-md text-sm leading-6 text-gray-700 sm:text-base"
+    >
+      You haven't created any contracts yet. Start by creating your first contract to begin freelancing securely.
+    </p>
+    <div
+      class="flex w-full max-w-md flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row"
+    >
+      <button
+        aria-label="Create Contract"
+        class="rounded-md bg-blue-700 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-800 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-900"
+        type="button"
+      >
+        Create Contract
+      </button>
+    </div>
+  </div>
+</main>
+`;
+
+exports[`ContractsPage Structure Snapshots matches snapshot for the loaded state with contracts 1`] = `
+<main
+  class="min-h-screen p-8"
+>
+  <h1
+    class="text-2xl font-bold mb-6"
+  >
+    Contracts
+  </h1>
+  <div
+    class="mb-4 flex justify-end"
+  >
+    <button
+      class="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+      type="button"
+    >
+      Create Contract
+    </button>
+  </div>
+  <ul
+    class="space-y-4"
+  >
+    <li
+      class="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm"
+    >
+      <p
+        class="font-semibold text-slate-900"
+      >
+        Website Redesign
+      </p>
+      <p
+        class="text-sm text-slate-500"
+      >
+        Active
+         · Created 
+        Jan 15, 2025
+      </p>
+    </li>
+    <li
+      class="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm"
+    >
+      <p
+        class="font-semibold text-slate-900"
+      >
+        Mobile App Development
+      </p>
+      <p
+        class="text-sm text-slate-500"
+      >
+        Pending
+         · Created 
+        Feb 1, 2025
+      </p>
+    </li>
+  </ul>
+</main>
+`;

--- a/src/app/contracts/__tests__/page.test.tsx
+++ b/src/app/contracts/__tests__/page.test.tsx
@@ -438,6 +438,49 @@ describe('ContractsPage', () => {
     expect(screen.getByText(/Active · Created Apr 20, 2026/)).toBeInTheDocument();
   });
 
+  describe('Structure Snapshots', () => {
+    it('matches snapshot for the empty state', () => {
+      mockListContracts.mockReturnValue([]);
+      const { container } = render(<ContractsPage />);
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('matches snapshot for the loaded state with contracts', () => {
+      const mockContracts = [
+        {
+          contractName: 'Website Redesign',
+          parties: [
+            { label: 'Client', address: VALID_ADDRESS },
+            { label: 'Freelancer', address: VALID_ADDRESS },
+          ],
+          totalValue: 5000,
+          currency: 'USD',
+          status: 'Active' as const,
+          createdAt: 'Jan 15, 2025',
+          milestoneCount: 3,
+        },
+        {
+          contractName: 'Mobile App Development',
+          parties: [
+            { label: 'Client', address: VALID_ADDRESS },
+            { label: 'Developer', address: VALID_ADDRESS },
+          ],
+          totalValue: 10000,
+          currency: 'EUR',
+          status: 'Pending' as const,
+          createdAt: 'Feb 1, 2025',
+          milestoneCount: 5,
+        },
+      ];
+
+      mockListContracts.mockReturnValue(mockContracts);
+      const { container } = render(<ContractsPage />);
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+
   it('calls saveContract and refreshes contracts on form submission', async () => {
     mockListContracts.mockReturnValue([]);
     render(<ContractsPage />);


### PR DESCRIPTION
## Summary
Closes #678

Adds deterministic structural/snapshot coverage for the `/contracts` page's rendered output, covering both the empty state and the loaded state (list of contracts). No timestamps or random values are involved — all fixture data uses fixed strings, so the snapshots are stable across runs.

## Changes
- `src/app/contracts/__tests__/page.test.tsx`: new `Structure Snapshots` describe block with two tests — empty state and loaded state (two contracts).
- `src/app/contracts/__tests__/__snapshots__/page.test.tsx.snap`: generated snapshot output.

## Test plan
- `npm run lint` — passes, no errors.
- `npm test` — 73 suites / 1262 tests passed, 9 snapshots passed (2 newly written for this change).
- `npm run build` — production build succeeds, `/contracts` route compiles and prerenders.

### Full test output (relevant run)
```
PASS src/app/contracts/__tests__/page.test.tsx
  ContractsPage
    ...
    Structure Snapshots
      √ matches snapshot for the empty state (16 ms)
      √ matches snapshot for the loaded state with contracts (6 ms)

Test Suites: 73 passed, 73 total
Tests:       1262 passed, 1262 total
Snapshots:   9 passed, 9 total
```