### PR TITLE
feat(navigation): add cmd+k command palette for route navigation

### DIFF
--- a/docs/components/CommandPalette.md
+++ b/docs/components/CommandPalette.md
@@ -1,0 +1,92 @@
+# CommandPalette
+
+Keyboard-driven route navigator for the TalentTrust application.
+
+## Overview
+
+`CommandPalette` provides a Cmd+K (Mac) / Ctrl+K (other) command palette
+that lets power users jump between contracts, milestones, and reputation
+pages without touching the mouse. It renders a modal overlay with a search
+input, supports fuzzy filtering across route labels and keywords, and
+navigates via arrow keys or mouse.
+
+## File Location
+
+- Component: `src/components/CommandPalette.tsx`
+- Tests: `src/components/__tests__/CommandPalette.test.tsx`
+- Mounting point: `src/app/layout.tsx`
+
+## Props
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| —    | —    | —        | CommandPalette accepts no props. Routes are internal. |
+
+## Usage
+
+```tsx
+import CommandPalette from '@/components/CommandPalette';
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        <CommandPalette />
+        {children}
+      </body>
+    </html>
+  );
+}
+```
+
+## Routes
+
+| Route | Label | Keywords |
+|-------|-------|----------|
+| `/contracts` | Contracts | contracts, escrow, payments |
+| `/milestones` | Milestones | milestones, milestone, tasks |
+| `/reputation` | Reputation | reputation, profile, rating |
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Cmd+K` / `Ctrl+K` | Open / toggle the palette |
+| `Escape` | Close the palette |
+| `↑` / `↓` | Move selection up / down |
+| `Enter` | Navigate to the selected route |
+
+## Accessibility
+
+- **`role="dialog"`** with **`aria-modal="true"`** — the palette is announced as a modal dialog.
+- **`role="combobox"`** on the search input with **`aria-expanded`**, **`aria-controls`**, and **`aria-activedescendant`** — follows the WAI-ARIA combobox pattern.
+- **`role="listbox"`** with **`role="option"`** and **`aria-selected`** — route list is a proper listbox.
+- **Focus management** — the input receives focus on open; the previously focused element regains focus on close.
+- **Reduced motion** — respects `prefers-reduced-motion: reduce` via the `useMediaQuery` hook, disabling open/close animations.
+- **Backdrop click** closes the palette.
+- **Footer hints** display keyboard shortcuts for discoverability.
+
+## Styling
+
+The component uses Tailwind CSS utility classes consistent with the
+existing design system:
+
+| Element | Classes |
+|---------|---------|
+| Backdrop | `bg-black/50 backdrop-blur-sm` |
+| Panel | `bg-white rounded-xl shadow-2xl border border-slate-200` |
+| Active option | `bg-blue-50 text-blue-700` |
+| Inactive option | `text-slate-700 hover:bg-slate-50` |
+| Input | `bg-transparent text-slate-900 placeholder-slate-400` |
+
+## Dependencies
+
+- `next/navigation` — `useRouter` for client-side navigation
+- `@/hooks/useMediaQuery` — detects `prefers-reduced-motion`
+- No additional packages required
+
+## Related
+
+- `src/components/Navbar.tsx` — primary navigation links (same routes)
+- `src/components/HeaderActions.tsx` — wallet/theme header controls
+- `src/app/layout.tsx` — mounting point

--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -7,6 +7,7 @@ import RootLayout from '../layout';
 // Mock next/navigation for RouteAnnouncer's usePathname call.
 jest.mock('next/navigation', () => ({
   usePathname: jest.fn().mockReturnValue('/'),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
 }));
 
 function renderLayout() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,6 +52,7 @@ import { WalletProvider } from '@/contexts/WalletContext';
 import RouteAnnouncer from '@/components/RouteAnnouncer';
 import Navbar from '@/components/Navbar';
 import HeaderActions from '@/components/HeaderActions';
+import CommandPalette from '@/components/CommandPalette';
 
 export default function RootLayout({
   children,
@@ -87,6 +88,7 @@ export default function RootLayout({
                   {children}
                 </main>
               </div>
+              <CommandPalette />
               <SettingsTrigger />
             </WalletProvider>
           </ToastProvider>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useRouter } from 'next/navigation';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+/** A single navigable route shown in the command palette. */
+interface CommandRoute {
+  href: string;
+  label: string;
+  keywords: string[];
+}
+
+const ROUTES: CommandRoute[] = [
+  { href: '/contracts', label: 'Contracts', keywords: ['contracts', 'escrow', 'payments'] },
+  { href: '/milestones', label: 'Milestones', keywords: ['milestones', 'milestone', 'tasks'] },
+  { href: '/reputation', label: 'Reputation', keywords: ['reputation', 'profile', 'rating'] },
+];
+
+/**
+ * Simple fuzzy match: returns true when every character in `query`
+ * appears in `text` in order (case-insensitive).
+ */
+function fuzzyMatch(query: string, text: string): boolean {
+  const lower = query.toLowerCase();
+  const target = text.toLowerCase();
+  let qi = 0;
+  for (let ti = 0; ti < target.length && qi < lower.length; ti++) {
+    if (target[ti] === lower[qi]) qi++;
+  }
+  return qi === lower.length;
+}
+
+/**
+ * CommandPalette — keyboard-driven route navigator.
+ *
+ * Opens on Cmd+K (Mac) / Ctrl+K and closes on Escape.
+ * Lists all primary routes with fuzzy filtering and arrow-key
+ * navigation. Respects `prefers-reduced-motion` for open/close
+ * transitions.
+ *
+ * @example
+ * ```tsx
+ * // In src/app/layout.tsx
+ * <CommandPalette />
+ * ```
+ */
+export default function CommandPalette(): React.JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const router = useRouter();
+  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+
+  const inputId = useId();
+  const listboxId = useId();
+
+  const filteredRoutes = useMemo(() => {
+    if (!query.trim()) return ROUTES;
+    return ROUTES.filter(
+      (route) =>
+        fuzzyMatch(query, route.label) ||
+        route.keywords.some((kw) => fuzzyMatch(query, kw)),
+    );
+  }, [query]);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setQuery('');
+    setActiveIndex(0);
+    const trigger = previousFocusRef.current;
+    if (trigger && document.contains(trigger)) {
+      trigger.focus();
+    }
+  }, []);
+
+  const navigateTo = useCallback(
+    (href: string) => {
+      close();
+      router.push(href);
+    },
+    [close, router],
+  );
+
+  // Global keyboard listener
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setIsOpen((prev) => {
+          if (!prev) {
+            previousFocusRef.current =
+              document.activeElement instanceof HTMLElement ? document.activeElement : null;
+            setQuery('');
+            setActiveIndex(0);
+          } else {
+            const trigger = previousFocusRef.current;
+            if (trigger && document.contains(trigger)) {
+              trigger.focus();
+            }
+          }
+          return !prev;
+        });
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        setIsOpen((prev) => {
+          if (!prev) return prev;
+          const trigger = previousFocusRef.current;
+          if (trigger && document.contains(trigger)) {
+            trigger.focus();
+          }
+          return false;
+        });
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  // Focus input on open
+  useEffect(() => {
+    if (isOpen) {
+      // Small delay so the DOM is painted before we focus
+      const id = requestAnimationFrame(() => inputRef.current?.focus());
+      return () => cancelAnimationFrame(id);
+    }
+  }, [isOpen]);
+
+  // Reset active index when filtered list changes
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [filteredRoutes.length, query]);
+
+  const handleInputKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        close();
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex((prev) => (prev + 1) % filteredRoutes.length);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex((prev) =>
+          prev <= 0 ? filteredRoutes.length - 1 : prev - 1,
+        );
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (filteredRoutes[activeIndex]) {
+          navigateTo(filteredRoutes[activeIndex].href);
+        }
+        break;
+    }
+  };
+
+  // Scroll active option into view
+  useEffect(() => {
+    if (!isOpen) return;
+    const option = listRef.current?.children[activeIndex] as HTMLElement | undefined;
+    if (option && typeof option.scrollIntoView === 'function') {
+      option.scrollIntoView({ block: 'nearest' });
+    }
+  }, [activeIndex, isOpen]);
+
+  if (!isOpen) return <></>;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 transition-opacity backdrop-blur-sm"
+        onClick={close}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div
+        className={`relative z-10 w-full max-w-lg overflow-hidden rounded-xl border border-slate-200 bg-white shadow-2xl ${
+          prefersReducedMotion ? '' : 'animate-in fade-in zoom-in-95'
+        }`}
+      >
+        {/* Search input */}
+        <div className="flex items-center border-b border-slate-200 px-4">
+          <svg
+            aria-hidden="true"
+            className="h-5 w-5 shrink-0 text-slate-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <input
+            ref={inputRef}
+            id={inputId}
+            type="text"
+            role="combobox"
+            aria-expanded="true"
+            aria-controls={listboxId}
+            aria-activedescendant={
+              filteredRoutes[activeIndex]
+                ? `${listboxId}-option-${activeIndex}`
+                : undefined
+            }
+            aria-autocomplete="list"
+            aria-label="Search routes"
+            placeholder="Search routes..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleInputKeyDown}
+            className="w-full bg-transparent px-3 py-4 text-sm text-slate-900 placeholder-slate-400 outline-none"
+          />
+        </div>
+
+        {/* Route list */}
+        <div
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          aria-label="Navigation routes"
+          className="max-h-60 overflow-y-auto p-2"
+        >
+          {filteredRoutes.length === 0 ? (
+            <p className="px-4 py-6 text-center text-sm text-slate-500">
+              No routes found.
+            </p>
+          ) : (
+            filteredRoutes.map((route, index) => {
+              const isActive = index === activeIndex;
+              const optionId = `${listboxId}-option-${index}`;
+              return (
+                <button
+                  key={route.href}
+                  id={optionId}
+                  role="option"
+                  aria-selected={isActive}
+                  type="button"
+                  onClick={() => navigateTo(route.href)}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm transition-colors ${
+                    isActive
+                      ? 'bg-blue-50 text-blue-700'
+                      : 'text-slate-700 hover:bg-slate-50'
+                  }`}
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="h-4 w-4 shrink-0 text-slate-400"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                  <span className="font-medium">{route.label}</span>
+                  <span className="ml-auto text-xs text-slate-400">
+                    {route.href}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        {/* Footer hint */}
+        <div className="flex items-center justify-between border-t border-slate-200 px-4 py-2 text-xs text-slate-400">
+          <span>Navigate with ↑↓</span>
+          <span>↵ Open</span>
+          <span>Esc Close</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,548 @@
+/**
+ * @file CommandPalette.test.tsx
+ *
+ * Comprehensive test suite for the CommandPalette component.
+ *
+ * Coverage targets:
+ *  1. Global keyboard shortcut (Cmd+K / Ctrl+K) opens the palette.
+ *  2. Escape closes the palette and restores focus.
+ *  3. ARIA combobox / listbox roles and attributes.
+ *  4. Arrow-key navigation through route options.
+ *  5. Enter selects the active route and navigates.
+ *  6. Fuzzy filtering matches routes and keywords.
+ *  7. Mouse hover updates the active index.
+ *  8. Backdrop click closes the palette.
+ *  9. Reduced-motion preference disables transition animation.
+ * 10. Focus management: input receives focus on open, trigger regains focus on close.
+ * 11. Accessibility: jest-axe audit passes.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import CommandPalette from '../CommandPalette';
+
+expect.extend(toHaveNoViolations);
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('@/hooks/useMediaQuery', () => ({
+  useMediaQuery: jest.fn(() => false),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Fire the platform-appropriate shortcut. Uses CtrlKey since jsdom is not Mac. */
+const openPalette = () => {
+  fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+};
+
+const closePalette = () => {
+  fireEvent.keyDown(document, { key: 'Escape' });
+};
+
+// ---------------------------------------------------------------------------
+// Suite 1 — Open / close via keyboard shortcut
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — open/close', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it('renders nothing initially', () => {
+    render(<CommandPalette />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens on Ctrl+K', () => {
+    render(<CommandPalette />);
+    openPalette();
+    expect(screen.getByRole('dialog', { name: /command palette/i })).toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    render(<CommandPalette />);
+    openPalette();
+    closePalette();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('toggles open/closed on repeated Ctrl+K', () => {
+    render(<CommandPalette />);
+    openPalette();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    openPalette();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    openPalette();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 2 — Search input
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — search input', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it('renders a combobox input with placeholder', () => {
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+    expect(input).toHaveAttribute('placeholder', 'Search routes...');
+  });
+
+  it('input receives focus on open', async () => {
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+    await waitFor(() => expect(input).toHaveFocus());
+  });
+
+  it('has aria-expanded="true" and aria-controls pointing to the listbox', () => {
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    expect(input).toHaveAttribute('aria-controls');
+  });
+
+  it('has aria-autocomplete="list"', () => {
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 3 — Route list rendering
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — route list', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it('lists all three routes by default', () => {
+    render(<CommandPalette />);
+    openPalette();
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    expect(within(listbox).getByRole('option', { name: /contracts/i })).toBeInTheDocument();
+    expect(within(listbox).getByRole('option', { name: /milestones/i })).toBeInTheDocument();
+    expect(within(listbox).getByRole('option', { name: /reputation/i })).toBeInTheDocument();
+  });
+
+  it('shows the href for each route', () => {
+    render(<CommandPalette />);
+    openPalette();
+    expect(screen.getByText('/contracts')).toBeInTheDocument();
+    expect(screen.getByText('/milestones')).toBeInTheDocument();
+    expect(screen.getByText('/reputation')).toBeInTheDocument();
+  });
+
+  it('first option is aria-selected by default', () => {
+    render(<CommandPalette />);
+    openPalette();
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+    expect(options[1]).toHaveAttribute('aria-selected', 'false');
+    expect(options[2]).toHaveAttribute('aria-selected', 'false');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 4 — Arrow key navigation
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — arrow key navigation', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it('ArrowDown moves selection to the next option', async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    await user.click(input);
+    await user.keyboard('{ArrowDown}');
+
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('ArrowUp moves selection to the previous option', async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    await user.click(input);
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{ArrowUp}');
+
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('ArrowDown wraps from last to first', async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    await user.click(input);
+    // Navigate to last option
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{ArrowDown}');
+    // Wrap to first
+    await user.keyboard('{ArrowDown}');
+
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('ArrowUp wraps from first to last', async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    await user.click(input);
+    await user.keyboard('{ArrowUp}');
+
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+    expect(options[2]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('aria-activedescendant updates as arrow keys are pressed', async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    await user.click(input);
+    await user.keyboard('{ArrowDown}');
+
+    expect(input).toHaveAttribute('aria-activedescendant');
+    const activedescendant = input.getAttribute('aria-activedescendant');
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+    expect(activedescendant).toBe(options[1].id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 5 — Enter to navigate
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — Enter navigation', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it('Enter navigates to the active route', async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    await user.click(input);
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Enter}');
+
+    expect(mockPush).toHaveBeenCalledWith('/milestones');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('Enter navigates to the first route by default', async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    await user.click(input);
+    await user.keyboard('{Enter}');
+
+    expect(mockPush).toHaveBeenCalledWith('/contracts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 6 — Fuzzy filtering
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — fuzzy filtering', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it('filters routes by label substring', () => {
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    fireEvent.change(input, { target: { value: 'mile' } });
+
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Milestones');
+  });
+
+  it('filters routes by keyword', () => {
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    fireEvent.change(input, { target: { value: 'escrow' } });
+
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Contracts');
+  });
+
+  it('shows "No routes found" when nothing matches', () => {
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    fireEvent.change(input, { target: { value: 'xyz123' } });
+
+    expect(screen.getByText('No routes found.')).toBeInTheDocument();
+  });
+
+  it('fuzzy match works with non-contiguous characters', () => {
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    // "Ctr" matches "Contracts" (C, t, r in order)
+    fireEvent.change(input, { target: { value: 'ctr' } });
+
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Contracts');
+  });
+
+  it('filtering is case-insensitive', () => {
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    fireEvent.change(input, { target: { value: 'REPUTATION' } });
+
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Reputation');
+  });
+
+  it('empty query shows all routes', () => {
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+
+    fireEvent.change(input, { target: { value: 'mile' } });
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '' } });
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+    expect(options).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 7 — Mouse interaction
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — mouse interaction', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it('hovering an option updates the active selection', () => {
+    render(<CommandPalette />);
+    openPalette();
+
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const options = within(listbox).getAllByRole('option');
+
+    fireEvent.mouseEnter(options[2]);
+
+    expect(options[2]).toHaveAttribute('aria-selected', 'true');
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('clicking an option navigates and closes', () => {
+    render(<CommandPalette />);
+    openPalette();
+
+    const listbox = screen.getByRole('listbox', { name: /navigation routes/i });
+    const reputation = within(listbox).getByRole('option', { name: /reputation/i });
+
+    fireEvent.click(reputation);
+
+    expect(mockPush).toHaveBeenCalledWith('/reputation');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('clicking the backdrop closes the palette', () => {
+    render(<CommandPalette />);
+    openPalette();
+
+    // The backdrop is the first element with aria-hidden="true"
+    const backdrop = document.querySelector('[aria-hidden="true"]');
+    expect(backdrop).toBeInTheDocument();
+    fireEvent.click(backdrop!);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 8 — Reduced motion
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — reduced motion', () => {
+  it('does not apply animation classes when prefers-reduced-motion is reduce', () => {
+    const useMediaQuery = require('@/hooks/useMediaQuery').useMediaQuery;
+    useMediaQuery.mockReturnValue(true);
+
+    render(<CommandPalette />);
+    openPalette();
+
+    const panel = screen.getByRole('dialog').querySelector('.max-w-lg');
+    expect(panel?.className).not.toContain('animate-in');
+  });
+
+  it('applies animation classes when reduced motion is not preferred', () => {
+    const useMediaQuery = require('@/hooks/useMediaQuery').useMediaQuery;
+    useMediaQuery.mockReturnValue(false);
+
+    render(<CommandPalette />);
+    openPalette();
+
+    const panel = screen.getByRole('dialog').querySelector('.max-w-lg');
+    expect(panel?.className).toContain('animate-in');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 9 — Focus management
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — focus management', () => {
+  it('restores focus to the previously focused element on close', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <button type="button" data-testid="trigger">
+          Open
+        </button>
+        <CommandPalette />
+      </>,
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+
+    // Open via keyboard
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+
+    // Input should be focused now (after rAF flush)
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+    await waitFor(() => expect(input).toHaveFocus());
+
+    // Close
+    await user.keyboard('{Escape}');
+
+    // Focus should return to trigger
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 10 — Keyboard hint footer
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — footer hints', () => {
+  it('displays keyboard hints', () => {
+    render(<CommandPalette />);
+    openPalette();
+
+    expect(screen.getByText('Navigate with ↑↓')).toBeInTheDocument();
+    expect(screen.getByText('↵ Open')).toBeInTheDocument();
+    expect(screen.getByText('Esc Close')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 11 — Accessibility (jest-axe)
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — accessibility', () => {
+  it('has no axe violations when open', async () => {
+    const { container } = render(<CommandPalette />);
+    openPalette();
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no axe violations when open with filtered results', async () => {
+    const { container } = render(<CommandPalette />);
+    openPalette();
+
+    const input = screen.getByRole('combobox', { name: /search routes/i });
+    fireEvent.change(input, { target: { value: 'mile' } });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 12 — Unmount
+// ---------------------------------------------------------------------------
+
+describe('CommandPalette — unmount', () => {
+  it('unmounts cleanly while open', () => {
+    const { unmount } = render(<CommandPalette />);
+    openPalette();
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it('unmounts cleanly while closed', () => {
+    const { unmount } = render(<CommandPalette />);
+    expect(() => unmount()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Cmd+K / Ctrl+K command palette for quickly jumping between Contracts, Milestones, and Reputation routes without touching the mouse.

Closes #424

## What's Included

- **** — Modal command palette with fuzzy filtering, arrow-key navigation, and ARIA combobox/listbox pattern
- **** — 35 tests across 12 suites covering keyboard shortcuts, filtering, a11y, focus management, reduced motion, and axe audits
- **** — Full documentation with usage, keyboard shortcuts, accessibility details
- **** — Mounts CommandPalette at the root layout level

## Features

- Opens on Cmd+K (Mac) / Ctrl+K, closes on Escape or backdrop click
- Fuzzy filtering across route labels and keywords
- Arrow-key navigation with wrapping, Enter to select
- Respects `prefers-reduced-motion` for open/close transitions
- Focus returns to previously focused element on close

## Verification

- `npm run lint` — clean
- `npm test` — 1253/1253 tests pass (73 suites)
- `npm run build` — builds successfully
- CommandPalette coverage: 99% statements, 100% functions, 98.88% lines