### PR TITLE
feat(forms): add density toggle for forms view

### DIFF
--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -6,13 +6,14 @@ The provider is mounted as the outermost application provider in `src/app/layout
 
 ## Preference Model
 
-`UserPreferences` contains four fields:
+`UserPreferences` contains the following fields:
 
 | Field | Type | Default | Behavior |
 |-------|------|---------|----------|
 | `theme` | `'light' \| 'dark' \| 'system'` | `'system'` | Controls the `data-theme` attribute and `light` / `dark` class on `document.documentElement`. |
 | `amountFormat` | `'usd' \| 'ngn' \| 'compact'` | `'usd'` | Selects how `formatAmount` formats currency values. |
 | `toastDensity` | `'relaxed' \| 'compact'` | `'relaxed'` | Available to toast UI consumers for spacing decisions. |
+| `formDensity` | `'comfortable' \| 'compact'` | `'comfortable'` | Controls spacing in form fields; `compact` reduces vertical gaps for denser layouts. |
 | `quietMode` | `boolean` | `false` | Available to notification consumers that need to reduce interruption. |
 
 The defaults live in `DEFAULT_PREFERENCES`:
@@ -22,6 +23,7 @@ The defaults live in `DEFAULT_PREFERENCES`:
   theme: 'system',
   amountFormat: 'usd',
   toastDensity: 'relaxed',
+  formDensity: 'comfortable',
   quietMode: false,
 }
 ```

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import React from 'react';
+import { usePreferences } from '@/lib/preferences';
 
 /**
  * Props for the FormField component.
@@ -30,6 +33,19 @@ interface FormFieldProps {
  * 5. Appends a visual required indicator (`*`) which is hidden from screen readers with `aria-hidden="true"`.
  * 6. Renders the error message with `role="alert"` for direct announcements to assistive technologies.
  */
+const SPACING = {
+  comfortable: {
+    field: 'mb-4',
+    label: 'mb-1',
+    message: 'mt-1',
+  },
+  compact: {
+    field: 'mb-2',
+    label: 'mb-0.5',
+    message: 'mt-0.5',
+  },
+} as const;
+
 export const FormField: React.FC<FormFieldProps> = ({
   label,
   id,
@@ -38,6 +54,8 @@ export const FormField: React.FC<FormFieldProps> = ({
   children,
   required,
 }) => {
+  const { preferences } = usePreferences();
+  const spacing = SPACING[preferences.formDensity];
   const errorId = `${id}-error`;
   const helperId = `${id}-helper`;
   
@@ -69,10 +87,10 @@ export const FormField: React.FC<FormFieldProps> = ({
   } as React.HTMLAttributes<HTMLElement>);
 
   return (
-    <div className="mb-4 w-full">
+    <div className={`${spacing.field} w-full`}>
       <label
         htmlFor={id}
-        className="block text-sm font-medium text-gray-700 mb-1"
+        className={`block text-sm font-medium text-gray-700 ${spacing.label}`}
       >
         {label}
         {isRequired && (
@@ -83,12 +101,12 @@ export const FormField: React.FC<FormFieldProps> = ({
       </label>
       {child}
       {helperText && (
-        <p id={helperId} className="mt-1 text-sm text-gray-500">
+        <p id={helperId} className={`${spacing.message} text-sm text-gray-500`}>
           {helperText}
         </p>
       )}
       {error && (
-        <p id={errorId} className="mt-1 text-sm text-red-600 font-medium" role="alert">
+        <p id={errorId} className={`${spacing.message} text-sm text-red-600 font-medium`} role="alert">
           {error}
         </p>
       )}

--- a/src/components/__tests__/FormField.test.tsx
+++ b/src/components/__tests__/FormField.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { FormField } from '../FormField';
 import { testA11y } from '../../test-utils/a11y';
+import { PreferencesProvider } from '@/lib/preferences';
+import { resetCache } from '@/lib/safeStorage';
 
 describe('FormField', () => {
   const defaultProps = {
@@ -103,6 +106,49 @@ describe('FormField', () => {
           <input type="text" />
         </FormField>
       );
+    });
+  });
+});
+
+describe('FormField density', () => {
+  const defaultProps = { label: 'Field', id: 'field' };
+
+  beforeEach(() => {
+    localStorage.clear();
+    resetCache();
+  });
+
+  const renderWithPreferences = (ui: React.ReactElement) =>
+    render(<PreferencesProvider>{ui}</PreferencesProvider>);
+
+  it('applies comfortable spacing by default', async () => {
+    renderWithPreferences(
+      <FormField {...defaultProps} helperText="Hint">
+        <input type="text" data-testid="input" />
+      </FormField>,
+    );
+
+    expect(screen.getByText('Field').className).toContain('mb-1');
+    expect(screen.getByText('Hint').className).toContain('mt-1');
+  });
+
+  it('applies compact spacing when formDensity is compact', async () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ formDensity: 'compact' }),
+    );
+
+    renderWithPreferences(
+      <FormField {...defaultProps} helperText="Hint">
+        <input type="text" data-testid="input" />
+      </FormField>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Field').className).toContain('mb-0');
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Hint').className).toContain('mt-0');
     });
   });
 });

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useRef, useEffect } from 'react';
-import { usePreferences, Theme, AmountFormat, ToastDensity } from '@/lib/preferences';
+import { usePreferences, Theme, AmountFormat, ToastDensity, FormDensity } from '@/lib/preferences';
 
 const FOCUSABLE_SELECTORS =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -154,6 +154,27 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                       className={`px-3 py-2 text-sm rounded-md border capitalize transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ${
                         preferences.toastDensity === d 
                           ? 'border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]' 
+                          : 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]'
+                      }`}
+                    >
+                      {d}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label id="form-density-label" className="block text-sm font-medium mb-2 text-[var(--foreground)]">Form Density</label>
+                <div className="grid grid-cols-2 gap-2" role="radiogroup" aria-labelledby="form-density-label" aria-label="Form Density">
+                  {(['comfortable', 'compact'] as FormDensity[]).map((d) => (
+                    <button
+                      key={d}
+                      onClick={() => updatePreference('formDensity', d)}
+                      role="radio"
+                      aria-checked={preferences.formDensity === d}
+                      className={`px-3 py-2 text-sm rounded-md border capitalize transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 ${
+                        preferences.formDensity === d
+                          ? 'border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]'
                           : 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]'
                       }`}
                     >

--- a/src/components/settings/__tests__/SettingsPanel.test.tsx
+++ b/src/components/settings/__tests__/SettingsPanel.test.tsx
@@ -134,11 +134,34 @@ describe('SettingsPanel', () => {
     expect(saved.toastDensity).toBe('compact');
   });
 
+  it('updates form density preference', () => {
+    renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+    const formDensityGroup = screen.getByRole('radiogroup', { name: /form density/i });
+    const compactButton = within(formDensityGroup).getByRole('radio', { name: /compact/i });
+    fireEvent.click(compactButton);
+
+    expect(compactButton.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('persists formDensity to localStorage when changed', () => {
+    renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
+
+    const formDensityGroup = screen.getByRole('radiogroup', { name: /form density/i });
+    const compactButton = within(formDensityGroup).getByRole('radio', { name: /compact/i });
+    fireEvent.click(compactButton);
+
+    const saved = JSON.parse(
+      localStorage.getItem('talenttrust-user-preferences') || '{}'
+    );
+    expect(saved.formDensity).toBe('compact');
+  });
+
   it('restores preferences from localStorage on remount (simulated reload)', () => {
     // Pre-seed localStorage as if a previous session saved dark + NGN
     localStorage.setItem(
       'talenttrust-user-preferences',
-      JSON.stringify({ theme: 'dark', amountFormat: 'ngn', toastDensity: 'compact', quietMode: true })
+      JSON.stringify({ theme: 'dark', amountFormat: 'ngn', toastDensity: 'compact', formDensity: 'compact', quietMode: true })
     );
 
     renderWithProvider(<SettingsPanel isOpen={true} onClose={() => {}} />);
@@ -155,6 +178,10 @@ describe('SettingsPanel', () => {
     // Toast density: compact should be checked
     const densityGroup = screen.getByRole('radiogroup', { name: /toast density/i });
     expect(within(densityGroup).getByRole('radio', { name: /compact/i }).getAttribute('aria-checked')).toBe('true');
+
+    // Form density: compact should be checked
+    const formDensityGroup = screen.getByRole('radiogroup', { name: /form density/i });
+    expect(within(formDensityGroup).getByRole('radio', { name: /compact/i }).getAttribute('aria-checked')).toBe('true');
 
     // Quiet mode: on
     expect(screen.getByRole('switch', { name: /quiet mode/i }).getAttribute('aria-checked')).toBe('true');
@@ -317,6 +344,10 @@ describe('SettingsPanel', () => {
     // Toast density radiogroup
     const densityGroup = screen.getByRole('radiogroup', { name: /toast density/i });
     expect(densityGroup).toBeInTheDocument();
+    
+    // Form density radiogroup
+    const formDensityGroup = screen.getByRole('radiogroup', { name: /form density/i });
+    expect(formDensityGroup).toBeInTheDocument();
     
     // Quiet mode switch
     const quietSwitch = screen.getByRole('switch', { name: /quiet mode/i });

--- a/src/lib/__tests__/preferences.test.tsx
+++ b/src/lib/__tests__/preferences.test.tsx
@@ -74,6 +74,7 @@ describe('PreferencesProvider', () => {
       theme: 'system',
       amountFormat: 'usd',
       toastDensity: 'relaxed',
+      formDensity: 'comfortable',
       quietMode: false,
       toastDuration: 'normal',
       idleDisconnectMs: 0,
@@ -126,6 +127,36 @@ describe('PreferencesProvider', () => {
     ).toBe(false);
   });
 
+  it('uses default formDensity when none is stored', () => {
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    expect(result.current.preferences.formDensity).toBe('comfortable');
+  });
+
+  it('persists formDensity and restores it on hydation', () => {
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+
+    act(() => {
+      result.current.updatePreference('formDensity', 'compact');
+    });
+
+    expect(result.current.preferences.formDensity).toBe('compact');
+    const saved = JSON.parse(localStorage.getItem('talenttrust-user-preferences') || '{}');
+    expect(saved.formDensity).toBe('compact');
+
+    // Remount to simulate reload
+    const { result: r2 } = renderHook(() => usePreferences(), { wrapper });
+    expect(r2.current.preferences.formDensity).toBe('compact');
+  });
+
+  it('falls back to comfortable when stored formDensity is invalid', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ formDensity: 'ultra-compact' }),
+    );
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    expect(result.current.preferences.formDensity).toBe('comfortable');
+  });
+
   it('rejects non-boolean quietMode values (truthy coercion guard)', () => {
     localStorage.setItem(
       'talenttrust-user-preferences',
@@ -142,13 +173,14 @@ describe('PreferencesProvider', () => {
     expect(r2.current.preferences.quietMode).toBe(false);
   });
 
-  it('persists only the six known keys even after a malicious payload round-trips', async () => {
+  it('persists only the seven known keys even after a malicious payload round-trips', async () => {
     localStorage.setItem(
       'talenttrust-user-preferences',
       JSON.stringify({
         theme: 'dark',
         amountFormat: 'ngn',
         toastDensity: 'compact',
+        formDensity: 'compact',
         quietMode: true,
         toastDuration: 'long',
         idleDisconnectMs: 10000,
@@ -166,6 +198,7 @@ describe('PreferencesProvider', () => {
     // so we compare with `.sort()` for engine-independent comparison.
     expect(Object.keys(serialized).sort()).toEqual([
       'amountFormat',
+      'formDensity',
       'idleDisconnectMs',
       'quietMode',
       'theme',
@@ -220,6 +253,7 @@ describe('sanitizePreferences (pure helper)', () => {
     theme: 'system',
     amountFormat: 'usd',
     toastDensity: 'relaxed',
+    formDensity: 'comfortable',
     quietMode: false,
     toastDuration: 'normal',
     idleDisconnectMs: 0,
@@ -251,6 +285,7 @@ describe('sanitizePreferences (pure helper)', () => {
         theme: 'dark',
         amountFormat: 'compact',
         toastDensity: 'compact',
+        formDensity: 'compact',
         quietMode: true,
         toastDuration: 'long',
         idleDisconnectMs: 15000,
@@ -259,6 +294,7 @@ describe('sanitizePreferences (pure helper)', () => {
       theme: 'dark',
       amountFormat: 'compact',
       toastDensity: 'compact',
+      formDensity: 'compact',
       quietMode: true,
       toastDuration: 'long',
       idleDisconnectMs: 15000,
@@ -272,6 +308,7 @@ describe('sanitizePreferences (pure helper)', () => {
       theme: 'light',
       amountFormat: 'usd',
       toastDensity: 'relaxed',
+      formDensity: 'comfortable',
       quietMode: true,
       toastDuration: 'normal',
       idleDisconnectMs: 0,
@@ -368,6 +405,7 @@ describe('sanitizePreferences (pure helper)', () => {
       theme: 'dark',
       amountFormat: 'usd',
       toastDensity: 'compact',
+      formDensity: 'comfortable',
       quietMode: false,
       toastDuration: 'persistent',
       idleDisconnectMs: 10000,

--- a/src/lib/preferences.tsx
+++ b/src/lib/preferences.tsx
@@ -7,6 +7,7 @@ import { getItem, setItem } from './safeStorage';
 export type Theme = 'light' | 'dark' | 'system';
 export type AmountFormat = 'usd' | 'ngn' | 'compact';
 export type ToastDensity = 'relaxed' | 'compact';
+export type FormDensity = 'comfortable' | 'compact';
 /**
  * Controls the default auto-dismiss duration for toasts when the caller does
  * not supply an explicit `duration`.
@@ -49,6 +50,7 @@ export interface UserPreferences {
   theme: Theme;
   amountFormat: AmountFormat;
   toastDensity: ToastDensity;
+  formDensity: FormDensity;
   quietMode: boolean;
   toastDuration: ToastDuration;
   /**
@@ -62,6 +64,7 @@ const DEFAULT_PREFERENCES: UserPreferences = {
   theme: 'system',
   amountFormat: 'usd',
   toastDensity: 'relaxed',
+  formDensity: 'comfortable',
   quietMode: false,
   toastDuration: 'normal',
   idleDisconnectMs: 0,
@@ -77,6 +80,7 @@ const KNOWN_KEYS: ReadonlySet<keyof UserPreferences> = new Set([
   'theme',
   'amountFormat',
   'toastDensity',
+  'formDensity',
   'quietMode',
   'toastDuration',
   'idleDisconnectMs',
@@ -99,6 +103,7 @@ const DANGEROUS_KEYS: ReadonlySet<string> = new Set(['__proto__', 'constructor',
 const ALLOWED_THEMES: ReadonlySet<Theme> = new Set(['light', 'dark', 'system']);
 const ALLOWED_AMOUNT_FORMATS: ReadonlySet<AmountFormat> = new Set(['usd', 'ngn', 'compact']);
 const ALLOWED_TOAST_DENSITIES: ReadonlySet<ToastDensity> = new Set(['relaxed', 'compact']);
+const ALLOWED_FORM_DENSITIES: ReadonlySet<FormDensity> = new Set(['comfortable', 'compact']);
 const ALLOWED_TOAST_DURATIONS: ReadonlySet<ToastDuration> = new Set(['short', 'normal', 'long', 'persistent']);
 
 interface PreferencesContextType {
@@ -150,6 +155,7 @@ export function sanitizePreferences(raw: unknown): UserPreferences {
   let theme: Theme = DEFAULT_PREFERENCES.theme;
   let amountFormat: AmountFormat = DEFAULT_PREFERENCES.amountFormat;
   let toastDensity: ToastDensity = DEFAULT_PREFERENCES.toastDensity;
+  let formDensity: FormDensity = DEFAULT_PREFERENCES.formDensity;
   let quietMode: boolean = DEFAULT_PREFERENCES.quietMode;
   let toastDuration: ToastDuration = DEFAULT_PREFERENCES.toastDuration;
   let idleDisconnectMs: number = DEFAULT_PREFERENCES.idleDisconnectMs;
@@ -184,6 +190,11 @@ export function sanitizePreferences(raw: unknown): UserPreferences {
           toastDensity = value as ToastDensity;
         }
         break;
+      case 'formDensity':
+        if (typeof value === 'string' && ALLOWED_FORM_DENSITIES.has(value as FormDensity)) {
+          formDensity = value as FormDensity;
+        }
+        break;
       case 'quietMode':
         if (typeof value === 'boolean') {
           quietMode = value;
@@ -208,7 +219,7 @@ export function sanitizePreferences(raw: unknown): UserPreferences {
     }
   }
 
-  return { theme, amountFormat, toastDensity, quietMode, toastDuration, idleDisconnectMs };
+  return { theme, amountFormat, toastDensity, formDensity, quietMode, toastDuration, idleDisconnectMs };
 }
 
 /**


### PR DESCRIPTION
Closes #822

## Description

Adds a persisted form density preference that allows users to switch between **Comfortable** and **Compact** spacing for forms.

The preference follows the existing user preferences infrastructure, is stored in the existing SSR-safe namespaced preferences object, restores automatically on application startup, and safely falls back to the default when an invalid value is encountered.

## Type of Change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [x] Documentation update

---

## Pre-flight Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage

- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
- [x] If this PR adds or modifies UI components, accessibility tests were written using the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

Executed the project's standard verification commands:

- `npm run lint`
- `npm test` (73 test suites, 1,267 tests passed)
- `npm run build`

Added test coverage for:

- Default `formDensity` preference initialization
- Preference persistence and hydration from storage
- Invalid stored values falling back to the default
- FormField rendering with both comfortable and compact spacing
- Form Density settings radiogroup interactions
- Preference updates and persistence through the Settings panel

---

## Accessibility & Security Notes

### Accessibility

Added the Form Density selector using the existing accessible radiogroup pattern (`role="radio"` and `aria-checked`) already used by the Settings panel.

### Security

The feature only persists a validated UI preference using the existing SSR-safe preferences storage. No authentication, authorization, API, wallet, or user-input security behavior was modified.
