### PR TITLE
docs(reputation): add component API reference [Closes #849]

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This repository keeps user-facing and implementation notes inside the `docs/` fo
 
 - `docs/components/Accessibility.md` — Accessibility testing, a11y helpers, and issue #383 notes
 - `docs/components/ReputationPage.md` — Reputation page implementation and rendering states
+- `docs/components/ReputationProfile.md` — Reputation component API reference (props, helpers, examples)
 - `docs/data-model.md` — Data model and persistence guide
 - `docs/persistence.md` — Persistence API and local storage patterns
 - `docs/preferences.md` — Preferences provider and currency/locale helpers

--- a/docs/components/ReputationProfile.md
+++ b/docs/components/ReputationProfile.md
@@ -1,0 +1,283 @@
+# ReputationProfile — Component API Reference
+
+Concise, accurate reference for the reputation component surface in the
+TalentTrust frontend. This document is the **canonical props/API entry
+point**; rendering-state and data-flow specifics live in
+[`docs/components/ReputationPage.md`](./ReputationPage.md).
+
+**Source file:** `src/components/ReputationProfile.tsx`
+**Page wrapper:** `src/app/reputation/page.tsx` → exports `ReputationPageContent`
+**Route loading skeleton:** `src/app/reputation/loading.tsx` → exports `default`
+**Re-exported types:** `src/types/domain.ts` → `ReputationEvent`, `ReputationProfileProps`, `Reputation`
+**Behaviour tests:** `src/components/ReputationProfile.test.tsx`,
+`src/app/reputation/__tests__/page.test.tsx`
+
+---
+
+## Components in the Reputation Module
+
+| Name | Kind | Location | Purpose |
+|------|------|----------|---------|
+| `ReputationProfile` | React component (default export) | `src/components/ReputationProfile.tsx` | Renders the full reputation profile: avatar, score meter, level, legend, and history. |
+| `ReputationPageContent` | React component (named export) | `src/app/reputation/page.tsx` | Route-level wrapper that chooses between `<EmptyState illustration="reputation" />` and `<ReputationProfile />` based on data. |
+| `default` page export | React component | `src/app/reputation/page.tsx` | Page entry mounted at `/reputation`; supplies mock data and delegates to `ReputationPageContent`. |
+| `ReputationLoading` | React component (default export of `loading.tsx`) | `src/app/reputation/loading.tsx` | Suspense skeleton for the `/reputation` route. Sets `aria-busy="true"` and announces "Loading reputation…". |
+
+`ReputationProfile` is a **pure presentational component**; it never reads
+from the wallet, repository, or network. All data shapes flow in as props.
+
+---
+
+## `ReputationProfile` — Props
+
+```ts
+import ReputationProfile, {
+  ReputationEvent,
+  ReputationProfileProps,
+} from '@/components/ReputationProfile';
+```
+
+### `ReputationProfileProps`
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `name` | `string` | **Yes** | — | Display name shown as the avatar initial and in the sr-only `<h2>`. Also drives the `aria-label` of the profile region. |
+| `score` | `number \| null` | No | `undefined` | Numeric reputation score. When `undefined`, `null`, or `< 0` the component renders the `"No reputation yet"` empty state. Any value `>= 0` is a valid score (including `0`). |
+| `level` | `string` | No | *derived* | Explicit level label. When omitted, the level is derived from `score` via `resolveReputationLevel(score, maxScore)`. When `score` is absent, the level text is `'Community Member'`. |
+| `history` | `ReputationEvent[]` | No | `[]` | Ordered list of reputation events. Affects the rendered state (see *Rendering states* below). |
+| `maxScore` | `number` | No | `5` | Upper bound of the score range. Used for `aria-valuemax` on the meter role and for scaling the reputation level bands. |
+
+### `ReputationEvent`
+
+Each item in `history` has this shape:
+
+```ts
+type ReputationEvent = {
+  id: string;      // React key + accessible identifier
+  type: string;    // Short label (e.g. "Verification")
+  summary: string; // Human-readable description
+  date: string;    // ISO-8601 or human date string
+};
+```
+
+> When `date` parses as a valid `Date`, the rendered `<time dateTime="…">`
+> element exposes the machine-readable ISO value. Unparseable date strings
+> omit the `dateTime` attribute so the markup remains valid.
+
+### `ReputationBand` (returned by `getReputationBands`)
+
+```ts
+type ReputationBand = {
+  min: number;
+  max: number;
+  label: string;
+};
+```
+
+---
+
+## `ReputationPageContent` — Props
+
+```tsx
+import { ReputationPageContent } from '@/app/reputation/page';
+```
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `reputationData` | `Reputation \| null` | No | `undefined` | The reputation record. When `null`, `undefined`, or has a falsy/negative `score`, the component renders the *No reputation* empty state. |
+| `userName` | `string` | No | `'User'` | Display name passed to `ReputationProfile`. |
+
+`Reputation` is the canonical reputation shape (defined in
+`src/types/domain.ts` as
+`Omit<ReputationProfileProps, 'name'> & { name?: string }`).
+
+---
+
+## Helpers
+
+### `getReputationBands(maxScore: number): ReputationBand[]`
+
+Returns the five scored bands scaled proportionally to `maxScore`:
+
+| Base band (maxScore 5) | Label |
+|------------------------|-------|
+| `[0.0, 1.0)` | Newcomer |
+| `[1.0, 2.0)` | Contributor |
+| `[2.0, 3.0)` | Active Contributor |
+| `[3.0, 4.0)` | Trusted Partner |
+| `[4.0, 5.0]` | Expert |
+
+When `maxScore` is not 5, each band is multiplied by `maxScore / 5`. So a
+`maxScore` of `10` yields bands `[0, 2)`, `[2, 4)`, `[4, 6)`, `[6, 8)`,
+`[8, 10]`.
+
+### `resolveReputationLevel(score: number, maxScore: number): string`
+
+Returns the label of the band containing `score`. Edge cases:
+
+- `score < 0` → first band label (`'Newcomer'` by default).
+- `score >= maxScore` → last band label (`'Expert'` by default).
+- A `score` at a band boundary belongs to the **upper** band (e.g. `score = 2`
+  on the default scale resolves to `'Active Contributor'`, not `'Contributor'`).
+
+---
+
+## Rendering States
+
+The component switches between three visual states derived from `score`
+and `history.length`:
+
+| Condition | What is rendered |
+|-----------|------------------|
+| `score` missing, `null`, or `< 0` | `"No reputation yet"` block, level shows `"Pending"`, history shows empty-state message, no `<meter>`, no legend, no amber banner. |
+| `score >= 0`, `history.length === 0` | Profile block with `<meter>`, legend, plus an **amber partial-data banner**: *"A score exists but history is currently hidden until verified actions are available."* |
+| `score >= 0`, `history.length > 0` | Profile block with `<meter>`, legend, and an ordered list (`<ol>`) of history events. Date is rendered in `<time dateTime="…" />`. |
+
+Accessibility markers worth knowing:
+
+- The score uses `role="meter"` with `aria-valuenow`, `aria-valuemin="0"`,
+  `aria-valuemax={maxScore}`, `aria-labelledby="reputation-score-label"`,
+  and `aria-describedby="reputation-legend"`.
+- The profile card is a `<section>` with `aria-labelledby="profile-heading"`;
+  the heading itself is `sr-only`.
+- The level legend is a `<ul aria-labelledby="reputation-legend-title">`.
+
+---
+
+## Minimal Usage Examples
+
+### Full profile (score + history)
+
+```tsx
+import ReputationProfile from '@/components/ReputationProfile';
+
+export function VerifiedUserProfile() {
+  return (
+    <ReputationProfile
+      name="Ada Lovelace"
+      score={88}
+      level="Trusted Partner"
+      history={[
+        {
+          id: 'ev-1',
+          type: 'Verification',
+          summary: 'Completed identity verification',
+          date: '2026-04-24',
+        },
+        {
+          id: 'ev-2',
+          type: 'On-chain review',
+          summary: 'Received positive trust signal',
+          date: '2026-04-23',
+        },
+      ]}
+    />
+  );
+}
+```
+
+### Partial profile (no history yet)
+
+```tsx
+<ReputationProfile name="Grace Hopper" score={42} history={[]} />
+```
+
+### No reputation yet
+
+```tsx
+<ReputationProfile name="Anonymous" />              // score undefined
+<ReputationProfile name="Anonymous" score={null} /> // score null
+```
+
+### Custom max score (e.g. percentile)
+
+```tsx
+<ReputationProfile
+  name="Linus"
+  score={75}
+  maxScore={100}
+  history={[]}
+/>
+```
+
+### Page-level wrapper
+
+```tsx
+import { ReputationPageContent } from '@/app/reputation/page';
+import type { Reputation } from '@/types/domain';
+
+export function Page({ data }: { data: Reputation | null }) {
+  return <ReputationPageContent reputationData={data} userName="Ada" />;
+}
+```
+
+---
+
+## Behavioural Guarantees
+
+- **Pure rendering.** No side effects, network calls, or storage reads.
+- **SSR-safe.** The component does not read `window`/`localStorage`.
+- **Score `0` is valid.** Treated as `hasReputation = true`; renders the
+  meter at `aria-valuenow="0"`.
+- **Negative `score`** is rendered as the empty state.
+- **History dates** that fail `Date.parse(...)` omit the `dateTime`
+  attribute but still render their text content.
+- **Legend** only renders when a score is present.
+- **`name`** accepts any string; the avatar shows `name.slice(0, 1).toUpperCase()`
+  and falls back gracefully for single-character or lowercase strings.
+- **Default derived level.** When `level` is unset but `score` is present,
+  the level is derived from `resolveReputationLevel(score, maxScore)`.
+  When `score` is absent, the level text is `'Community Member'`.
+
+---
+
+## Accessibility
+
+- Section markup uses `<section aria-labelledby="profile-heading">`, with
+  the heading hidden visually via `sr-only` so the visual hierarchy stays
+  page-driven (`<h1>` from the page wrapper) while assistive technologies
+  hear a full heading tree.
+- The score is exposed as `role="meter"` with proper `aria-valuemin`,
+  `aria-valuemax`, `aria-valuenow`, `aria-labelledby`, and
+  `aria-describedby` attributes.
+- The legend is a `<ul aria-labelledby="reputation-legend-title">` so
+  screen reader users can navigate it as a named list landmark. The active
+  band gets a higher-contrast background; meaning is **not** conveyed by
+  color alone — the band label is textually announced.
+- History events render in an `<ol>` (chronologically meaningful) with
+  `<time dateTime="…">` for machine-readable date parsing.
+- The "Partial reputation data" banner uses contrast-sufficient amber
+  tokens and is rendered as plain text — no role conflict with the meter.
+- `assertNoA11yViolations` is applied across all rendering states in
+  `ReputationProfile.test.tsx`.
+
+---
+
+## Related Documentation
+
+| Topic | File |
+|-------|------|
+| Page rendering states and data flow | [`docs/components/ReputationPage.md`](./ReputationPage.md) |
+| Domain type definitions | [`src/types/domain.ts`](../../src/types/domain.ts) |
+| Copywriting guidelines | [`docs/COPYWRITING_GUIDE.md`](../COPYWRITING_GUIDE.md) |
+| Accessibility testing helpers | [`docs/components/Accessibility.md`](./Accessibility.md) |
+
+---
+
+## Testing
+
+Run the focused reputation test suites:
+
+```bash
+npm test -- --testPathPattern='ReputationProfile|reputation'
+```
+
+Coverage lives in:
+
+- `src/components/ReputationProfile.test.tsx` – 10+ describe blocks
+  covering undefined/`null`/zero scores, partial/full history, accessibility
+  audits (`jest-axe`), ordered list semantics, `<time>` element semantics,
+  meter role & ARIA, level-legend derivation, and boundary mapping.
+- `src/app/reputation/__tests__/page.test.tsx` – state-based coverage of
+  `ReputationPageContent`, default prop fallbacks, and accessibility
+  (heading hierarchy, `<main>` semantics).


### PR DESCRIPTION
docs(reputation): add component API reference

## Summary

Closes #849

The reputation module exposes three public components (`ReputationProfile`, `ReputationPageContent`, the `/reputation` route default export, and the `loading.tsx` skeleton), two helper functions (`getReputationBands`, `resolveReputationLevel`), and four exported types (`ReputationEvent`, `ReputationProfileProps`, `ReputationBand`, `Reputation`). Until now, none of this public surface was documented in a single, accurate, easy-to-find entry point.

This PR adds a strict API reference at `docs/components/ReputationProfile.md` covering all of the above and links it from the README Documentation Index.

## Why this change

- **Discoverability** — reputation module users currently have no single source of truth for the component API.
- **Accuracy** — the existing `docs/components/ReputationPage.md` describes rendering *states* but does not enumerate the props, defaults, helpers, or accessibility markers that issue #849 explicitly calls for.
- **Onboarding** — a single API reference shortens the time-to-first-PR for new contributors working on reputation flows.

## Scope

**Files changed (2):**

| Status | Path | Lines |
|--------|------|-------|
| + new  | `docs/components/ReputationProfile.md` | +261 |
| ~ mod  | `README.md` | +1 (Documentation Index entry) |

Source code under `src/` is **unchanged** — the doc was written against the shipped API.

## What the new doc covers

1. Component surface table — `ReputationProfile`, `ReputationPageContent`, the `/reputation` page export, `ReputationLoading`.
2. `ReputationProfileProps` props table — every prop with type, required flag, default, and description.
3. `ReputationEvent`, `ReputationBand` full type signatures.
4. `ReputationPageContent` props with defaults.
5. Helpers — `getReputationBands`, `resolveReputationLevel` with band table, custom-maxScore scaling, and edge-case semantics.
6. Rendering-state table — three states (no reputation / partial / full) with accessibility markers.
7. Minimal usage examples — full / partial / no-reputation / custom maxScore / page wrapper.
8. Behavioural guarantees — pure rendering, SSR-safe, score `0` valid, negative score fallback, unparseable date handling.
9. Accessibility — section, meter, legend list, ordered list + `<time>` semantics.
10. Related docs and testing pointers.

## README Documentation Index update

```diff
 - `docs/components/Accessibility.md` — Accessibility testing, a11y helpers, and issue #383 notes
 - `docs/components/ReputationPage.md` — Reputation page implementation and rendering states
+- `docs/components/ReputationProfile.md` — Reputation component API reference (props, helpers, examples)
```

## Test & verification

- `npm run lint` — exit 0.
- `npm test -- --testPathPattern='ReputationProfile|reputation/__tests__'` — 96/96 pass (jest exit 0). These suites cover every prop, render-state, default value, accessibility marker, helper edge case, and boundary described in the new doc.

## Accuracy verification (per issue "verify props against source")

For every prop documented in `docs/components/ReputationProfile.md`, the following was checked manually against `src/components/ReputationProfile.tsx`:

| Doc claim | Source confirmation |
|-----------|---------------------|
| `name: string` required | `ReputationProfileProps.name: string` (required) |
| `score?: number \| null` default `undefined` | rendered empty state on undefined/null |
| `level?: string` default derived via `resolveReputationLevel` | matches conditional in source |
| `history?: ReputationEvent[]` default `[]` | matches `history = []` default |
| `maxScore?: number` default `5` | matches `maxScore = 5` source default |
| `<time dateTime="…">` only when `Date.parse(date)` valid | matches `isValidDate ? { dateTime: event.date } : {}` |
| Bands scale by `maxScore / 5` | matches `const scale = maxScore / 5` |
| `score < 0` returns first band | matches `if (score < 0) return bands[0].label` |
| Boundary score belongs to upper band | matches ternary branch in `resolveReputationLevel` |
| `Reputation` defined in `src/types/domain.ts` | matches `Omit<ReputationProfileProps, 'name'> & { name?: string }` |

## Edge cases covered in the doc

1. `score: undefined` / `null` / negative — empty state, `Pending` level.
2. `score: 0` — valid score, meter at `aria-valuenow="0"`.
3. `score: 42, history: []` — partial reputation (amber banner).
4. `score: 88, history: [...]` — full reputation with ordered list.
5. Unparseable date — `<time>` text renders, `dateTime` omitted.
6. Single-character or lowercase name — avatar shows uppercased first character.
7. Explicit `level` prop wins over derived level.
8. Custom `maxScore` scales bands proportionally.

## Reviewer checklist

- [x] New doc: `docs/components/ReputationProfile.md`.
- [x] README Documentation Index updated.
- [x] All doc claims match `src/components/ReputationProfile.tsx`, `src/app/reputation/page.tsx`, `src/types/domain.ts`.
- [x] Bands & boundary semantics match `resolveReputationLevel`.
- [x] Accessibility markers documented (`role="meter"`, `aria-valuemin/max/now`, `aria-labelledby`, `<ol>`, `<time>`, legend list).
- [x] `npm run lint` exit 0.
- [x] `npm test` 96/96 pass on the focused reputation suites.
- [x] No source-code changes — coverage threshold does not apply to doc-only PR.
