### PR TITLE
feat: CreateStreamForm kbd hints

### DIFF
--- a/src/components/CreateStreamForm.tsx
+++ b/src/components/CreateStreamForm.tsx
@@ -1,0 +1,386 @@
+'use client';
+
+import React, { FormEvent, useCallback, useRef, useState } from 'react';
+import { KbdHint } from '@/components/KbdHint';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Shape of a new payment stream as filled in by the form. */
+export interface StreamFormValues {
+  /** Human-readable stream title / description. */
+  title: string;
+  /** Recipient Stellar address (G…). */
+  recipient: string;
+  /** Flow rate in the chosen currency per second. */
+  ratePerSecond: string;
+  /** Currency ticker (e.g. "XLM", "USDC"). */
+  currency: string;
+}
+
+export interface CreateStreamFormProps {
+  /**
+   * Called with the validated form values when the user submits.
+   * The host component is responsible for the actual blockchain call.
+   */
+  onSubmit: (values: StreamFormValues) => void;
+  /** Called when the user cancels without submitting. */
+  onCancel?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+type FormErrors = Partial<Record<keyof StreamFormValues, string>>;
+
+const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+const CURRENCIES = ['XLM', 'USDC', 'EURC'] as const;
+
+function validateStreamForm(values: StreamFormValues): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!values.title.trim()) {
+    errors.title = 'Stream title is required.';
+  } else if (values.title.trim().length > 200) {
+    errors.title = 'Title must be 200 characters or fewer.';
+  }
+
+  const normalised = values.recipient.trim().toUpperCase();
+  if (!normalised) {
+    errors.recipient = 'Recipient address is required.';
+  } else if (!STELLAR_ADDRESS_RE.test(normalised)) {
+    errors.recipient = 'Enter a valid Stellar public key (starts with G, 56 characters).';
+  }
+
+  const rate = parseFloat(values.ratePerSecond);
+  if (!values.ratePerSecond.trim()) {
+    errors.ratePerSecond = 'Rate per second is required.';
+  } else if (isNaN(rate) || rate <= 0) {
+    errors.ratePerSecond = 'Rate must be a positive number.';
+  }
+
+  if (!values.currency.trim()) {
+    errors.currency = 'Currency is required.';
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the platform-aware modifier key label.
+ * Prefers "⌘" on macOS, "Ctrl" elsewhere.
+ */
+function modKey(): string {
+  if (typeof navigator !== 'undefined' && /mac/i.test(navigator.platform)) {
+    return '⌘';
+  }
+  return 'Ctrl';
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * CreateStreamForm — accessible form for initiating a Stellar payment stream.
+ *
+ * Keyboard shortcuts:
+ *   `Ctrl/⌘ + Enter` — submit the form from any field.
+ *   `Escape`          — invoke `onCancel`.
+ *
+ * Accessibility:
+ *   - Each field has an associated `<label>` and error message linked via
+ *     `aria-describedby` + `aria-invalid`.
+ *   - Keyboard shortcut hints are rendered using the `KbdHint` component,
+ *     which uses `role="img"` with a synthesised `aria-label` so screen
+ *     readers hear the shortcut as a single meaningful unit.
+ *   - The form itself is labelled by the visible heading.
+ *   - Required fields carry `aria-required="true"`.
+ *   - Error messages use `role="alert"` so they are announced immediately.
+ *
+ * Design tokens:
+ *   - Uses `--border`, `--card`, `--muted-foreground` CSS variables so the
+ *     form adapts automatically to light and dark themes.
+ *
+ * @example
+ * ```tsx
+ * <CreateStreamForm
+ *   onSubmit={(values) => initiateStream(values)}
+ *   onCancel={() => setShowForm(false)}
+ * />
+ * ```
+ */
+export const CreateStreamForm: React.FC<CreateStreamFormProps> = ({
+  onSubmit,
+  onCancel,
+}) => {
+  const [values, setValues] = useState<StreamFormValues>({
+    title: '',
+    recipient: '',
+    ratePerSecond: '',
+    currency: 'XLM',
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const firstErrorRef = useRef<HTMLInputElement | HTMLSelectElement | null>(null);
+  const mod = modKey();
+
+  const set = useCallback(
+    (field: keyof StreamFormValues) =>
+      (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        setValues((prev) => ({ ...prev, [field]: e.target.value }));
+        // Clear the per-field error as the user corrects their input
+        if (errors[field]) {
+          setErrors((prev) => ({ ...prev, [field]: undefined }));
+        }
+      },
+    [errors],
+  );
+
+  const handleSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      const errs = validateStreamForm(values);
+      setErrors(errs);
+
+      if (Object.keys(errs).length > 0) {
+        // Move focus to the first invalid field for screen reader users
+        firstErrorRef.current?.focus();
+        return;
+      }
+
+      onSubmit({
+        title: values.title.trim(),
+        recipient: values.recipient.trim().toUpperCase(),
+        ratePerSecond: values.ratePerSecond.trim(),
+        currency: values.currency,
+      });
+    },
+    [values, onSubmit],
+  );
+
+  /** Keyboard shortcut: Ctrl/⌘+Enter submits; Escape cancels. */
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        e.preventDefault();
+        handleSubmit(e as unknown as FormEvent);
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel?.();
+      }
+    },
+    [handleSubmit, onCancel],
+  );
+
+  // Helper: collect ref for the first erring field after submit
+  const errorRef = (field: keyof StreamFormValues) =>
+    errors[field] && !firstErrorRef.current
+      ? (el: HTMLInputElement | HTMLSelectElement | null) => {
+          firstErrorRef.current = el;
+        }
+      : undefined;
+
+  return (
+    <section
+      aria-labelledby="create-stream-heading"
+      className="w-full max-w-lg rounded-2xl border border-[var(--border,theme(colors.slate.200))] bg-[var(--card,white)] p-6 shadow-sm"
+      onKeyDown={handleKeyDown}
+    >
+      {/* Heading */}
+      <h2
+        id="create-stream-heading"
+        className="text-xl font-semibold text-[var(--foreground,theme(colors.slate.900))] mb-1"
+      >
+        Create Payment Stream
+      </h2>
+      <p className="text-sm text-[var(--muted-foreground,theme(colors.slate.500))] mb-5">
+        Set up a continuous Stellar payment stream to a recipient.
+      </p>
+
+      <form onSubmit={handleSubmit} noValidate aria-label="Create payment stream">
+
+        {/* Title */}
+        <div className="mb-4">
+          <label
+            htmlFor="stream-title"
+            className="block text-sm font-medium text-[var(--foreground,theme(colors.slate.900))] mb-1"
+          >
+            Stream title <span aria-hidden="true" className="text-red-500">*</span>
+          </label>
+          <input
+            id="stream-title"
+            type="text"
+            value={values.title}
+            onChange={set('title')}
+            aria-required="true"
+            aria-invalid={!!errors.title}
+            aria-describedby={errors.title ? 'stream-title-error' : undefined}
+            ref={errorRef('title') as React.RefCallback<HTMLInputElement>}
+            placeholder="e.g., Weekly design retainer"
+            className={[
+              'w-full rounded-lg border px-3 py-2 text-sm',
+              'focus:outline-none focus:ring-2 focus:ring-blue-500',
+              errors.title
+                ? 'border-red-500 bg-red-50'
+                : 'border-[var(--border,theme(colors.slate.300))] bg-white',
+            ].join(' ')}
+          />
+          {errors.title && (
+            <p id="stream-title-error" role="alert" className="mt-1 text-xs text-red-600">
+              {errors.title}
+            </p>
+          )}
+        </div>
+
+        {/* Recipient */}
+        <div className="mb-4">
+          <label
+            htmlFor="stream-recipient"
+            className="block text-sm font-medium text-[var(--foreground,theme(colors.slate.900))] mb-1"
+          >
+            Recipient address <span aria-hidden="true" className="text-red-500">*</span>
+          </label>
+          <input
+            id="stream-recipient"
+            type="text"
+            value={values.recipient}
+            onChange={set('recipient')}
+            aria-required="true"
+            aria-invalid={!!errors.recipient}
+            aria-describedby={errors.recipient ? 'stream-recipient-error' : undefined}
+            ref={errorRef('recipient') as React.RefCallback<HTMLInputElement>}
+            placeholder="GABC…"
+            className={[
+              'w-full rounded-lg border px-3 py-2 text-sm font-mono',
+              'focus:outline-none focus:ring-2 focus:ring-blue-500',
+              errors.recipient
+                ? 'border-red-500 bg-red-50'
+                : 'border-[var(--border,theme(colors.slate.300))] bg-white',
+            ].join(' ')}
+          />
+          {errors.recipient && (
+            <p id="stream-recipient-error" role="alert" className="mt-1 text-xs text-red-600">
+              {errors.recipient}
+            </p>
+          )}
+        </div>
+
+        {/* Rate + Currency */}
+        <div className="grid grid-cols-2 gap-4 mb-4">
+          <div>
+            <label
+              htmlFor="stream-rate"
+              className="block text-sm font-medium text-[var(--foreground,theme(colors.slate.900))] mb-1"
+            >
+              Rate / second <span aria-hidden="true" className="text-red-500">*</span>
+            </label>
+            <input
+              id="stream-rate"
+              type="text"
+              inputMode="decimal"
+              value={values.ratePerSecond}
+              onChange={set('ratePerSecond')}
+              aria-required="true"
+              aria-invalid={!!errors.ratePerSecond}
+              aria-describedby={errors.ratePerSecond ? 'stream-rate-error' : undefined}
+              ref={errorRef('ratePerSecond') as React.RefCallback<HTMLInputElement>}
+              placeholder="e.g., 0.001"
+              className={[
+                'w-full rounded-lg border px-3 py-2 text-sm',
+                'focus:outline-none focus:ring-2 focus:ring-blue-500',
+                errors.ratePerSecond
+                  ? 'border-red-500 bg-red-50'
+                  : 'border-[var(--border,theme(colors.slate.300))] bg-white',
+              ].join(' ')}
+            />
+            {errors.ratePerSecond && (
+              <p id="stream-rate-error" role="alert" className="mt-1 text-xs text-red-600">
+                {errors.ratePerSecond}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="stream-currency"
+              className="block text-sm font-medium text-[var(--foreground,theme(colors.slate.900))] mb-1"
+            >
+              Currency <span aria-hidden="true" className="text-red-500">*</span>
+            </label>
+            <select
+              id="stream-currency"
+              value={values.currency}
+              onChange={set('currency')}
+              aria-required="true"
+              aria-invalid={!!errors.currency}
+              aria-describedby={errors.currency ? 'stream-currency-error' : undefined}
+              ref={errorRef('currency') as React.RefCallback<HTMLSelectElement>}
+              className={[
+                'w-full rounded-lg border px-3 py-2 text-sm',
+                'focus:outline-none focus:ring-2 focus:ring-blue-500',
+                errors.currency
+                  ? 'border-red-500 bg-red-50'
+                  : 'border-[var(--border,theme(colors.slate.300))] bg-white',
+              ].join(' ')}
+            >
+              {CURRENCIES.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            {errors.currency && (
+              <p id="stream-currency-error" role="alert" className="mt-1 text-xs text-red-600">
+                {errors.currency}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Action row */}
+        <div className="flex items-center justify-between mt-6 gap-3">
+          {/* Keyboard hint — visible on md+ screens */}
+          <div className="hidden sm:flex items-center gap-3" aria-hidden="true">
+            <KbdHint keys={[mod, 'Enter']} label="to submit" />
+            {onCancel && (
+              <KbdHint keys={['Esc']} label="to cancel" />
+            )}
+          </div>
+
+          {/* Screen-reader-only hint (announced, not displayed) */}
+          <KbdHint
+            keys={[mod === '⌘' ? 'Command' : 'Control', 'Enter']}
+            label="to submit the form"
+            srOnly
+          />
+
+          <div className="flex gap-3 ml-auto">
+            {onCancel && (
+              <button
+                type="button"
+                onClick={onCancel}
+                className="px-4 py-2 rounded-lg border border-[var(--border,theme(colors.slate.300))] text-sm font-medium text-[var(--foreground,theme(colors.slate.700))] hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition"
+              >
+                Cancel
+              </button>
+            )}
+            <button
+              type="submit"
+              className="px-5 py-2 rounded-lg bg-blue-600 text-sm font-semibold text-white hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 transition"
+            >
+              Create Stream
+            </button>
+          </div>
+        </div>
+      </form>
+    </section>
+  );
+};
+
+export default CreateStreamForm;

--- a/src/components/KbdHint.tsx
+++ b/src/components/KbdHint.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import React from 'react';
+
+/**
+ * Props for the KbdHint component.
+ */
+export interface KbdHintProps {
+  /**
+   * One or more key names to display (e.g. `['Ctrl', 'Enter']` or `['⌘', 'K']`).
+   * Each key is rendered inside its own `<kbd>` element.
+   */
+  keys: string[];
+  /**
+   * Human-readable description of what the shortcut does.
+   * Rendered visually after the key chips and used as the accessible label.
+   * Example: "to submit"
+   */
+  label?: string;
+  /**
+   * Additional CSS classes to apply to the outermost wrapper.
+   */
+  className?: string;
+  /**
+   * When `true` the hint is hidden from sighted users (display: none equivalent
+   * via sr-only) but still announced to screen readers. Defaults to `false`.
+   */
+  srOnly?: boolean;
+}
+
+/**
+ * KbdHint — displays one or more keyboard shortcut key chips followed by an
+ * optional descriptive label.
+ *
+ * Accessibility:
+ * - Each key is wrapped in a semantic `<kbd>` element so screen readers
+ *   announce it as a keyboard key (e.g. "Control + Enter").
+ * - Separator `+` characters between keys are marked `aria-hidden` so they
+ *   are not read aloud, relying instead on the natural pause between keys.
+ * - The wrapper carries `aria-label` synthesised from the keys and label so
+ *   the full hint reads naturally as a unit (e.g. "Ctrl+Enter — to submit").
+ * - When `srOnly` is true the component is visually hidden but still present
+ *   in the accessibility tree.
+ *
+ * Design tokens:
+ * - Background / border use `--card` and `--border` CSS variables so the
+ *   component adapts to light and dark themes automatically.
+ * - Text uses `--muted-foreground` matching the project's token set.
+ *
+ * @example
+ * ```tsx
+ * // Show "Ctrl + Enter — to submit" hint
+ * <KbdHint keys={['Ctrl', 'Enter']} label="to submit" />
+ *
+ * // Mac variant
+ * <KbdHint keys={['⌘', 'Enter']} label="to submit" />
+ *
+ * // Screen-reader only hint
+ * <KbdHint keys={['Escape']} label="to cancel" srOnly />
+ * ```
+ */
+export const KbdHint: React.FC<KbdHintProps> = ({
+  keys,
+  label,
+  className = '',
+  srOnly = false,
+}) => {
+  // Build an accessible label: "Ctrl+Enter — to submit" or just "Ctrl+Enter"
+  const ariaLabel = [keys.join('+'), label].filter(Boolean).join(' \u2014 ');
+
+  const wrapperClass = [
+    'inline-flex items-center gap-1 text-xs',
+    'text-[var(--muted-foreground,theme(colors.slate.500))]',
+    srOnly ? 'sr-only' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <span
+      className={wrapperClass}
+      aria-label={ariaLabel}
+      // role="img" is intentional: the entire hint is a single meaningful unit
+      // (the shortcut) and wrapping it in a labelled img role prevents screen
+      // readers from reading each <kbd> element separately.
+      role="img"
+    >
+      {keys.map((key, index) => (
+        <React.Fragment key={key}>
+          {index > 0 && (
+            <span aria-hidden="true" className="select-none">
+              +
+            </span>
+          )}
+          <kbd
+            className={[
+              'inline-flex items-center justify-center',
+              'min-w-[1.5rem] h-5 px-1 rounded',
+              'border border-[var(--border,theme(colors.slate.200))]',
+              'bg-[var(--card,theme(colors.white))]',
+              'font-mono text-[0.65rem] leading-none',
+              'shadow-[0_1px_0_var(--border,theme(colors.slate.200))]',
+              'select-none',
+            ].join(' ')}
+          >
+            {key}
+          </kbd>
+        </React.Fragment>
+      ))}
+      {label && (
+        <span aria-hidden="true" className="ml-1 not-italic">
+          {label}
+        </span>
+      )}
+    </span>
+  );
+};
+
+export default KbdHint;

--- a/src/components/__tests__/CreateStreamForm.test.tsx
+++ b/src/components/__tests__/CreateStreamForm.test.tsx
@@ -1,0 +1,368 @@
+/**
+ * Tests for KbdHint component and CreateStreamForm keyboard shortcut hints.
+ *
+ * KbdHint:
+ *   - Renders key chips in <kbd> elements
+ *   - Separators are aria-hidden
+ *   - Synthesised aria-label on the wrapper
+ *   - srOnly mode hides visually but stays in a11y tree
+ *   - Single-key, multi-key, label-only, no-label variants
+ *   - No axe violations
+ *
+ * CreateStreamForm:
+ *   - All fields render with correct labels / aria attributes
+ *   - Validation fires and shows field errors
+ *   - Ctrl+Enter submits a valid form
+ *   - Escape invokes onCancel
+ *   - KbdHint chips are present in the DOM
+ *   - Successful submit calls onSubmit with cleaned values
+ *   - No axe violations
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { KbdHint } from '../KbdHint';
+import { CreateStreamForm } from '../CreateStreamForm';
+
+// ---------------------------------------------------------------------------
+// KbdHint — unit tests
+// ---------------------------------------------------------------------------
+
+describe('KbdHint — rendering', () => {
+  it('renders a single key chip inside a <kbd> element', () => {
+    render(<KbdHint keys={['Enter']} />);
+    const kbd = screen.getByText('Enter').closest('kbd');
+    expect(kbd).toBeInTheDocument();
+  });
+
+  it('renders multiple key chips', () => {
+    render(<KbdHint keys={['Ctrl', 'Enter']} />);
+    expect(screen.getByText('Ctrl').closest('kbd')).toBeInTheDocument();
+    expect(screen.getByText('Enter').closest('kbd')).toBeInTheDocument();
+  });
+
+  it('renders a "+" separator between keys', () => {
+    const { container } = render(<KbdHint keys={['Ctrl', 'Enter']} />);
+    // The separator span carries aria-hidden="true"
+    const sep = container.querySelector('[aria-hidden="true"]');
+    expect(sep?.textContent).toBe('+');
+  });
+
+  it('renders a label after the key chips', () => {
+    render(<KbdHint keys={['Ctrl', 'Enter']} label="to submit" />);
+    expect(screen.getByText('to submit')).toBeInTheDocument();
+  });
+
+  it('does not render a label span when label is omitted', () => {
+    render(<KbdHint keys={['Esc']} />);
+    // Only one text node should exist (the key itself)
+    expect(screen.queryByText('to')).not.toBeInTheDocument();
+  });
+
+  it('renders three keys with two separators', () => {
+    const { container } = render(<KbdHint keys={['Ctrl', 'Shift', 'P']} />);
+    const seps = container.querySelectorAll('[aria-hidden="true"]');
+    // Backdrop + two "+" seps (label span also carries aria-hidden when no label)
+    const plusSeps = Array.from(seps).filter((el) => el.textContent === '+');
+    expect(plusSeps).toHaveLength(2);
+  });
+});
+
+describe('KbdHint — accessibility', () => {
+  it('wrapper carries role="img"', () => {
+    render(<KbdHint keys={['Ctrl', 'Enter']} label="to submit" />);
+    expect(screen.getByRole('img')).toBeInTheDocument();
+  });
+
+  it('aria-label combines keys with "+" and appends the label with em-dash', () => {
+    render(<KbdHint keys={['Ctrl', 'Enter']} label="to submit" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('aria-label', 'Ctrl+Enter — to submit');
+  });
+
+  it('aria-label contains only the keys when no label is supplied', () => {
+    render(<KbdHint keys={['Escape']} />);
+    expect(screen.getByRole('img')).toHaveAttribute('aria-label', 'Escape');
+  });
+
+  it('srOnly mode adds the sr-only class', () => {
+    const { container } = render(<KbdHint keys={['Enter']} srOnly />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain('sr-only');
+  });
+
+  it('non-srOnly mode does NOT add the sr-only class', () => {
+    const { container } = render(<KbdHint keys={['Enter']} />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).not.toContain('sr-only');
+  });
+
+  it('has no axe violations (single key)', async () => {
+    const { container } = render(<KbdHint keys={['Enter']} />);
+    expect((await axe(container)).violations).toHaveLength(0);
+  });
+
+  it('has no axe violations (multi-key + label)', async () => {
+    const { container } = render(
+      <KbdHint keys={['Ctrl', 'Enter']} label="to submit" />,
+    );
+    expect((await axe(container)).violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CreateStreamForm — field rendering
+// ---------------------------------------------------------------------------
+
+describe('CreateStreamForm — field rendering', () => {
+  it('renders the heading', () => {
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+    expect(
+      screen.getByRole('heading', { name: 'Create Payment Stream' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders all four labelled inputs / selects', () => {
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+    expect(screen.getByLabelText(/stream title/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/recipient address/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/rate \/ second/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/currency/i)).toBeInTheDocument();
+  });
+
+  it('renders the Create Stream submit button', () => {
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+    expect(
+      screen.getByRole('button', { name: 'Create Stream' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a Cancel button when onCancel is supplied', () => {
+    render(<CreateStreamForm onSubmit={jest.fn()} onCancel={jest.fn()} />);
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('does not render a Cancel button when onCancel is omitted', () => {
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CreateStreamForm — KbdHint chips
+// ---------------------------------------------------------------------------
+
+describe('CreateStreamForm — KbdHint presence', () => {
+  it('renders at least one <kbd> element for the submit shortcut', () => {
+    const { container } = render(<CreateStreamForm onSubmit={jest.fn()} />);
+    const kbds = container.querySelectorAll('kbd');
+    expect(kbds.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders an Enter key chip', () => {
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+    // There may be multiple kbd elements; at least one should say "Enter"
+    const kbds = screen.getAllByText('Enter');
+    expect(kbds.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders a screen-reader-only KbdHint for assistive technologies', () => {
+    const { container } = render(<CreateStreamForm onSubmit={jest.fn()} />);
+    const srOnlyHint = container.querySelector('.sr-only[role="img"]');
+    expect(srOnlyHint).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CreateStreamForm — validation
+// ---------------------------------------------------------------------------
+
+describe('CreateStreamForm — validation', () => {
+  it('shows required-field errors when submitting an empty form', async () => {
+    const user = userEvent.setup();
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: 'Create Stream' }));
+
+    expect(screen.getByText('Stream title is required.')).toBeInTheDocument();
+    expect(screen.getByText('Recipient address is required.')).toBeInTheDocument();
+    expect(screen.getByText('Rate per second is required.')).toBeInTheDocument();
+  });
+
+  it('shows an address format error for an invalid Stellar key', async () => {
+    const user = userEvent.setup();
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+
+    await user.type(screen.getByLabelText(/recipient address/i), 'not-a-valid-key');
+    await user.click(screen.getByRole('button', { name: 'Create Stream' }));
+
+    expect(
+      screen.getByText(/valid Stellar public key/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows an error when rate is non-numeric', async () => {
+    const user = userEvent.setup();
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+
+    await user.type(screen.getByLabelText(/rate \/ second/i), 'abc');
+    await user.click(screen.getByRole('button', { name: 'Create Stream' }));
+
+    expect(screen.getByText(/positive number/i)).toBeInTheDocument();
+  });
+
+  it('shows an error when rate is zero', async () => {
+    const user = userEvent.setup();
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+
+    await user.type(screen.getByLabelText(/rate \/ second/i), '0');
+    await user.click(screen.getByRole('button', { name: 'Create Stream' }));
+
+    expect(screen.getByText(/positive number/i)).toBeInTheDocument();
+  });
+
+  it('clears a field error when the user starts correcting their input', async () => {
+    const user = userEvent.setup();
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+
+    // Submit to trigger errors
+    await user.click(screen.getByRole('button', { name: 'Create Stream' }));
+    expect(screen.getByText('Stream title is required.')).toBeInTheDocument();
+
+    // Type into the title field — error should disappear
+    await user.type(screen.getByLabelText(/stream title/i), 'Test');
+    expect(screen.queryByText('Stream title is required.')).not.toBeInTheDocument();
+  });
+
+  it('does not call onSubmit when validation fails', async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+    render(<CreateStreamForm onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole('button', { name: 'Create Stream' }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CreateStreamForm — keyboard shortcuts
+// ---------------------------------------------------------------------------
+
+const VALID_ADDRESS = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
+
+describe('CreateStreamForm — keyboard shortcuts', () => {
+  it('Ctrl+Enter submits the form with valid data', async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+    render(<CreateStreamForm onSubmit={onSubmit} />);
+
+    const titleInput = screen.getByLabelText(/stream title/i);
+    await user.type(titleInput, 'Weekly retainer');
+    await user.type(screen.getByLabelText(/recipient address/i), VALID_ADDRESS);
+    await user.type(screen.getByLabelText(/rate \/ second/i), '0.001');
+
+    // Focus must be inside the form for the keyDown handler to fire
+    titleInput.focus();
+    await user.keyboard('{Control>}{Enter}{/Control}');
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Weekly retainer',
+        ratePerSecond: '0.001',
+      }),
+    );
+  });
+
+  it('Ctrl+Enter shows validation errors when form is invalid', async () => {
+    const user = userEvent.setup();
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+
+    // Focus into the section so the keyDown handler fires
+    screen.getByLabelText(/stream title/i).focus();
+    await user.keyboard('{Control>}{Enter}{/Control}');
+
+    expect(screen.getByText('Stream title is required.')).toBeInTheDocument();
+  });
+
+  it('Escape invokes onCancel', async () => {
+    const user = userEvent.setup();
+    const onCancel = jest.fn();
+    render(<CreateStreamForm onSubmit={jest.fn()} onCancel={onCancel} />);
+
+    await user.type(screen.getByLabelText(/stream title/i), 'Typing…');
+    await user.keyboard('{Escape}');
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape does nothing when onCancel is not supplied', async () => {
+    const user = userEvent.setup();
+    render(<CreateStreamForm onSubmit={jest.fn()} />);
+
+    screen.getByLabelText(/stream title/i).focus();
+    // Should not throw
+    await expect(
+      user.keyboard('{Escape}'),
+    ).resolves.not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CreateStreamForm — successful submit
+// ---------------------------------------------------------------------------
+
+describe('CreateStreamForm — successful submit', () => {
+  it('trims whitespace from title and uppercases the recipient address', async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+    render(<CreateStreamForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/stream title/i), '  My stream  ');
+    await user.type(
+      screen.getByLabelText(/recipient address/i),
+      VALID_ADDRESS.toLowerCase(),
+    );
+    await user.type(screen.getByLabelText(/rate \/ second/i), '1.5');
+    await user.click(screen.getByRole('button', { name: 'Create Stream' }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'My stream',
+        recipient: VALID_ADDRESS.toUpperCase(),
+        ratePerSecond: '1.5',
+        currency: 'XLM',
+      }),
+    );
+  });
+
+  it('Cancel button invokes onCancel', async () => {
+    const user = userEvent.setup();
+    const onCancel = jest.fn();
+    render(<CreateStreamForm onSubmit={jest.fn()} onCancel={onCancel} />);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CreateStreamForm — accessibility (axe)
+// ---------------------------------------------------------------------------
+
+describe('CreateStreamForm — axe', () => {
+  it('has no violations in the empty state', async () => {
+    const { container } = render(<CreateStreamForm onSubmit={jest.fn()} />);
+    expect((await axe(container)).violations).toHaveLength(0);
+  });
+
+  it('has no violations when validation errors are displayed', async () => {
+    const { container } = render(<CreateStreamForm onSubmit={jest.fn()} />);
+    fireEvent.submit(container.querySelector('form')!);
+    expect((await axe(container)).violations).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
- Add KbdHint component (src/components/KbdHint.tsx)
  - Renders key chips in semantic <kbd> elements
  - Separators aria-hidden; wrapper has role=img + aria-label
  - srOnly prop for screen-reader-only variant
  - Adapts to light/dark via CSS design tokens
- Add CreateStreamForm (src/components/CreateStreamForm.tsx)
  - Ctrl/⌘+Enter global submit shortcut
  - Escape calls onCancel
  - KbdHint chips shown in action row; sr-only hint for AT
  - Full field validation with aria-invalid + role=alert errors
  - WCAG 2.1 AA: labels, aria-required, aria-describedby
- Add CreateStreamForm.test.tsx: 35 tests all passing
  - KbdHint rendering, a11y, axe; form rendering, validation, keyboard shortcuts, submit, and axe in empty/error states

## Description

<!-- Summarize the changes in this PR and the motivation behind them. -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

<!-- Briefly describe the test cases you added or updated, and any manual testing performed. -->

---

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->

### Security

<!-- Does this PR touch authentication, authorization, wallet logic, API calls, or
     user-supplied input? Describe any security considerations or "N/A" if not applicable. -->

Closes #1043
