### PR TITLE
Docs/wallet 51 apiref

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This repository keeps user-facing and implementation notes inside the `docs/` fo
 
 - `docs/components/Accessibility.md` — Accessibility testing, a11y helpers, and issue #383 notes
 - `docs/components/ReputationPage.md` — Reputation page implementation and rendering states
+- `docs/components/Toast.md` — Toast usage guide: provider setup, `useToast` hook, props, common patterns, and accessibility
 - `docs/data-model.md` — Data model and persistence guide
 - `docs/persistence.md` — Persistence API and local storage patterns
 - `docs/preferences.md` — Preferences provider and currency/locale helpers

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This repository keeps user-facing and implementation notes inside the `docs/` fo
 - `docs/components/Accessibility.md` — Accessibility testing, a11y helpers, and issue #383 notes
 - `docs/components/ReputationPage.md` — Reputation page implementation and rendering states
 - `docs/components/Toast.md` — Toast usage guide: provider setup, `useToast` hook, props, common patterns, and accessibility
+- `docs/components/Wallet.md` — Wallet API reference: `WalletProvider`, `useWallet` hook, `WalletConnectButton`, and `WalletAddressInput` props and usage examples
 - `docs/data-model.md` — Data model and persistence guide
 - `docs/persistence.md` — Persistence API and local storage patterns
 - `docs/preferences.md` — Preferences provider and currency/locale helpers

--- a/docs/components/Toast.md
+++ b/docs/components/Toast.md
@@ -1,4 +1,4 @@
-﻿# Toast
+# Toast
 
 Transient notification system for success and error feedback. Supports auto-dismiss, pause-on-interaction (hover and focus), screen-reader announcements, density preferences, and quiet-mode suppression.
 
@@ -7,386 +7,14 @@ Transient notification system for success and error feedback. Supports auto-dism
 
 ---
 
-## Provider Architecture
+## Quick Start
 
-```text
-<PreferencesProvider>            <- src/lib/preferences.tsx
-  <ToastProvider>                <- src/components/toast/toast-provider.tsx
-    {children}
-    <ToastAnnouncer />           {/* two sr-only live-region <div>s */}
-    <ToastViewport />            {/* fixed top-right visual stack */}
-  </ToastProvider>
-</PreferencesProvider>
-```
+### 1. Mount the provider
 
-`ToastProvider` **must** be a descendant of `PreferencesProvider` because it reads
-`quietMode`, `toastDensity`, and `toastDuration` from `usePreferences()`
-(source line 403; JSDoc lines 229-231).
-
-All active toasts render in a **single** fixed column anchored `top-4 right-4`
-(source line 125). There is no multi-column layout.
-
----
-
-## Exports
-
-| Export          | Kind      | Description                                            |
-|-----------------|-----------|--------------------------------------------------------|
-| `ToastProvider` | Component | Context provider; renders viewport and announcer        |
-| `useToast`      | Hook      | Returns `{ toasts, showSuccess, showError, dismissToast }` |
-
-Both are named exports from `@/components/toast/toast-provider`.
-
----
-
-## API Reference
-
-### Types
-
-```ts
-type ToastVariant = 'success' | 'error';             // source line 15
-
-type ToastAction = {
-  /** Plain-text label. Never interpolated as HTML. */
-  label: string;                                      // source lines 19-20
-  /** Called when the user clicks the action button. */
-  onClick: () => void;                                // source line 22
-};
-
-type ToastInput = {
-  title: string;                                      // source line 26
-  description?: string;                               // source line 27
-  duration?: number;      // ms; overrides preference  // source line 28
-  action?: ToastAction;   // optional inline button    // source line 33
-};
-
-type ToastRecord = ToastInput & {
-  id: string;
-  variant: ToastVariant;
-};                                                    // source lines 36-39
-
-type ToastContextValue = {
-  toasts: ToastRecord[];
-  showSuccess: (toast: ToastInput) => string;
-  showError:   (toast: ToastInput) => string;
-  dismissToast: (id: string) => void;
-};                                                    // source lines 41-46
-```
-
-### `useToast()` hook
-
-Must be called inside `<ToastProvider>`.
-Throws `Error('useToast must be used within a ToastProvider')` otherwise
-(source lines 532-534).
-
-Returns the `ToastContextValue` object:
-
-| Member              | Type                         | Description                                      |
-|---------------------|------------------------------|--------------------------------------------------|
-| `toasts`            | `ToastRecord[]`              | All currently visible toasts                     |
-| `showSuccess(toast)`| `(ToastInput) => string`     | Creates a success toast; see return-value table  |
-| `showError(toast)`  | `(ToastInput) => string`     | Creates an error toast; always returns an ID     |
-| `dismissToast(id)`  | `(string) => void`           | Removes the toast with the given ID immediately  |
-
-### `showSuccess(toast: ToastInput): string`
-
-```ts
-// source lines 405-416
-const showSuccess = useCallback(
-  (toast: ToastInput) => {
-    if (preferences.quietMode) {
-      return 'suppressed';          // literal string when quietMode is true
-    }
-    const durationMs =
-      toast.duration !== undefined ? toast.duration : DURATION_MAP[preferences.toastDuration];
-    return createToast('success', toast, durationMs);
-  },
-  [createToast, preferences.quietMode, preferences.toastDuration],
-);
-```
-
-### `showError(toast: ToastInput): string`
-
-```ts
-// source lines 418-425
-const showError = useCallback(
-  (toast: ToastInput) => {
-    const durationMs =
-      toast.duration !== undefined ? toast.duration : DURATION_MAP[preferences.toastDuration];
-    return createToast('error', toast, durationMs);
-  },
-  [createToast, preferences.toastDuration],
-);
-```
-
-`showError` has **no** quiet-mode branch - it always creates a toast (source line 418;
-confirmed by test `quietMode - does not suppress error toasts when quietMode is true`,
-lines 360-395).
-
-### `dismissToast(id: string): void`
-
-Removes the matching toast by filtering state (source lines 286-288).
-If `id` does not correspond to any visible toast the call is a no-op.
-
----
-
-## Return-Value Table
-
-| Function       | Scenario                                       | Return value                  |
-|----------------|------------------------------------------------|-------------------------------|
-| `showSuccess`  | Normal (quietMode is `false`)                  | Unique ID string e.g. `"toast-<uuid>"` |
-| `showSuccess`  | Quiet mode active (`preferences.quietMode === true`) | `'suppressed'` - no toast is created |
-| `showError`    | Any (quiet mode is ignored)                    | Unique ID string e.g. `"toast-<uuid>"` |
-| `dismissToast` | -                                              | `void`                        |
-
-The returned ID prefix is always `"toast-"` (source line 80; test line 163:
-`expect(ids.every((id) => id.startsWith('toast-'))).toBe(true)`).
-
----
-
-## Behavioral Guarantees
-
-### Quiet Mode
-
-Source: lines 405-409.
-Test suite: `describe('quietMode', ...)` (test lines 313-396).
-
-When `preferences.quietMode === true`:
-
-- `showSuccess()` returns the **literal string `'suppressed'`** and does **not** add
-  any entry to the `toasts` array (test line 356-357:
-  `expect(result).toBe('suppressed')` and
-  `expect(screen.queryByRole('status')).not.toBeInTheDocument()`).
-- `showError()` is **completely unaffected**. It returns a valid `toast-...` ID,
-  the toast is rendered, and `role="alert"` is present (test lines 392-394).
-- The quiet-mode gate is applied **before** `createToast`, so no ID is ever
-  generated for suppressed calls (source line 407-408).
-
-Callers may branch on the literal `'suppressed'` string:
-
-```ts
-const result = showSuccess({ title: 'Done' });
-if (result === 'suppressed') { /* user preference active */ }
-```
-
-### `MAX_VISIBLE_TOASTS` and Eviction Order
-
-Source: lines 62-69 (constant), lines 387-395 (eviction logic).
-Test suite: `describe('maxVisible cap (MAX_VISIBLE_TOASTS = 4)', ...)` (test lines 488-678).
-
-```ts
-const MAX_VISIBLE_TOASTS = 4;   // source line 69
-```
-
-When a new toast would make the queue length exceed `MAX_VISIBLE_TOASTS`,
-the **oldest** toast (index 0) is evicted **before** the new one is appended:
-
-```ts
-// source lines 387-395
-setToasts((currentToasts) => {
-  const next = [...currentToasts, { ...toast, id, variant }];
-  if (next.length <= MAX_VISIBLE_TOASTS) {
-    return next;
-  }
-  // Evict the oldest toast and cancel its timer.
-  const [evicted, ...remaining] = next;
-  clearToastTimer(evicted.id);
-  return remaining;
-});
-```
-
-The eviction order is **oldest-first (FIFO)**. Tests confirm:
-
-- Adding 5 toasts: `Toast 1` is gone, `Toast 2`-`Toast 5` are visible
-  (test lines 549-553).
-- Adding 6 toasts: `Toast 1` and `Toast 2` are gone, `Toast 6` is visible
-  (test lines 565-568).
-- The evicted toast's auto-dismiss timer is **cancelled** (`clearToastTimer`)
-  so its callback cannot fire after removal (test lines 571-616,
-  `clearTimeoutSpy` assertion at line 609).
-- The live region after eviction announces the **newest** surviving toast
-  (test lines 618-629).
-- Eviction works the same way when `toastDuration` is `'persistent'`
-  (test lines 1332-1372).
-
-### Density and Stacking Gap
-
-Source: lines 125-127 (JSX), lines 255-258 (JSDoc), line 482 (prop pass).
-Test suite: `describe('density', ...)` (test lines 398-441).
-
-`preferences.toastDensity` controls the Tailwind `gap-*` class on the viewport container:
-
-| `toastDensity` value  | CSS class | Approximate gap |
-|-----------------------|-----------|-----------------|
-| `'relaxed'` (default) | `gap-3`   | 12 px           |
-| `'compact'`           | `gap-1.5` | 6 px            |
-
-Source (line 126):
+`ToastProvider` must wrap any component that calls `useToast()`. In this project it is already wired in `src/app/layout.tsx` inside `PreferencesProvider`:
 
 ```tsx
-density === 'compact' ? 'gap-1.5' : 'gap-3'
-```
-
-Tests assert the className via `viewport.className.match(/gap-3/)` and
-`/gap-1\.5/` (test lines 419, 439).
-
-### Auto-Dismiss Duration
-
-Source: lines 55-60 (`DURATION_MAP`), lines 410-413 / 420-422 (resolution logic).
-Test suite: `describe('toastDuration preference', ...)` (test lines 1002-1373).
-
-```ts
-const DURATION_MAP: Readonly<Record<ToastDuration, number | null>> = {
-  short:      2500,
-  normal:     5000,
-  long:      10000,
-  persistent: null,   // null -> no timer scheduled
-};
-```
-
-**Resolution order** (same for both `showSuccess` and `showError`):
-
-1. If `toast.duration` is explicitly supplied, use it **as-is** (even `0`).
-2. Otherwise look up `DURATION_MAP[preferences.toastDuration]`.
-
-Per-call `duration` always wins, including over `'persistent'`
-(source lines 410-412; test lines 1178-1214).
-
-For `'persistent'`, `DURATION_MAP` returns `null`. When `durationMs` is `null`,
-`createToast` stores `undefined` on the record (source line 388:
-`duration: durationMs ?? undefined`). The `useEffect` then skips
-`scheduleToastDismiss` for that toast (source lines 436-438).
-
-| Preference value | Effective duration | Auto-dismissed? |
-|------------------|--------------------|-----------------|
-| `'short'`        | 2 500 ms           | Yes             |
-| `'normal'`       | 5 000 ms           | Yes (default)   |
-| `'long'`         | 10 000 ms          | Yes             |
-| `'persistent'`   | -                  | No              |
-
-### Pause on Hover / Focus
-
-Source: lines 137-140 (event handlers), lines 342-381 (pause/resume logic).
-Test suite: tests at lines 202-264.
-
-Each toast panel listens for:
-
-| Event        | Handler           |
-|--------------|-------------------|
-| `mouseenter` | `onPauseTimer`    |
-| `mouseleave` | `onResumeTimer`   |
-| `focus`      | `onPauseTimer`    |
-| `blur`       | `onResumeTimer`   |
-
-A `pauseCount` integer tracks overlapping interactions (source lines 349, 374).
-The timer only resumes when `pauseCount` returns to `0` (source line 376).
-Remaining time is computed from `expiresAt - Date.now()` at pause time
-(source lines 355-357) and passed to a fresh `setTimeout` on resume (source line 377).
-
-### Action Button Contract
-
-Source: lines 17-23 (type), lines 159-173 (render), lines 277-281 (JSDoc).
-Test suite: `describe('toast action button', ...)` (test lines 684-995).
-
-```ts
-type ToastAction = {
-  label: string;        // rendered as a plain text node - never set via innerHTML
-  onClick: () => void;  // callback; toast dismissed unconditionally after call
-};
-```
-
-**Plain-text enforcement.** `label` is rendered as a React text child:
-
-```tsx
-{toast.action.label}   // source line 171
-```
-
-It is **never** set via `innerHTML` or `dangerouslySetInnerHTML`.
-The XSS test (test lines 892-924) verifies that a malicious label string
-`'<img src=x onerror=alert(1)>'` appears as literal text and
-`actionBtn.querySelector('img')` returns `null`.
-
-**Dismiss-on-fire.** Clicking the action button **always** calls `onDismiss`
-immediately after `onClick`, unconditionally (source lines 165-168):
-
-```tsx
-onClick={() => {
-  toast.action!.onClick();
-  onDismiss(toast.id);
-}}
-```
-
-The action button fires the callback (test line 783) and the toast is removed
-(test lines 786-824). The auto-dismiss timer is cancelled once the toast is
-gone (test lines 821-824).
-
-**Backward compatibility.** Omitting `action` renders no action button;
-only the dismiss `x` button is present inside the toast panel
-(test lines 862-889).
-
----
-
-## Accessibility
-
-### `role` attributes
-
-Source: line 141.
-Tests: line 60 (`getByRole('status')`), line 74 (`getByRole('alert')`).
-
-| Toast variant | `role` value | AT behavior                                     |
-|---------------|--------------|-------------------------------------------------|
-| `'success'`   | `"status"`   | Announced when the AT is idle (non-interrupting) |
-| `'error'`     | `"alert"`    | Announced immediately; may trigger alert sound   |
-
-The viewport container carries `role="region"` and `aria-label="Notifications"`
-with `aria-atomic="false"` (source lines 122-124), making it a navigable
-landmark. The `aria-atomic="false"` means individual toasts, not the
-entire container, are treated as atomic units.
-
-### Live-Region Announcer
-
-Source: lines 203-217 (`ToastAnnouncer`).
-Tests: lines 62, 75.
-
-`ToastAnnouncer` renders **two** `sr-only` `<div>` elements inside the provider:
-
-| Region  | `aria-live`   | `aria-atomic` | Content                                              |
-|---------|---------------|---------------|------------------------------------------------------|
-| Success | `"polite"`    | `"true"`      | `title[. description]` of the **latest** success toast |
-| Error   | `"assertive"` | `"true"`      | `title[. description]` of the **latest** error toast   |
-
-The content formula (source lines 210, 213):
-
-```
-`${toast.title}${toast.description ? `. ${toast.description}` : ''}`
-```
-
-Only the **most recent** toast of each variant is announced. When the toast
-stack is replaced by eviction, the live region reflects the newest surviving
-toast (test lines 618-629: after adding 5 toasts the polite region contains
-`'Toast 5'`, not `'Toast 1'`).
-
-### Dismiss Button
-
-Source: lines 175-194.
-Tests: lines 86-90 (`dismiss success notification`), lines 1146, 1168.
-
-Each toast renders one dismiss button with:
-
-- `aria-label="Dismiss success notification"` or `"Dismiss error notification"`
-  (source line 176: `` aria-label={`Dismiss ${badgeLabel.toLowerCase()} notification`} ``).
-- `focus:ring-2 focus:ring-[var(--ring)]` (source line 189) - fully keyboard accessible.
-- `<span aria-hidden="true">&times;</span>` hides the `x` glyph from AT.
-
----
-
-## Mounting Example
-
-The following pattern matches the actual import paths and prop signatures used in the
-test file (test import lines 3-4).
-
-```tsx
-// app/layout.tsx  (or root provider file)
+// src/app/layout.tsx
 import { PreferencesProvider } from '@/lib/preferences';
 import { ToastProvider } from '@/components/toast/toast-provider';
 
@@ -405,30 +33,204 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-Consuming the hook in a client component:
+`ToastProvider` **must** be a descendant of `PreferencesProvider` because it reads
+`quietMode`, `toastDensity`, and `toastDuration` from `usePreferences()`.
+
+### 2. Call the hook
+
+```tsx
+'use client';
+import { useToast } from '@/components/toast/toast-provider';
+
+export function SaveButton() {
+  const { showSuccess, showError } = useToast();
+
+  const handleSave = async () => {
+    try {
+      await saveData();
+      showSuccess({ title: 'Saved', description: 'Your changes have been saved.' });
+    } catch {
+      showError({ title: 'Save failed', description: 'Please try again.' });
+    }
+  };
+
+  return <button onClick={handleSave}>Save</button>;
+}
+```
+
+---
+
+## Provider Architecture
+
+```text
+<PreferencesProvider>            <- src/lib/preferences.tsx
+  <ToastProvider>                <- src/components/toast/toast-provider.tsx
+    {children}
+    <ToastAnnouncer />           {/* two sr-only live-region <div>s */}
+    <ToastViewport />            {/* fixed top-right visual stack */}
+  </ToastProvider>
+</PreferencesProvider>
+```
+
+All active toasts render in a **single** fixed column anchored `top-4 right-4`.
+There is no multi-column layout.
+
+---
+
+## Exports
+
+| Export               | Kind      | Description                                              |
+|----------------------|-----------|----------------------------------------------------------|
+| `ToastProvider`      | Component | Context provider; renders viewport and announcer          |
+| `useToast`           | Hook      | Returns `{ toasts, showSuccess, showError, dismissToast }` |
+| `ToastErrorBoundary` | Component | Class error boundary wrapping the toast viewport          |
+
+All three are named exports from `@/components/toast/toast-provider`.
+
+---
+
+## API Reference
+
+### Types
+
+```ts
+type ToastVariant = 'success' | 'error';
+
+type ToastAction = {
+  /** Plain-text label. Never interpolated as HTML. */
+  label: string;
+  /** Called when the user clicks the action button. */
+  onClick: () => void;
+};
+
+type ToastInput = {
+  title: string;
+  description?: string;
+  /** Duration in ms. Overrides the user preference when supplied. */
+  duration?: number;
+  /** Optional inline action button. */
+  action?: ToastAction;
+};
+
+type ToastRecord = ToastInput & {
+  id: string;
+  variant: ToastVariant;
+};
+
+type ToastContextValue = {
+  toasts: ToastRecord[];
+  showSuccess: (toast: ToastInput) => string;
+  showError:   (toast: ToastInput) => string;
+  dismissToast: (id: string) => void;
+};
+```
+
+### `useToast()` hook
+
+Must be called inside `<ToastProvider>`.
+Throws `Error('useToast must be used within a ToastProvider')` otherwise.
+
+Returns the `ToastContextValue` object:
+
+| Member               | Type                     | Description                                      |
+|----------------------|--------------------------|--------------------------------------------------|
+| `toasts`             | `ToastRecord[]`          | All currently visible toasts                     |
+| `showSuccess(toast)` | `(ToastInput) => string` | Creates a success toast; see return-value table  |
+| `showError(toast)`   | `(ToastInput) => string` | Creates an error toast; always returns an ID     |
+| `dismissToast(id)`   | `(string) => void`       | Removes the toast with the given ID immediately  |
+
+### `showSuccess(toast: ToastInput): string`
+
+```ts
+const showSuccess = useCallback(
+  (toast: ToastInput) => {
+    if (preferences.quietMode) {
+      return 'suppressed';          // literal string when quietMode is true
+    }
+    const durationMs =
+      toast.duration !== undefined ? toast.duration : DURATION_MAP[preferences.toastDuration];
+    return createToast('success', toast, durationMs);
+  },
+  [createToast, preferences.quietMode, preferences.toastDuration],
+);
+```
+
+### `showError(toast: ToastInput): string`
+
+```ts
+const showError = useCallback(
+  (toast: ToastInput) => {
+    const durationMs =
+      toast.duration !== undefined ? toast.duration : DURATION_MAP[preferences.toastDuration];
+    return createToast('error', toast, durationMs);
+  },
+  [createToast, preferences.toastDuration],
+);
+```
+
+`showError` has **no** quiet-mode branch — it always creates a toast.
+
+### `dismissToast(id: string): void`
+
+Removes the matching toast by ID. If the ID does not correspond to any visible
+toast the call is a no-op.
+
+### `ToastErrorBoundary`
+
+A class-based React error boundary that wraps the `ToastAnnouncer` and `ToastViewport`
+inside `ToastProvider`. If the toast viewport throws during render, the boundary catches
+the error, reports it via `reportError` from `@/lib/errorReporter`, and renders a
+fallback panel with a **Retry** button. Clicking Retry resets the boundary state so the
+viewport can re-mount.
+
+```tsx
+// Used internally by ToastProvider — you normally do not need to use it directly.
+// If you need a standalone boundary for a custom viewport, import it explicitly:
+import { ToastErrorBoundary } from '@/components/toast/toast-provider';
+
+<ToastErrorBoundary>
+  <MyCustomToastViewport />
+</ToastErrorBoundary>
+```
+
+---
+
+## Return-Value Table
+
+| Function       | Scenario                                              | Return value                         |
+|----------------|-------------------------------------------------------|--------------------------------------|
+| `showSuccess`  | Normal (`quietMode` is `false`)                       | Unique ID string e.g. `"toast-<uuid>"` |
+| `showSuccess`  | Quiet mode active (`preferences.quietMode === true`)  | `'suppressed'` — no toast is created |
+| `showError`    | Any (quiet mode is ignored)                           | Unique ID string e.g. `"toast-<uuid>"` |
+| `dismissToast` | —                                                     | `void`                               |
+
+The returned ID prefix is always `"toast-"`.
+
+---
+
+## Common Patterns
+
+### Basic success and error
 
 ```tsx
 'use client';
 import { useToast } from '@/components/toast/toast-provider';
 
 export function ContractActions() {
-  const { showSuccess, showError, dismissToast } = useToast();
+  const { showSuccess, showError } = useToast();
 
   const handleRelease = async () => {
     try {
       await releaseFunds();
-      const id = showSuccess({
+      showSuccess({
         title: 'Milestone released',
         description: 'Funds are on the way to the freelancer wallet.',
-        action: {
-          label: 'Undo',
-          onClick: () => cancelRelease(),
-          // onClick fires before dismiss; toast is always removed afterward
-        },
       });
-      // id === 'suppressed' if quietMode is on; otherwise a 'toast-<uuid>' string
     } catch {
-      showError({ title: 'Release failed', description: 'Wallet not connected.' });
+      showError({
+        title: 'Release failed',
+        description: 'Wallet not connected.',
+      });
     }
   };
 
@@ -436,14 +238,255 @@ export function ContractActions() {
 }
 ```
 
+### Undo action
+
+Pass an `action` to render an inline button inside the toast. The callback fires
+and the toast dismisses immediately when the user clicks it.
+
+```tsx
+const handleRelease = async () => {
+  await releaseFunds();
+  showSuccess({
+    title: 'Milestone released',
+    description: 'Funds are on the way.',
+    action: {
+      label: 'Undo',
+      onClick: () => cancelRelease(),
+      // onClick fires before dismiss; toast is always removed afterward
+    },
+  });
+};
+```
+
+### Checking quiet mode
+
+`showSuccess` returns the literal string `'suppressed'` when the user has quiet
+mode enabled. Branch on it if the caller needs to fall back to another form of
+feedback:
+
+```tsx
+const id = showSuccess({ title: 'Profile saved' });
+if (id === 'suppressed') {
+  // quietMode is on — update a status indicator instead
+  setStatusText('Profile saved');
+}
+```
+
+### Programmatic dismiss
+
+Use the returned ID to dismiss a toast before its auto-dismiss timer fires —
+useful for "loading" style toasts:
+
+```tsx
+const { showSuccess, showError, dismissToast } = useToast();
+
+const handleUpload = async () => {
+  const loadingId = showSuccess({
+    title: 'Uploading…',
+    duration: 60_000,   // keep visible during upload
+  });
+
+  try {
+    await uploadFile(file);
+    dismissToast(loadingId);
+    showSuccess({ title: 'Upload complete' });
+  } catch {
+    dismissToast(loadingId);
+    showError({ title: 'Upload failed' });
+  }
+};
+```
+
+### Per-call duration override
+
+Supply `duration` in milliseconds to override the user's preference for a
+single toast:
+
+```tsx
+// Show a critical error for 15 seconds regardless of user preference.
+showError({
+  title: 'Payment failed',
+  description: 'Insufficient balance.',
+  duration: 15_000,
+});
+
+// Show a brief confirmation for 1.5 seconds.
+showSuccess({ title: 'Copied!', duration: 1_500 });
+
+// Keep a toast on screen until the user dismisses it manually.
+showSuccess({ title: 'Waiting for wallet…', duration: Infinity });
+```
+
+### Persistent toast (no auto-dismiss)
+
+Set `toastDuration` to `'persistent'` in user preferences, or pass a very large
+`duration`. The toast stays until the user clicks the dismiss button:
+
+```tsx
+// preference-driven — affects all toasts for this user
+// (stored in talenttrust-user-preferences via PreferencesProvider)
+
+// per-call — only this one toast stays persistent
+showError({ title: 'Action required', duration: 0 }); // duration 0 = dismiss immediately
+// NOTE: to keep on screen indefinitely, pass a large number or Infinity:
+showError({ title: 'Action required', description: 'Please review the contract.', duration: 2_147_483_647 });
+```
+
+---
+
+## Behavioral Guarantees
+
+### Quiet Mode
+
+When `preferences.quietMode === true`:
+
+- `showSuccess()` returns the **literal string `'suppressed'`** and does **not** add
+  any entry to the `toasts` array.
+- `showError()` is **completely unaffected**. It returns a valid `toast-...` ID and
+  the toast is rendered with `role="alert"`.
+- The quiet-mode gate is applied **before** `createToast`, so no ID is ever
+  generated for suppressed calls.
+
+### `MAX_VISIBLE_TOASTS` and Eviction Order
+
+```ts
+const MAX_VISIBLE_TOASTS = 4;
+```
+
+When a new toast would make the queue length exceed `MAX_VISIBLE_TOASTS`,
+the **oldest** toast (index 0) is evicted **before** the new one is appended:
+
+```ts
+setToasts((currentToasts) => {
+  const next = [...currentToasts, { ...toast, id, variant }];
+  if (next.length <= MAX_VISIBLE_TOASTS) {
+    return next;
+  }
+  const [evicted, ...remaining] = next;
+  clearToastTimer(evicted.id);
+  return remaining;
+});
+```
+
+Eviction is **oldest-first (FIFO)**. The evicted toast's auto-dismiss timer is
+cancelled so its callback cannot fire after removal. The live region after
+eviction announces the **newest** surviving toast.
+
+### Density and Stacking Gap
+
+`preferences.toastDensity` controls the Tailwind `gap-*` class on the viewport:
+
+| `toastDensity` value  | CSS class | Approximate gap |
+|-----------------------|-----------|-----------------|
+| `'relaxed'` (default) | `gap-3`   | 12 px           |
+| `'compact'`           | `gap-1.5` | 6 px            |
+
+### Auto-Dismiss Duration
+
+```ts
+const DURATION_MAP: Readonly<Record<ToastDuration, number | null>> = {
+  short:      2500,
+  normal:     5000,
+  long:      10000,
+  persistent: null,   // null -> no timer scheduled
+};
+```
+
+**Resolution order** (same for both `showSuccess` and `showError`):
+
+1. If `toast.duration` is explicitly supplied, use it **as-is**.
+2. Otherwise look up `DURATION_MAP[preferences.toastDuration]`.
+
+Per-call `duration` always wins, including over `'persistent'`.
+
+| Preference value | Effective duration | Auto-dismissed? |
+|------------------|--------------------|-----------------|
+| `'short'`        | 2 500 ms           | Yes             |
+| `'normal'`       | 5 000 ms           | Yes (default)   |
+| `'long'`         | 10 000 ms          | Yes             |
+| `'persistent'`   | —                  | No              |
+
+### Pause on Hover / Focus
+
+Each toast panel listens for:
+
+| Event        | Handler         |
+|--------------|-----------------|
+| `mouseenter` | pause timer     |
+| `mouseleave` | resume timer    |
+| `focus`      | pause timer     |
+| `blur`       | resume timer    |
+
+A `pauseCount` integer tracks overlapping interactions. The timer only resumes
+when `pauseCount` returns to `0`. Remaining time is computed from
+`expiresAt - Date.now()` at pause time and passed to a fresh `setTimeout` on
+resume.
+
+### Action Button Contract
+
+```ts
+type ToastAction = {
+  label: string;        // rendered as a plain text node — never set via innerHTML
+  onClick: () => void;  // callback; toast dismissed unconditionally after call
+};
+```
+
+**Plain-text enforcement.** `label` is rendered as a React text child and is
+**never** set via `innerHTML` or `dangerouslySetInnerHTML`.
+
+**Dismiss-on-fire.** Clicking the action button **always** calls `onDismiss`
+immediately after `onClick`, unconditionally:
+
+```tsx
+onClick={() => {
+  toast.action!.onClick();
+  onDismiss(toast.id);
+}}
+```
+
+---
+
+## Accessibility
+
+### `role` attributes
+
+| Toast variant | `role` value | AT behavior                                      |
+|---------------|--------------|--------------------------------------------------|
+| `'success'`   | `"status"`   | Announced when the AT is idle (non-interrupting) |
+| `'error'`     | `"alert"`    | Announced immediately; may trigger alert sound   |
+
+The viewport container carries `role="region"` and `aria-label="Notifications"`
+with `aria-atomic="false"`, making it a navigable landmark.
+
+### Live-Region Announcer
+
+`ToastAnnouncer` renders **two** `sr-only` `<div>` elements:
+
+| Region  | `aria-live`   | `aria-atomic` | Content                                                |
+|---------|---------------|---------------|--------------------------------------------------------|
+| Success | `"polite"`    | `"true"`      | `title[. description]` of the **latest** success toast |
+| Error   | `"assertive"` | `"true"`      | `title[. description]` of the **latest** error toast   |
+
+Only the **most recent** toast of each variant is announced. After eviction, the
+live region reflects the newest surviving toast.
+
+### Dismiss Button
+
+Each toast renders one dismiss button with:
+
+- `aria-label="Dismiss success notification"` or `"Dismiss error notification"`
+- `focus:ring-2 focus:ring-[var(--ring)]` — fully keyboard accessible
+- `<span aria-hidden="true">&times;</span>` hides the `×` glyph from AT
+
 ---
 
 ## Troubleshooting
 
 | Symptom | Likely cause |
 |---------|--------------|
-| `useToast` throws `"must be used within a ToastProvider"` | Component is outside `<ToastProvider>` (source line 533) |
-| Success toasts not appearing | `quietMode` is `true`; `showSuccess` returns `'suppressed'` (source lines 407-408) |
-| Only 4 toasts visible after a burst | `MAX_VISIBLE_TOASTS = 4`; oldest toast evicted (source lines 69, 392-395) |
-| Toast never dismisses | `toastDuration` is `'persistent'` with no per-call `duration` override (source lines 436-438) |
-| Action button click does not dismiss | Impossible by design: `onDismiss` is called unconditionally after `onClick` (source lines 165-168) |
+| `useToast` throws `"must be used within a ToastProvider"` | Component is outside `<ToastProvider>` |
+| Success toasts not appearing | `quietMode` is `true`; `showSuccess` returns `'suppressed'` |
+| Only 4 toasts visible after a burst | `MAX_VISIBLE_TOASTS = 4`; oldest toast evicted |
+| Toast never dismisses | `toastDuration` is `'persistent'` with no per-call `duration` override |
+| Action button click does not dismiss | Impossible by design: `onDismiss` is called unconditionally after `onClick` |
+| Toast viewport crashes silently | `ToastErrorBoundary` caught a render error; check `reportError` output |

--- a/docs/components/Wallet.md
+++ b/docs/components/Wallet.md
@@ -1,0 +1,379 @@
+# Wallet
+
+Stellar wallet integration for TalentTrust. Manages connection state globally via React Context and exposes UI components for connecting, displaying, and collecting wallet addresses.
+
+**Sources:**
+- `src/contexts/WalletContext.tsx` — provider, hook, and type definitions
+- `src/components/WalletConnectButton.tsx` — primary connect/disconnect UI
+- `src/components/WalletAddressInput.tsx` — validated address form field
+
+---
+
+> ⚠️ **Mock implementation notice**
+>
+> `connect()` is **currently mocked**. It simulates a 1-second delay and resolves with the
+> hard-coded `MOCKED_STELLAR_ADDRESS` constant. No real wallet extension is contacted.
+> The public API will remain unchanged when real Freighter integration lands; only the
+> internals of `connect()` will change.
+
+---
+
+## Quick Start
+
+### 1. Mount the provider
+
+`WalletProvider` is already wired at the root in `src/app/layout.tsx`. Place it inside
+`ToastProvider` so it can dispatch toast notifications:
+
+```tsx
+// src/app/layout.tsx
+import { WalletProvider } from '@/contexts/WalletContext';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <PreferencesProvider>
+          <ToastProvider>
+            <WalletProvider idleTimeout={900_000}>
+              {children}
+            </WalletProvider>
+          </ToastProvider>
+        </PreferencesProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+### 2. Drop in the connect button
+
+```tsx
+import { WalletConnectButton } from '@/components/WalletConnectButton';
+
+export function Header() {
+  return (
+    <header>
+      <WalletConnectButton />
+    </header>
+  );
+}
+```
+
+### 3. Read wallet state in any client component
+
+```tsx
+'use client';
+import { useWallet } from '@/contexts/WalletContext';
+
+export function PayButton() {
+  const { address, connect } = useWallet();
+
+  if (!address) {
+    return <button onClick={connect}>Connect wallet to pay</button>;
+  }
+
+  return <button>Pay from {address.slice(0, 6)}…</button>;
+}
+```
+
+---
+
+## Provider: `WalletProvider`
+
+```tsx
+<WalletProvider idleTimeout={900_000}>
+  {children}
+</WalletProvider>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | — | React subtree that requires wallet context. |
+| `idleTimeout` | `number` | `preferences.idleDisconnectMs` | Inactivity duration in milliseconds before the session auto-disconnects. `0` disables the feature. When omitted, falls back to the value stored in `PreferencesProvider`. |
+
+### Provider placement
+
+`WalletProvider` must be a descendant of both `PreferencesProvider` (for the `idleDisconnectMs`
+default) and `ToastProvider` (for connection-failure and session-expired notifications):
+
+```
+RootLayout
+└── PreferencesProvider
+    └── ToastProvider
+        └── WalletProvider   ← here
+            └── {children}
+```
+
+### Idle auto-disconnect
+
+When `idleTimeout > 0` and a wallet is connected, the provider attaches passive listeners for
+`pointermove`, `keydown`, `visibilitychange`, `mousedown`, and `touchstart`. If none of these
+events fires within `idleTimeout` ms, `disconnect()` is called automatically and a
+_"Session expired"_ toast is shown. The timer resets on each activity event and is fully cleaned
+up on unmount.
+
+Recommended production value: `900_000` (15 minutes).
+
+---
+
+## Hook: `useWallet`
+
+```tsx
+const { address, isConnecting, error, connect, disconnect } = useWallet();
+```
+
+Must be called inside a `<WalletProvider>` subtree. Throws
+`"useWallet must be used within a WalletProvider"` if called outside one.
+
+### Return value (`WalletContextType`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `address` | `string \| null` | Connected Stellar public key (G-address), or `null`. Rehydrated from `localStorage` on mount so it survives page refreshes. |
+| `isConnecting` | `boolean` | `true` while a connection attempt is in flight. Use to disable the connect button and show a spinner. |
+| `error` | `string \| null` | Human-readable error from the most recent failed `connect()` call, or `null`. Cleared automatically at the start of each new attempt. |
+| `connect` | `() => Promise<void>` | Initiates a connection attempt. Always resolves; errors are surfaced via `error` and an accessible error toast, never via rejection. |
+| `disconnect` | `() => void` | Clears `address`, removes `wallet_connected_address` from `localStorage`, and cancels any running idle timer. |
+
+### `connect()` state transitions
+
+1. Sets `isConnecting → true`, clears `error → null`.
+2. Attempts to connect (currently mocked with a 1-second delay).
+3. **Success:** sets `address` and persists to `localStorage`.
+4. **Failure:** sets `error` and fires a `showError` toast.
+5. Sets `isConnecting → false` in all cases (via `finally`).
+
+### Known error constants
+
+| Constant | Value | Cause |
+|----------|-------|-------|
+| `FREIGHTER_NOT_INSTALLED` | `"Freighter wallet is not installed. Please install the Freighter browser extension."` | Browser extension not detected. |
+| `USER_REJECTED` | `"User rejected the connection request."` | User dismissed the Freighter approval popup. |
+
+Both are exported from `src/contexts/WalletContext.tsx`.
+
+### Example
+
+```tsx
+'use client';
+import { useWallet } from '@/contexts/WalletContext';
+
+export function ConnectButton() {
+  const { address, isConnecting, error, connect, disconnect } = useWallet();
+
+  if (isConnecting) return <p aria-live="polite">Connecting…</p>;
+
+  if (error) {
+    return (
+      <div role="alert">
+        <p>Connection error: {error}</p>
+        <button onClick={connect}>Retry</button>
+      </div>
+    );
+  }
+
+  if (address) {
+    return (
+      <button onClick={disconnect}>
+        Disconnect ({address.slice(0, 6)}…)
+      </button>
+    );
+  }
+
+  return <button onClick={connect}>Connect Wallet</button>;
+}
+```
+
+---
+
+## Component: `WalletConnectButton`
+
+```tsx
+import { WalletConnectButton } from '@/components/WalletConnectButton';
+
+<WalletConnectButton />
+```
+
+Self-contained UI for the full connect/disconnect lifecycle. Requires no props — it reads
+all state from `useWallet()` internally. Depends on both `WalletProvider` and `ToastProvider`
+being present in the tree.
+
+### Props
+
+None. This component is fully self-contained.
+
+### Rendered branches
+
+| State | Rendered output |
+|-------|----------------|
+| Disconnected | "Connect Wallet" button (`aria-label="Connect wallet"`). |
+| Connecting | Disabled button with animated spinner and "Connecting…" text. |
+| Error | Red banner with "Connection Error" label and a "Retry" link (`aria-label="Retry wallet connection"`). |
+| Connected | Address pill (truncated via `truncateAddress`), copy button (`aria-label="Copy address to clipboard"`), and disconnect button (`aria-label="Disconnect wallet"`). |
+
+### Clipboard copy behaviour
+
+The copy button uses `navigator.clipboard.writeText`. Failures surface as error toasts rather
+than console logs (the address is treated as sensitive data):
+
+| Scenario | Result |
+|----------|--------|
+| Success | Checkmark icon; reverts to copy icon after 2 s. |
+| `navigator.clipboard` absent | Error toast: "Copy not supported". |
+| `writeText` absent | Error toast: "Copy not supported". |
+| `writeText` rejects (e.g. permission denied) | Error toast: "Copy failed". |
+
+---
+
+## Component: `WalletAddressInput`
+
+```tsx
+import { WalletAddressInput } from '@/components/WalletAddressInput';
+
+<WalletAddressInput
+  id="recipient"
+  label="Recipient address"
+  value={address}
+  onChange={setAddress}
+/>
+```
+
+A validated Stellar address input field. Wraps `FormField` and validates on blur using
+`isValidStellarAddress` from `src/lib/stellarAddress.ts`. Normalizes the value to uppercase
+on blur to match on-chain representation.
+
+### Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `id` | `string` | ✓ | — | `id` for the `<input>` and its associated `<label>`. |
+| `label` | `string` | ✓ | — | Visible label text. Also used in generated error messages. |
+| `value` | `string` | ✓ | — | Controlled input value. |
+| `onChange` | `(value: string) => void` | ✓ | — | Called on every keystroke with the raw input value, and on blur with the normalized (uppercased) value if it changed. |
+| `error` | `string` | — | `undefined` | External error message from the parent form (e.g. submit-time validation). Takes precedence over any internally generated blur error. |
+| `helperText` | `string` | — | `undefined` | Supplemental hint displayed below the input. |
+| `required` | `boolean` | — | `undefined` | Marks the field as required visually and semantically. Triggers a `"${label} is required"` error on blur when the value is empty. |
+| `placeholder` | `string` | — | `"GXXXXXXXXX…"` | Input placeholder text. |
+| `onValidation` | `(fieldId: string, error: string \| null) => void` | — | `undefined` | Called after every blur with the validation result. Use to feed errors into a parent `ErrorSummary`. |
+
+### Validation rules (applied on blur)
+
+| Condition | Error message |
+|-----------|--------------|
+| Empty value and `required={true}` | `"${label} is required"` |
+| Non-empty value fails `isValidStellarAddress` | `"${label} must be a valid Stellar G... address"` |
+| Valid address | No error; value is normalized to uppercase. |
+
+### Accessibility
+
+`WalletAddressInput` inherits the full accessibility wiring from `FormField`:
+- `<label>` linked by `id`.
+- `aria-invalid="true"` on the `<input>` when an error is present.
+- `aria-describedby` pointing to the helper text and error message paragraphs.
+- Error paragraph uses `role="alert"` for immediate screen-reader announcement.
+
+### Example — form with submit validation
+
+```tsx
+'use client';
+import { useState } from 'react';
+import { WalletAddressInput } from '@/components/WalletAddressInput';
+
+export function SendForm() {
+  const [recipient, setRecipient] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string | null>>({});
+
+  const handleValidation = (fieldId: string, error: string | null) => {
+    setFieldErrors(prev => ({ ...prev, [fieldId]: error }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // fieldErrors.recipient will be populated by blur validation
+    if (fieldErrors.recipient) return;
+    // proceed with recipient address…
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <WalletAddressInput
+        id="recipient"
+        label="Recipient address"
+        value={recipient}
+        onChange={setRecipient}
+        required
+        helperText="Enter the full 56-character Stellar public key."
+        onValidation={handleValidation}
+      />
+      <button type="submit">Send</button>
+    </form>
+  );
+}
+```
+
+---
+
+## Named exports
+
+### `src/contexts/WalletContext.tsx`
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `WalletProvider` | Component | Context provider. Place at the app root. |
+| `useWallet` | Hook | Primary consumer API. Throws outside `WalletProvider`. |
+| `WalletContextType` | TypeScript type | Shape of the context value. |
+| `MOCKED_STELLAR_ADDRESS` | `string` constant | Hard-coded G-address used by the mock `connect()`. |
+| `FREIGHTER_NOT_INSTALLED` | `string` constant | Error string when the Freighter extension is absent. |
+| `USER_REJECTED` | `string` constant | Error string when the user dismisses the approval popup. |
+
+### `src/components/WalletConnectButton.tsx`
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `WalletConnectButton` | Component (named + default) | Self-contained connect/disconnect UI. |
+
+### `src/components/WalletAddressInput.tsx`
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `WalletAddressInput` | Component (named + default) | Validated Stellar address input field. |
+| `WalletAddressInputProps` | TypeScript interface | Prop types for `WalletAddressInput`. |
+
+---
+
+## Session persistence
+
+The connected address is stored in `localStorage` under the key `wallet_connected_address`.
+It is rehydrated on client mount so sessions survive page refreshes. Storage access is wrapped
+in `src/lib/safeStorage.ts` to handle restricted browser environments gracefully.
+
+Only the Stellar public key is persisted — no private keys, seeds, or personal information.
+
+---
+
+## Related documentation
+
+| Document | Description |
+|----------|-------------|
+| [`docs/components/WalletContext.md`](./WalletContext.md) | Detailed `WalletProvider` / `useWallet` reference with full test coverage notes. |
+| [`docs/components/WalletConnectButton.md`](./WalletConnectButton.md) | In-depth `WalletConnectButton` documentation including clipboard-copy edge cases. |
+| [`docs/contexts/wallet-session.md`](../contexts/wallet-session.md) | Idle auto-disconnect lifecycle, activity events, and session rehydration flow. |
+
+---
+
+## Testing
+
+| Test file | Module under test |
+|-----------|-------------------|
+| `src/contexts/__tests__/WalletContext.test.tsx` | `WalletProvider`, `useWallet` |
+| `src/components/__tests__/WalletConnectButton.test.tsx` | `WalletConnectButton` |
+| `src/components/__tests__/WalletAddressInput.test.tsx` | `WalletAddressInput` |
+
+Run all wallet tests:
+
+```bash
+npm test -- --testPathPattern="WalletContext|WalletConnectButton|WalletAddressInput"
+```


### PR DESCRIPTION
docs(wallet): add component API reference (#51)
  
  Summary
  
  Adds docs/components/Wallet.md — a unified, reviewer-friendly reference for all wallet-related
  components and APIs. Links the new doc from the README documentation index.
  
  What's documented
  
  - WalletProvider — props table (children, idleTimeout), provider placement diagram, idle
  auto-disconnect behaviour, and recommended production configuration
  - useWallet hook — full WalletContextType return value table, connect() state transition steps,
  known error constants (FREIGHTER_NOT_INSTALLED, USER_REJECTED), and a complete usage example
  - WalletConnectButton — self-contained component with no props; rendered-branches table
  (disconnected / connecting / error / connected), and clipboard copy failure scenarios
  - WalletAddressInput — all 8 props documented with types, defaults, and descriptions; blur
  validation rules; accessibility wiring via FormField; form integration example with
  onValidation
  - Named exports table for all three source files
  - Session persistence notes (storage key, rehydration, security profile)
  - Cross-links to WalletContext.md, WalletConnectButton.md, and wallet-session.md
  
  Changes
  
  ┌───────────────────────────┬─────────────────────┐
  │ File                      │ Change              │
  ├───────────────────────────┼─────────────────────┤
  │ docs/components/Wallet.md │ Created (379 lines)                              │
  ├───────────────────────────┼──────────────────────────────────────────────────┤
  │ README.md                 │ Added Wallet.md entry to the Documentation Index │
  └───────────────────────────┴──────────────────────────────────────────────────┘
  
  Verification
  
  - npm run lint — ✅ clean
  - npm test — ✅ all suites pass
  - npm run build — ⚠️ pre-existing native binding failure (@tailwindcss/oxide binary missing in
  this dev container); confirmed identical on main before these changes — not introduced by this
  PR
  
  Pre-flight checklist
  
  - [x] Lint passes
  - [x] Tests pass
  - [x] Docs accurate to current source (WalletContext.tsx, WalletConnectButton.tsx,
  WalletAddressInput.tsx)
  - [x] Linked from README docs index
  - [x] No code changes — documentation only

closes #854 