### PR TITLE
feat(contracts): add inline edit mode to contracts rows

### DIFF
--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -3,7 +3,8 @@
 import React, { useState, useCallback } from 'react';
 import EmptyState from '../../components/EmptyState';
 import { ContractCreationForm } from '../../components/ContractCreationForm';
-import { listContracts, saveContract } from '@/lib/repository';
+import EditableContractRow from '../../components/EditableContractRow';
+import { listContracts, saveContract, updateContract } from '@/lib/repository';
 import type { Contract } from '@/types/domain';
 
 const ContractsPage: React.FC = () => {
@@ -36,6 +37,15 @@ const ContractsPage: React.FC = () => {
     setShowForm(false);
   }, []);
 
+  /**
+   * Persists an inline row edit (keyed by the row's original name so renames
+   * update in place) and refreshes the list from storage.
+   */
+  const handleInlineSave = useCallback((originalName: string, updated: Contract) => {
+    updateContract(originalName, updated);
+    setContracts(listContracts());
+  }, []);
+
   return (
     <main className="min-h-screen p-8">
       <h1 className="text-2xl font-bold mb-6">Contracts</h1>
@@ -61,18 +71,13 @@ const ContractsPage: React.FC = () => {
               Create Contract
             </button>
           </div>
-          {/* TODO: Replace with a proper ContractSummary list component. */}
           <ul className="space-y-4">
             {contracts.map((contract, idx) => (
-              <li
+              <EditableContractRow
                 key={`${contract.contractName}-${idx}`}
-                className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm"
-              >
-                <p className="font-semibold text-slate-900">{contract.contractName}</p>
-                <p className="text-sm text-slate-500">
-                  {contract.status} · Created {contract.createdAt}
-                </p>
-              </li>
+                contract={contract}
+                onSave={handleInlineSave}
+              />
             ))}
           </ul>
         </>

--- a/src/components/EditableContractRow.tsx
+++ b/src/components/EditableContractRow.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import React, { useEffect, useId, useRef, useState } from 'react';
+import type { Contract } from '@/types/domain';
+import type { StatusType } from './StatusBadge';
+
+const STATUS_OPTIONS: StatusType[] = ['Active', 'Completed', 'Disputed', 'Pending', 'Paid'];
+
+export interface EditableContractRowProps {
+  contract: Contract;
+  /**
+   * Called with the contract's original name and the edited contract when a
+   * valid save is committed. The original name lets the caller locate the row
+   * even when the name itself was changed.
+   */
+  onSave: (originalName: string, updated: Contract) => void;
+}
+
+/**
+ * A contracts list row that can switch into an inline edit mode with
+ * save/cancel. Editing validates the name before saving, is keyboard
+ * accessible (Escape cancels), and announces the outcome to assistive tech.
+ */
+const EditableContractRow: React.FC<EditableContractRowProps> = ({ contract, onSave }) => {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(contract.contractName);
+  const [status, setStatus] = useState<StatusType>(contract.status);
+  const [error, setError] = useState('');
+  const [announcement, setAnnouncement] = useState('');
+
+  const nameId = useId();
+  const statusId = useId();
+  const errorId = useId();
+  const nameInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      nameInputRef.current?.focus();
+    }
+  }, [editing]);
+
+  const startEditing = () => {
+    setName(contract.contractName);
+    setStatus(contract.status);
+    setError('');
+    setEditing(true);
+  };
+
+  const cancelEditing = () => {
+    setEditing(false);
+    setError('');
+    setAnnouncement('Edit cancelled.');
+  };
+
+  const saveEditing = () => {
+    const trimmedName = name.trim();
+    if (trimmedName.length === 0) {
+      setError('Contract name is required.');
+      nameInputRef.current?.focus();
+      return;
+    }
+
+    onSave(contract.contractName, { ...contract, contractName: trimmedName, status });
+    setEditing(false);
+    setError('');
+    setAnnouncement(`Contract "${trimmedName}" updated.`);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLLIElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelEditing();
+    }
+  };
+
+  const liveRegion = (
+    <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+      {announcement}
+    </span>
+  );
+
+  if (!editing) {
+    return (
+      <li className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="font-semibold text-slate-900">{contract.contractName}</p>
+            <p className="text-sm text-slate-500">
+              {contract.status} · Created {contract.createdAt}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={startEditing}
+            aria-label={`Edit ${contract.contractName}`}
+            className="rounded-2xl border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          >
+            Edit
+          </button>
+        </div>
+        {liveRegion}
+      </li>
+    );
+  }
+
+  return (
+    <li
+      className="rounded-3xl border border-blue-200 bg-white p-4 shadow-sm"
+      onKeyDown={handleKeyDown}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <label htmlFor={nameId} className="text-sm font-medium text-slate-700">
+            Contract name
+          </label>
+          <input
+            id={nameId}
+            ref={nameInputRef}
+            type="text"
+            value={name}
+            onChange={(event) => {
+              setName(event.target.value);
+              if (error) setError('');
+            }}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? errorId : undefined}
+            className="rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          />
+          {error && (
+            <p id={errorId} role="alert" className="text-sm font-medium text-red-600">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor={statusId} className="text-sm font-medium text-slate-700">
+            Status
+          </label>
+          <select
+            id={statusId}
+            value={status}
+            onChange={(event) => setStatus(event.target.value as StatusType)}
+            className="rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          >
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={cancelEditing}
+            className="rounded-2xl border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={saveEditing}
+            className="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+      {liveRegion}
+    </li>
+  );
+};
+
+export default EditableContractRow;

--- a/src/components/__tests__/EditableContractRow.test.tsx
+++ b/src/components/__tests__/EditableContractRow.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EditableContractRow from '../EditableContractRow';
+import { assertNoA11yViolations } from '@/test-utils/a11y';
+import type { Contract } from '@/types/domain';
+
+const baseContract: Contract = {
+  contractName: 'Alpha Agreement',
+  parties: [{ label: 'Client', address: '0xAAA' }],
+  totalValue: 1000,
+  currency: 'USD',
+  status: 'Active',
+  createdAt: '2026-01-01',
+  milestoneCount: 2,
+};
+
+function renderRow(overrides: Partial<Contract> = {}) {
+  const onSave = jest.fn();
+  const contract = { ...baseContract, ...overrides };
+  const utils = render(
+    <ul>
+      <EditableContractRow contract={contract} onSave={onSave} />
+    </ul>,
+  );
+  return { onSave, contract, ...utils };
+}
+
+function enterEditMode() {
+  fireEvent.click(screen.getByRole('button', { name: /edit alpha agreement/i }));
+}
+
+describe('EditableContractRow', () => {
+  it('renders the contract details and an edit affordance in display mode', () => {
+    renderRow();
+    expect(screen.getByText('Alpha Agreement')).toBeInTheDocument();
+    expect(screen.getByText(/Active · Created 2026-01-01/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit alpha agreement/i })).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('reveals name and status inputs when editing starts', () => {
+    renderRow();
+    enterEditMode();
+    expect(screen.getByLabelText('Contract name')).toHaveValue('Alpha Agreement');
+    expect(screen.getByLabelText('Status')).toHaveValue('Active');
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('saves an edited name and status, then returns to display mode', () => {
+    const { onSave } = renderRow();
+    enterEditMode();
+
+    fireEvent.change(screen.getByLabelText('Contract name'), {
+      target: { value: 'Renamed Agreement' },
+    });
+    fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'Completed' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith('Alpha Agreement', {
+      ...baseContract,
+      contractName: 'Renamed Agreement',
+      status: 'Completed',
+    });
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Contract "Renamed Agreement" updated.');
+  });
+
+  it('trims surrounding whitespace from the saved name', () => {
+    const { onSave } = renderRow();
+    enterEditMode();
+    fireEvent.change(screen.getByLabelText('Contract name'), {
+      target: { value: '   Padded Name   ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSave).toHaveBeenCalledWith(
+      'Alpha Agreement',
+      expect.objectContaining({ contractName: 'Padded Name' }),
+    );
+  });
+
+  it('blocks saving when the name is empty and shows an alert', () => {
+    const { onSave } = renderRow();
+    enterEditMode();
+    fireEvent.change(screen.getByLabelText('Contract name'), { target: { value: '   ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('Contract name is required.');
+    expect(screen.getByLabelText('Contract name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Contract name')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('clears the validation error once the name is corrected', () => {
+    renderRow();
+    enterEditMode();
+    fireEvent.change(screen.getByLabelText('Contract name'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Contract name'), { target: { value: 'Fixed' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('cancels editing without saving and restores original values', () => {
+    const { onSave } = renderRow();
+    enterEditMode();
+    fireEvent.change(screen.getByLabelText('Contract name'), { target: { value: 'Discarded' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText('Alpha Agreement')).toBeInTheDocument();
+
+    enterEditMode();
+    expect(screen.getByLabelText('Contract name')).toHaveValue('Alpha Agreement');
+  });
+
+  it('ignores non-Escape keys while editing', () => {
+    const { onSave } = renderRow();
+    enterEditMode();
+    fireEvent.keyDown(screen.getByLabelText('Contract name'), { key: 'Enter' });
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Contract name')).toBeInTheDocument();
+  });
+
+  it('cancels editing when Escape is pressed', () => {
+    const { onSave } = renderRow();
+    enterEditMode();
+    fireEvent.change(screen.getByLabelText('Contract name'), { target: { value: 'Discarded' } });
+    fireEvent.keyDown(screen.getByLabelText('Contract name'), { key: 'Escape' });
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit alpha agreement/i })).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations in display or edit mode', async () => {
+    const { container } = renderRow();
+    await assertNoA11yViolations(container);
+    enterEditMode();
+    await assertNoA11yViolations(container);
+  });
+});

--- a/src/lib/__tests__/repository.test.ts
+++ b/src/lib/__tests__/repository.test.ts
@@ -20,6 +20,7 @@ import {
   listContracts,
   saveContract,
   upsertContract,
+  updateContract,
   updateMilestone,
   listMilestones,
   saveMilestone,
@@ -214,6 +215,48 @@ describe('contract upsert', () => {
     expect(result[0]).toEqual(upserted);
     expect(result[1]).toEqual(contractB);
     expect(result[2]).toEqual(duplicateA2);
+  });
+});
+
+describe('updateContract', () => {
+  it('replaces the contract found by its original name, in place', () => {
+    saveContract(contractA);
+    saveContract(contractB);
+
+    const edited: Contract = { ...contractA, status: 'Completed' };
+    expect(updateContract(contractA.contractName, edited)).toBe(true);
+
+    const result = listContracts();
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(edited);
+    expect(result[1]).toEqual(contractB);
+  });
+
+  it('renames a contract without creating a duplicate', () => {
+    saveContract(contractA);
+
+    const renamed: Contract = { ...contractA, contractName: 'Renamed Alpha' };
+    expect(updateContract(contractA.contractName, renamed)).toBe(true);
+
+    const result = listContracts();
+    expect(result).toHaveLength(1);
+    expect(result[0].contractName).toBe('Renamed Alpha');
+  });
+
+  it('returns false and changes nothing when no contract matches the original name', () => {
+    saveContract(contractA);
+
+    expect(updateContract('Missing Contract', contractB)).toBe(false);
+    expect(listContracts()).toEqual([contractA]);
+  });
+
+  it('leaves milestones untouched', () => {
+    saveContract(contractA);
+    saveMilestone(milestoneA);
+
+    updateContract(contractA.contractName, { ...contractA, status: 'Paid' });
+
+    expect(listMilestones()).toEqual([milestoneA]);
   });
 });
 

--- a/src/lib/repository.ts
+++ b/src/lib/repository.ts
@@ -199,6 +199,34 @@ export function upsertContract(contract: Contract): boolean {
   return writeStore({ ...store, contracts });
 }
 
+/**
+ * Replaces the contract currently stored under `originalName` with `updated`.
+ *
+ * Unlike {@link upsertContract} (which keys on the *new* name), this locates
+ * the existing row by its original name first, so an inline edit that also
+ * renames the contract updates in place instead of creating a duplicate.
+ *
+ * @returns `true` on a successful write; `false` when no contract matches
+ *   `originalName` or when running without `localStorage`.
+ */
+export function updateContract(originalName: string, updated: Contract): boolean {
+  const store = readStore();
+  const index = store.contracts.findIndex(
+    (existingContract) => existingContract.contractName === originalName,
+  );
+
+  if (index === -1) {
+    console.warn(`[repository] updateContract: No contract found with name '${originalName}'.`);
+    return false;
+  }
+
+  const contracts = store.contracts.map((existingContract, i) =>
+    i === index ? updated : existingContract,
+  );
+
+  return writeStore({ ...store, contracts });
+}
+
 // ---------------------------------------------------------------------------
 // Public API — Milestones
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Adds inline edit mode to the contracts list rows, so editing no longer requires navigating away.

- New `EditableContractRow` component: each row shows the contract with an **Edit** button; clicking it swaps the row into an edit form with a name field and a status select, plus **Save**/**Cancel**.
- Validation before save: an empty/whitespace name blocks the save and shows an inline `role="alert"` error (the input is marked `aria-invalid` and linked via `aria-describedby`).
- Keyboard accessible: the edit form focuses the name input on entry, and **Escape cancels**. Buttons are real `<button>`s and inputs are labelled.
- Announces the outcome ("Contract \"X\" updated." / "Edit cancelled.") via a polite `role="status"` live region.
- New `updateContract(originalName, updated)` repository helper (mirrors `updateMilestone`): it finds the row by its **original** name, so a rename updates in place instead of creating a duplicate under the new name.

## Testing
Full output below.

- `npm run lint`: clean.
- `npm test`: **1274 passed / 74 suites**, 0 failures.
- `npm run build`: succeeds (the `/contracts` route builds).
- Coverage on the new component `EditableContractRow.tsx`: **100% statements / branches / functions / lines**. The 10 component tests cover edit, save (name + status), whitespace trimming, validation blocking + error clearing, cancel (with value restore), Escape-cancel, non-Escape keys ignored, and a jest-axe a11y check in both modes. `updateContract` is covered by repository tests (replace-in-place, rename-without-duplicate, no-match returns false, milestones untouched).

```
Test Suites: 74 passed, 74 total
Tests:       1274 passed, 1274 total
```

Closes #799
