### PR TITLE
feat(milestones): add command-palette entry

### DIFF
--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -4,9 +4,11 @@ import { axe } from 'jest-axe';
 import RootLayout from '../layout';
 
 // WalletProvider and RouteAnnouncer are already mocked in jest.setup.ts.
-// Mock next/navigation for RouteAnnouncer's usePathname call.
+// Mock next/navigation for RouteAnnouncer's usePathname call and
+// CommandPalette's useRouter call.
 jest.mock('next/navigation', () => ({
   usePathname: jest.fn().mockReturnValue('/'),
+  useRouter: jest.fn().mockReturnValue({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
 }));
 
 function renderLayout() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,6 +52,10 @@ import { WalletProvider } from '@/contexts/WalletContext';
 import RouteAnnouncer from '@/components/RouteAnnouncer';
 import Navbar from '@/components/Navbar';
 import HeaderActions from '@/components/HeaderActions';
+import CommandPalette from '@/components/CommandPalette';
+import { registerDefaultCommands } from '@/lib/commands/defaultCommands';
+
+registerDefaultCommands();
 
 export default function RootLayout({
   children,
@@ -88,6 +92,7 @@ export default function RootLayout({
                 </main>
               </div>
               <SettingsTrigger />
+              <CommandPalette />
             </WalletProvider>
           </ToastProvider>
         </PreferencesProvider>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useDialogFocusTrap } from '@/hooks/useDialogFocusTrap';
+import { getRegisteredCommands, type PaletteCommand } from '@/lib/commands/registry';
+
+function matches(command: PaletteCommand, query: string): boolean {
+  if (query.trim() === '') return true;
+  const haystack = [command.label, ...command.keywords].join(' ').toLowerCase();
+  return haystack.includes(query.trim().toLowerCase());
+}
+
+/**
+ * CommandPalette — a keyboard-operable, searchable list of app-wide actions.
+ *
+ * Opens via the visible trigger button or the Ctrl/Cmd+K shortcut from
+ * anywhere in the app. Filters registered commands (see
+ * `src/lib/commands/registry.ts`) by label and keywords, and navigates to
+ * the selected command's route on activation.
+ */
+export default function CommandPalette(): React.JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const router = useRouter();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const listboxId = useId();
+  const titleId = useId();
+
+  const commands = useMemo(() => getRegisteredCommands(), [isOpen]);
+  const results = useMemo(
+    () => commands.filter((command) => matches(command, query)),
+    [commands, query],
+  );
+
+  const close = () => {
+    setIsOpen(false);
+    setQuery('');
+    setActiveIndex(0);
+  };
+
+  const activate = (command: PaletteCommand) => {
+    router.push(command.href);
+    close();
+  };
+
+  useDialogFocusTrap({
+    isOpen,
+    dialogRef,
+    initialFocusRef: inputRef,
+    onEscape: close,
+    restoreFocus: true,
+  });
+
+  // Global Ctrl/Cmd+K shortcut, available regardless of open state.
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        setIsOpen((current) => !current);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query, isOpen]);
+
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((current) => (results.length === 0 ? 0 : (current + 1) % results.length));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((current) =>
+        results.length === 0 ? 0 : (current - 1 + results.length) % results.length,
+      );
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const selected = results[activeIndex];
+      if (selected) activate(selected);
+    }
+  };
+
+  const activeOptionId = results[activeIndex] ? `${listboxId}-${results[activeIndex].id}` : undefined;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setIsOpen(true)}
+        aria-label="Open command palette"
+        className="fixed bottom-6 right-24 inline-flex h-12 items-center gap-2 rounded-full bg-[var(--card)] px-4 text-sm font-medium text-[var(--foreground)] shadow-lg border border-[var(--border)] hover:bg-[var(--muted)] transition-colors z-40 focus:outline-none focus:ring-2 focus:ring-[var(--ring)] focus:ring-offset-2"
+      >
+        Search
+        <kbd className="rounded border border-[var(--border)] bg-[var(--muted)] px-1.5 py-0.5 text-xs">
+          Ctrl K
+        </kbd>
+      </button>
+
+      {isOpen ? (
+        <div className="fixed inset-0 z-50 flex items-start justify-center overflow-hidden pt-24">
+          <div
+            className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+            onClick={close}
+            aria-hidden="true"
+          />
+          <div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            className="relative z-10 w-full max-w-md rounded-lg border border-[var(--border)] bg-[var(--card)] shadow-xl"
+          >
+            <h2 id={titleId} className="sr-only">
+              Command palette
+            </h2>
+            <input
+              ref={inputRef}
+              type="text"
+              role="combobox"
+              aria-expanded="true"
+              aria-controls={listboxId}
+              aria-activedescendant={activeOptionId}
+              autoComplete="off"
+              placeholder="Type a command..."
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={handleInputKeyDown}
+              className="w-full rounded-t-lg border-b border-[var(--border)] bg-transparent px-4 py-3 text-sm text-[var(--foreground)] outline-none"
+            />
+            <ul id={listboxId} role="listbox" aria-label="Commands" className="max-h-72 overflow-y-auto py-1">
+              {results.length === 0 ? (
+                <li className="px-4 py-3 text-sm text-[var(--muted-foreground)]">No matching commands</li>
+              ) : (
+                results.map((command, index) => (
+                  <li
+                    key={command.id}
+                    id={`${listboxId}-${command.id}`}
+                    role="option"
+                    aria-selected={index === activeIndex}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onClick={() => activate(command)}
+                    className={[
+                      'cursor-pointer px-4 py-2 text-sm',
+                      index === activeIndex
+                        ? 'bg-[var(--primary)]/10 text-[var(--primary)]'
+                        : 'text-[var(--foreground)]',
+                    ].join(' ')}
+                  >
+                    {command.label}
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import CommandPalette from '../CommandPalette';
+import { clearCommands, registerCommand } from '@/lib/commands/registry';
+
+expect.extend(toHaveNoViolations);
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn(), prefetch: jest.fn() }),
+}));
+
+beforeEach(() => {
+  clearCommands();
+  registerCommand({
+    id: 'nav-milestones',
+    label: 'Go to Milestones',
+    keywords: ['milestones', 'milestone', 'payments', 'payouts'],
+    href: '/milestones',
+  });
+  mockPush.mockClear();
+});
+
+afterEach(() => {
+  clearCommands();
+});
+
+const openPalette = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: /open command palette/i }));
+  return user;
+};
+
+describe('CommandPalette — trigger', () => {
+  it('renders a visible trigger button', () => {
+    render(<CommandPalette />);
+    expect(screen.getByRole('button', { name: /open command palette/i })).toBeInTheDocument();
+  });
+
+  it('is closed by default', () => {
+    render(<CommandPalette />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the dialog when the trigger is clicked', async () => {
+    render(<CommandPalette />);
+    await openPalette();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+describe('CommandPalette — keyboard shortcut', () => {
+  it('opens on Ctrl+K from anywhere in the document', () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('opens on Cmd+K (metaKey)', () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(document, { key: 'k', metaKey: true });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('toggles closed on a second Ctrl+K', () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+
+describe('CommandPalette — milestones registration', () => {
+  it('lists the milestones command once open', async () => {
+    render(<CommandPalette />);
+    await openPalette();
+    expect(screen.getByRole('option', { name: 'Go to Milestones' })).toBeInTheDocument();
+  });
+
+  it('does not render duplicate milestones entries', async () => {
+    render(<CommandPalette />);
+    await openPalette();
+    expect(screen.getAllByRole('option', { name: 'Go to Milestones' })).toHaveLength(1);
+  });
+
+  it('filters the milestones entry in by keyword match', async () => {
+    render(<CommandPalette />);
+    const user = await openPalette();
+    await user.type(screen.getByRole('combobox'), 'payouts');
+    expect(screen.getByRole('option', { name: 'Go to Milestones' })).toBeInTheDocument();
+  });
+
+  it('filters the milestones entry out when the query does not match', async () => {
+    render(<CommandPalette />);
+    const user = await openPalette();
+    await user.type(screen.getByRole('combobox'), 'zzz-no-match');
+    expect(screen.queryByRole('option', { name: 'Go to Milestones' })).not.toBeInTheDocument();
+    expect(screen.getByText('No matching commands')).toBeInTheDocument();
+  });
+});
+
+describe('CommandPalette — activation', () => {
+  it('navigates to /milestones and closes when the milestones option is clicked', async () => {
+    render(<CommandPalette />);
+    await openPalette();
+
+    fireEvent.click(screen.getByRole('option', { name: 'Go to Milestones' }));
+
+    expect(mockPush).toHaveBeenCalledWith('/milestones');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('navigates to /milestones when Enter is pressed on the highlighted option', async () => {
+    render(<CommandPalette />);
+    const user = await openPalette();
+
+    await user.keyboard('{Enter}');
+
+    expect(mockPush).toHaveBeenCalledWith('/milestones');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('moves the active option with ArrowDown/ArrowUp before activating', async () => {
+    registerCommand({
+      id: 'nav-contracts',
+      label: 'Go to Contracts',
+      keywords: ['contracts'],
+      href: '/contracts',
+    });
+
+    render(<CommandPalette />);
+    const user = await openPalette();
+
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Enter}');
+
+    expect(mockPush).toHaveBeenCalledWith('/contracts');
+  });
+
+  it('returns focus to the trigger button after closing', async () => {
+    render(<CommandPalette />);
+    await openPalette();
+
+    fireEvent.click(screen.getByRole('option', { name: 'Go to Milestones' }));
+
+    expect(await screen.findByRole('button', { name: /open command palette/i })).toHaveFocus();
+  });
+});
+
+describe('CommandPalette — keyboard dismissal', () => {
+  it('closes on Escape', async () => {
+    render(<CommandPalette />);
+    await openPalette();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('closes when the backdrop is clicked', async () => {
+    render(<CommandPalette />);
+    await openPalette();
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(dialog.previousElementSibling as Element);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+
+describe('CommandPalette — accessibility (jest-axe)', () => {
+  it('has no axe violations when closed', async () => {
+    const { container } = render(<CommandPalette />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no axe violations when open', async () => {
+    const { container } = render(<CommandPalette />);
+    await openPalette();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/lib/commands/__tests__/registry.test.ts
+++ b/src/lib/commands/__tests__/registry.test.ts
@@ -1,0 +1,49 @@
+import { clearCommands, getRegisteredCommands, registerCommand } from '../registry';
+
+describe('command registry', () => {
+  afterEach(() => {
+    clearCommands();
+  });
+
+  it('starts empty', () => {
+    expect(getRegisteredCommands()).toEqual([]);
+  });
+
+  it('registers a command and makes it retrievable', () => {
+    registerCommand({ id: 'nav-milestones', label: 'Go to Milestones', keywords: ['milestones'], href: '/milestones' });
+
+    const commands = getRegisteredCommands();
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toMatchObject({ id: 'nav-milestones', label: 'Go to Milestones', href: '/milestones' });
+  });
+
+  it('does not create duplicate entries when the same id is registered twice', () => {
+    registerCommand({ id: 'nav-milestones', label: 'Go to Milestones', keywords: ['milestones'], href: '/milestones' });
+    registerCommand({ id: 'nav-milestones', label: 'Go to Milestones', keywords: ['milestones'], href: '/milestones' });
+
+    expect(getRegisteredCommands()).toHaveLength(1);
+  });
+
+  it('overwrites the previous entry when re-registering an existing id with new data', () => {
+    registerCommand({ id: 'nav-milestones', label: 'Old Label', keywords: ['old'], href: '/old' });
+    registerCommand({ id: 'nav-milestones', label: 'Go to Milestones', keywords: ['milestones'], href: '/milestones' });
+
+    const commands = getRegisteredCommands();
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toMatchObject({ label: 'Go to Milestones', href: '/milestones' });
+  });
+
+  it('supports multiple distinct commands', () => {
+    registerCommand({ id: 'nav-milestones', label: 'Go to Milestones', keywords: ['milestones'], href: '/milestones' });
+    registerCommand({ id: 'nav-contracts', label: 'Go to Contracts', keywords: ['contracts'], href: '/contracts' });
+
+    expect(getRegisteredCommands()).toHaveLength(2);
+  });
+
+  it('clearCommands removes all registered commands', () => {
+    registerCommand({ id: 'nav-milestones', label: 'Go to Milestones', keywords: ['milestones'], href: '/milestones' });
+    clearCommands();
+
+    expect(getRegisteredCommands()).toEqual([]);
+  });
+});

--- a/src/lib/commands/defaultCommands.ts
+++ b/src/lib/commands/defaultCommands.ts
@@ -1,0 +1,14 @@
+import { registerCommand } from './registry';
+
+/**
+ * Registers the palette entries available on every page. Imported once
+ * for its side effect from the root layout.
+ */
+export function registerDefaultCommands(): void {
+  registerCommand({
+    id: 'nav-milestones',
+    label: 'Go to Milestones',
+    keywords: ['milestones', 'milestone', 'payments', 'payouts'],
+    href: '/milestones',
+  });
+}

--- a/src/lib/commands/registry.ts
+++ b/src/lib/commands/registry.ts
@@ -1,0 +1,31 @@
+/** A single action exposed through the global command palette. */
+export interface PaletteCommand {
+  /** Stable, unique identifier. Re-registering the same id replaces the entry. */
+  id: string;
+  /** Human-readable label shown in the palette list. */
+  label: string;
+  /** Extra terms the palette matches against when filtering, alongside the label. */
+  keywords: readonly string[];
+  /** Route the palette navigates to when this command is activated. */
+  href: string;
+}
+
+const registeredCommands = new Map<string, PaletteCommand>();
+
+/**
+ * Registers a command with the palette. Registering with an id that already
+ * exists overwrites the previous entry instead of creating a duplicate.
+ */
+export function registerCommand(command: PaletteCommand): void {
+  registeredCommands.set(command.id, command);
+}
+
+/** Returns all currently registered commands. */
+export function getRegisteredCommands(): PaletteCommand[] {
+  return Array.from(registeredCommands.values());
+}
+
+/** Removes every registered command. Intended for test isolation. */
+export function clearCommands(): void {
+  registeredCommands.clear();
+}


### PR DESCRIPTION
## Summary

Closes #684 — exposes milestones in a global command palette.

- Added `src/lib/commands/registry.ts`: a small, id-keyed command registry (`registerCommand`, `getRegisteredCommands`, `clearCommands`). Re-registering an existing id overwrites the entry instead of creating a duplicate.
- Added `src/lib/commands/defaultCommands.ts`: registers the `Go to Milestones` entry (`href: /milestones`, keywords: `milestones`, `milestone`, `payments`, `payouts`).
- Added `src/components/CommandPalette.tsx`: an accessible, keyboard-operable palette.
  - Opens via a visible "Search / Ctrl K" trigger button or the `Ctrl+K` / `Cmd+K` shortcut from anywhere in the app.
  - `role="dialog"` + `combobox`/`listbox` wiring, arrow-key navigation, `Enter` to activate, `Escape`/backdrop-click to dismiss.
  - Reuses the existing `useDialogFocusTrap` hook (same one `ConfirmDialog` uses) for focus trapping and focus restoration on close.
  - Filters commands by label/keywords as you type.
- Wired `<CommandPalette />` into `src/app/layout.tsx` alongside the existing `SettingsTrigger`, and call `registerDefaultCommands()` once at module load.
- Updated the existing `src/app/__tests__/layout.test.tsx` mock of `next/navigation` to include `useRouter`, since the layout now renders a component that calls it.

## Test plan

- [x] `npm run lint` — clean, no errors/warnings on changed files or full repo.
- [x] `npm test` — full suite passes: **1284/1284 tests, 75/75 suites**, including 24 new tests covering command registration (dedup, overwrite, multi-command) and palette activation (open via click/Ctrl+K/Cmd+K, filter by keyword, keyboard navigation, Enter/click activation, focus restoration, Escape/backdrop dismissal, jest-axe a11y checks with 0 violations).
- [ ] `npm run build` — could not be verified in my local environment: `next build` (both Turbopack and the `--webpack` fallback) fails while loading the `lightningcss` native binding on this Windows sandbox, independent of any code in this PR. I confirmed this by stashing my changes and running the same build against unmodified `main` — it fails identically there, so it's a pre-existing environment limitation, not something introduced here.

### Full test output

```
Test Suites: 75 passed, 75 total
Tests:       1284 passed, 1284 total
Snapshots:   7 passed, 7 total
Time:        81.757 s
Ran all test suites.
```

New suites:
```
PASS src/lib/commands/__tests__/registry.test.ts
PASS src/components/__tests__/CommandPalette.test.tsx

Test Suites: 2 passed, 2 total
Tests:       24 passed, 24 total
Snapshots:   0 total
```
