### PR TITLE
Feature/contracts 05 copy

### DIFF
--- a/deploy.bat
+++ b/deploy.bat
@@ -1,0 +1,3 @@
+git add .
+git commit -m "feat(contracts): add copy-contract-id action"
+git push -u origin feature/contracts-05-copy-id

--- a/src/app/contracts/__tests__/page.test.tsx
+++ b/src/app/contracts/__tests__/page.test.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ToastProvider } from '@/components/toast/toast-provider';
+
+function render(ui: React.ReactElement, options = {}) {
+  return rtlRender(ui, { wrapper: ToastProvider, ...options });
+}
 import ContractsPage from '../page';
 import * as repository from '@/lib/repository';
 
@@ -17,6 +22,13 @@ jest.mock('@/lib/repository', () => {
   };
 });
 jest.mock('@/lib/stellarAddress');
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+  }),
+}));
 
 const mockListContracts = repository.listContracts as jest.MockedFunction<
   typeof repository.listContracts

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback } from 'react';
 import EmptyState from '../../components/EmptyState';
 import { ContractCreationForm } from '../../components/ContractCreationForm';
+import { ContractRow } from '../../components/contracts/ContractRow';
 import { listContracts, saveContract } from '@/lib/repository';
 import type { Contract } from '@/types/domain';
 
@@ -64,15 +65,10 @@ const ContractsPage: React.FC = () => {
           {/* TODO: Replace with a proper ContractSummary list component. */}
           <ul className="space-y-4">
             {contracts.map((contract, idx) => (
-              <li
-                key={`${contract.contractName}-${idx}`}
-                className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm"
-              >
-                <p className="font-semibold text-slate-900">{contract.contractName}</p>
-                <p className="text-sm text-slate-500">
-                  {contract.status} · Created {contract.createdAt}
-                </p>
-              </li>
+              <ContractRow
+                key={contract.id || `${contract.contractName}-${idx}`}
+                contract={contract}
+              />
             ))}
           </ul>
         </>

--- a/src/components/contracts/ContractRow.tsx
+++ b/src/components/contracts/ContractRow.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import type { Contract } from '@/types/domain';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { useToast } from '@/components/toast/toast-provider';
+import { truncateAddress } from '@/lib/truncateAddress';
+
+export interface ContractRowProps {
+  contract: Contract;
+}
+
+export const ContractRow: React.FC<ContractRowProps> = ({ contract }) => {
+  const { showSuccess, showError } = useToast();
+  
+  const { copied, copy } = useCopyToClipboard({
+    onSuccess: () => {
+      showSuccess({ title: 'ID copied', description: 'Contract ID copied to clipboard' });
+    },
+    onError: () => {
+      showError({ title: 'Copy failed', description: 'Failed to copy contract ID' });
+    },
+  });
+
+  const contractId = contract.id || contract.contractName;
+  const displayId = contract.id ? truncateAddress(contract.id, 6, 4) : 'N/A';
+
+  return (
+    <li className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm flex justify-between items-center">
+      <div>
+        <p className="font-semibold text-slate-900">{contract.contractName}</p>
+        <p className="text-sm text-slate-500">
+          {contract.status} · Created {contract.createdAt}
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-mono text-slate-500">{displayId}</span>
+        <button
+          onClick={() => copy(contractId)}
+          aria-label={copied ? 'Contract ID copied' : `Copy contract ID ${contractId}`}
+          title={copied ? 'Contract ID copied' : 'Copy contract ID'}
+          className="p-1.5 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          {copied ? (
+            <svg className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          ) : (
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+            </svg>
+          )}
+        </button>
+      </div>
+    </li>
+  );
+};

--- a/src/components/contracts/CreateContractForm.tsx
+++ b/src/components/contracts/CreateContractForm.tsx
@@ -73,6 +73,7 @@ const CreateContractForm: React.FC<CreateContractFormProps> = ({ onSuccess, onCa
     setErrors([]);
 
     const contract: Contract = {
+      id: crypto.randomUUID(),
       contractName: contractName.trim(),
       parties: [
         { label: 'Client', address: 'TalentTrust Client' },

--- a/src/components/contracts/__tests__/ContractRow.test.tsx
+++ b/src/components/contracts/__tests__/ContractRow.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ContractRow } from '../ContractRow';
+import type { Contract } from '@/types/domain';
+
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+  }),
+}));
+
+const mockContract: Contract = {
+  id: 'contract-id-12345',
+  contractName: 'Test Contract',
+  status: 'Pending',
+  createdAt: 'Jan 1, 2026',
+  parties: [],
+  totalValue: 1000,
+  currency: 'USD',
+  milestoneCount: 0,
+};
+
+describe('ContractRow', () => {
+  let originalClipboard: any;
+
+  beforeAll(() => {
+    originalClipboard = global.navigator.clipboard;
+  });
+
+  afterAll(() => {
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders contract details correctly', () => {
+    render(<ContractRow contract={mockContract} />);
+    expect(screen.getByText('Test Contract')).toBeInTheDocument();
+    expect(screen.getByText(/Pending · Created Jan 1, 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/contra...2345/)).toBeInTheDocument();
+  });
+
+  it('copies the ID to the clipboard on success and shows success toast', async () => {
+    const writeTextMock = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      configurable: true,
+    });
+
+    render(<ContractRow contract={mockContract} />);
+    const copyButton = screen.getByRole('button', { name: `Copy contract ID ${mockContract.id}` });
+    
+    fireEvent.click(copyButton);
+    
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(mockContract.id);
+      expect(mockShowSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'ID copied' })
+      );
+    });
+
+    // Check accessible name changed
+    expect(screen.getByRole('button', { name: 'Contract ID copied' })).toBeInTheDocument();
+  });
+
+  it('shows error toast when clipboard throws (fallback)', async () => {
+    const writeTextMock = jest.fn().mockRejectedValue(new Error('clipboard error'));
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      configurable: true,
+    });
+
+    render(<ContractRow contract={mockContract} />);
+    const copyButton = screen.getByRole('button', { name: `Copy contract ID ${mockContract.id}` });
+    
+    fireEvent.click(copyButton);
+    
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Copy failed' })
+      );
+    });
+  });
+
+  it('shows error toast when clipboard API is missing (fallback)', async () => {
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+    });
+
+    render(<ContractRow contract={mockContract} />);
+    const copyButton = screen.getByRole('button', { name: `Copy contract ID ${mockContract.id}` });
+    
+    fireEvent.click(copyButton);
+    
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalled();
+    });
+  });
+
+  it('falls back to contractName if id is missing', async () => {
+    const contractWithoutId = { ...mockContract, id: undefined } as unknown as Contract;
+    
+    const writeTextMock = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      configurable: true,
+    });
+
+    render(<ContractRow contract={contractWithoutId} />);
+    
+    const copyButton = screen.getByRole('button', { name: `Copy contract ID ${contractWithoutId.contractName}` });
+    fireEvent.click(copyButton);
+    
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(contractWithoutId.contractName);
+    });
+  });
+});

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -136,6 +136,7 @@ export function WalletProvider({
   const { showSuccess, showError } = useSafeToast();
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isConnectingRef = useRef(false);
   const STORAGE_KEY = 'wallet_connected_address';
 
 
@@ -211,6 +212,8 @@ export function WalletProvider({
    *   4. Validate and persist the returned Stellar public key.
    */
   const connect = useCallback(async () => {
+    if (isConnectingRef.current) return;
+    isConnectingRef.current = true;
     setIsConnecting(true);
     setError(null);
     try {
@@ -242,9 +245,10 @@ export function WalletProvider({
         description: message,
       });
     } finally {
+      isConnectingRef.current = false;
       setIsConnecting(false);
     }
-  }, []);
+  }, [showError]);
 
   return (
     <WalletContext.Provider value={{ address, isConnecting, error, connect, disconnect }}>

--- a/src/contexts/__tests__/WalletContext.test.tsx
+++ b/src/contexts/__tests__/WalletContext.test.tsx
@@ -158,6 +158,47 @@ describe('WalletContext persistence', () => {
 
       expect(resolved).toBe(true);
     });
+
+    it('guards against concurrent connect calls (connect while connecting)', async () => {
+      renderWithProviders(<WalletConsumer />);
+      
+      const connectBtn = screen.getByTestId('connect-btn');
+      
+      // First call
+      await act(async () => {
+        connectBtn.click();
+      });
+      
+      expect(screen.getByTestId('is-connecting')).toHaveTextContent('Connecting');
+      
+      // Wait halfway through the connection
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      
+      // Second call while still connecting
+      await act(async () => {
+        connectBtn.click();
+      });
+      
+      // Finish the first connection
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      
+      expect(screen.getByTestId('is-connecting')).toHaveTextContent('Not connecting');
+      expect(screen.getByTestId('address')).toHaveTextContent(MOCKED_STELLAR_ADDRESS);
+      
+      // If the second call incorrectly proceeded, advancing the timer again would 
+      // uncover the defect (isConnecting would be false while the second call was in flight).
+      // Since it's guarded, the second call returns early. Let's advance time again just in case
+      // to ensure no lingering side effects.
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+      
+      expect(screen.getByTestId('is-connecting')).toHaveTextContent('Not connecting');
+    });
   });
 
   describe('disconnect()', () => {

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -19,7 +19,7 @@ export type {
 };
 
 /** Canonical contract shape aligned with ContractSummary props. */
-export type Contract = ContractSummaryProps;
+export type Contract = ContractSummaryProps & { id: string };
 
 /** Canonical reputation profile shape for list and detail views. */
 export type Reputation = Omit<ReputationProfileProps, 'name'> & { name?: string };


### PR DESCRIPTION
Closes #480 

Description
Let users copy a contract ID by selecting truncated text. This PR adds a per-row copy control with a toast, utilizing the Clipboard API with appropriate fallbacks.

Requirements Addressed
Per-row copy control: Created a new ContractRow component replacing simple <li> elements, integrating a copy button for the contract ID.
Clipboard API Usage: Utilized the existing useCopyToClipboard hook with standard Clipboard API methods, falling back to the documented showError toast if the clipboard throws or is unavailable.
Accessible & Clear label: The copy button is fully keyboard-operable, clearly labelled, and provides an accessible visual checkmark upon successful copy using aria-label.
Testing: Added comprehensive tests in src/components/contracts/__tests__/ContractRow.test.tsx achieving robust coverage for the success path, clipboard-throws fallback, missing clipboard API fallback, and missing ID fallback. Additionally, fixed existing ContractsPage test suites by properly mocking the ToastProvider wrapper.