### PR TITLE
feat(milestones): add client-side validation

### DIFF
--- a/src/components/milestones/MilestoneCreationForm.tsx
+++ b/src/components/milestones/MilestoneCreationForm.tsx
@@ -5,21 +5,23 @@ import { FormField } from '@/components/FormField';
 import { ErrorSummary } from '@/components/ErrorSummary';
 import { useDialogFocusTrap } from '@/hooks/useDialogFocusTrap';
 import { sanitizeUserText } from '@/lib/sanitizeUserText';
+import {
+  validateMilestone,
+  MAX_MILESTONE_TITLE_LENGTH,
+  ALLOWED_CURRENCIES,
+  ALLOWED_STATUSES,
+} from '@/lib/validateMilestone';
 import type { Milestone } from '@/types/domain';
 
-export const MAX_MILESTONE_TITLE_LENGTH = 200;
+// Re-export so existing imports of MAX_MILESTONE_TITLE_LENGTH from this module
+// continue to work without breaking changes.
+export { MAX_MILESTONE_TITLE_LENGTH };
 
 /** Status options available when creating a milestone. */
-const STATUS_OPTIONS: Milestone['status'][] = [
-  'Pending',
-  'Active',
-  'Completed',
-  'Paid',
-  'Disputed',
-];
+const STATUS_OPTIONS = ALLOWED_STATUSES as unknown as Milestone['status'][];
 
 /** Currency options available when creating a milestone. */
-const CURRENCY_OPTIONS = ['USD', 'EUR', 'GBP', 'XLM'] as const;
+const CURRENCY_OPTIONS = ALLOWED_CURRENCIES;
 
 export interface MilestoneCreationFormProps {
   /**
@@ -73,36 +75,13 @@ export const MilestoneCreationForm: React.FC<MilestoneCreationFormProps> = ({
   const [errors, setErrors] = useState<Array<{ fieldId: string; message: string }>>([]);
 
   /**
-   * Validates form fields and returns an array of error objects.
-   * An empty array means the form is valid.
+   * Delegates to the pure `validateMilestone` helper and returns the resulting
+   * errors array. Keeping the call-site here (rather than inlining the logic)
+   * means the form stays thin while the rules live in a testable module.
    */
   const validateForm = useCallback((): Array<{ fieldId: string; message: string }> => {
-    const errs: Array<{ fieldId: string; message: string }> = [];
-
-    const sanitizedTitle = sanitizeUserText(title, MAX_MILESTONE_TITLE_LENGTH);
-    const unboundedTitle = sanitizeUserText(title, Number.MAX_SAFE_INTEGER);
-    if (!sanitizedTitle) {
-      errs.push({ fieldId: 'milestone-title', message: 'Title is required' });
-    } else if (unboundedTitle.length > MAX_MILESTONE_TITLE_LENGTH) {
-      errs.push({
-        fieldId: 'milestone-title',
-        message: `Title must be no more than ${MAX_MILESTONE_TITLE_LENGTH} characters`,
-      });
-    }
-
-    const numericPayout = parseFloat(payout);
-    if (!payout.trim()) {
-      errs.push({ fieldId: 'milestone-payout', message: 'Payout amount is required' });
-    } else if (isNaN(numericPayout) || numericPayout <= 0) {
-      errs.push({ fieldId: 'milestone-payout', message: 'Payout must be a positive number' });
-    }
-
-    if (!currency.trim()) {
-      errs.push({ fieldId: 'milestone-currency', message: 'Currency is required' });
-    }
-
-    return errs;
-  }, [title, payout, currency]);
+    return validateMilestone({ title, payout, currency, dueDate, status });
+  }, [title, payout, currency, dueDate, status]);
 
   /**
    * Handles form submission: validates, then calls `onSubmit` with the
@@ -223,7 +202,7 @@ export const MilestoneCreationForm: React.FC<MilestoneCreationFormProps> = ({
             </FormField>
           </div>
 
-          <FormField label="Status" id="milestone-status">
+          <FormField label="Status" id="milestone-status" error={getFieldError('milestone-status')}>
             <select
               value={status}
               onChange={(e) => setStatus(e.target.value as Milestone['status'])}
@@ -241,6 +220,7 @@ export const MilestoneCreationForm: React.FC<MilestoneCreationFormProps> = ({
             label="Due Date"
             id="milestone-dueDate"
             helperText="Optional — e.g., Jun 1, 2025"
+            error={getFieldError('milestone-dueDate')}
           >
             <input
               type="text"

--- a/src/lib/__tests__/validateMilestone.test.ts
+++ b/src/lib/__tests__/validateMilestone.test.ts
@@ -1,0 +1,609 @@
+import {
+  validateMilestone,
+  MAX_MILESTONE_TITLE_LENGTH,
+  MAX_PAYOUT_VALUE,
+  MAX_PAYOUT_DECIMAL_PLACES,
+  ALLOWED_CURRENCIES,
+  ALLOWED_STATUSES,
+  type MilestoneFormValues,
+} from '../validateMilestone';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Returns a fully-valid set of form values. Override individual fields as needed. */
+function validPayload(overrides: Partial<MilestoneFormValues> = {}): MilestoneFormValues {
+  return {
+    title: 'Frontend Development – Sprint 1',
+    payout: '2500',
+    currency: 'USD',
+    dueDate: 'Jun 1, 2025',
+    status: 'Pending',
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Exported constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('exported constants', () => {
+  it('exports MAX_MILESTONE_TITLE_LENGTH as 200', () => {
+    expect(MAX_MILESTONE_TITLE_LENGTH).toBe(200);
+  });
+
+  it('exports MAX_PAYOUT_VALUE as 10_000_000', () => {
+    expect(MAX_PAYOUT_VALUE).toBe(10_000_000);
+  });
+
+  it('exports MAX_PAYOUT_DECIMAL_PLACES as 2', () => {
+    expect(MAX_PAYOUT_DECIMAL_PLACES).toBe(2);
+  });
+
+  it('exports ALLOWED_CURRENCIES including USD, EUR, GBP, XLM', () => {
+    expect(ALLOWED_CURRENCIES).toEqual(expect.arrayContaining(['USD', 'EUR', 'GBP', 'XLM']));
+    expect(ALLOWED_CURRENCIES).toHaveLength(4);
+  });
+
+  it('exports ALLOWED_STATUSES including all five statuses', () => {
+    expect(ALLOWED_STATUSES).toEqual(
+      expect.arrayContaining(['Pending', 'Active', 'Completed', 'Paid', 'Disputed']),
+    );
+    expect(ALLOWED_STATUSES).toHaveLength(5);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Valid payload
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('valid payload', () => {
+  it('returns an empty array for a fully valid input', () => {
+    expect(validateMilestone(validPayload())).toEqual([]);
+  });
+
+  it('returns an empty array when dueDate and status are omitted', () => {
+    const { dueDate: _d, status: _s, ...rest } = validPayload();
+    expect(validateMilestone(rest)).toEqual([]);
+  });
+
+  it('returns an empty array when dueDate is empty string', () => {
+    expect(validateMilestone(validPayload({ dueDate: '' }))).toEqual([]);
+  });
+
+  it('returns an empty array when dueDate is whitespace only', () => {
+    expect(validateMilestone(validPayload({ dueDate: '   ' }))).toEqual([]);
+  });
+
+  it('returns an empty array when status is omitted', () => {
+    const { status: _s, ...rest } = validPayload();
+    expect(validateMilestone(rest)).toEqual([]);
+  });
+
+  it('accepts a payout of 1 (minimum positive)', () => {
+    expect(validateMilestone(validPayload({ payout: '1' }))).toEqual([]);
+  });
+
+  it('accepts the payout exactly at MAX_PAYOUT_VALUE', () => {
+    expect(validateMilestone(validPayload({ payout: String(MAX_PAYOUT_VALUE) }))).toEqual([]);
+  });
+
+  it('accepts a decimal payout within MAX_PAYOUT_DECIMAL_PLACES', () => {
+    expect(validateMilestone(validPayload({ payout: '99.99' }))).toEqual([]);
+  });
+
+  it('accepts a payout with exactly one decimal place', () => {
+    expect(validateMilestone(validPayload({ payout: '100.5' }))).toEqual([]);
+  });
+
+  it('accepts a payout with no decimal point', () => {
+    expect(validateMilestone(validPayload({ payout: '500' }))).toEqual([]);
+  });
+
+  it('accepts all four ALLOWED_CURRENCIES', () => {
+    for (const currency of ALLOWED_CURRENCIES) {
+      const errors = validateMilestone(validPayload({ currency }));
+      expect(errors).toEqual([]);
+    }
+  });
+
+  it('accepts all five ALLOWED_STATUSES', () => {
+    for (const status of ALLOWED_STATUSES) {
+      const errors = validateMilestone(validPayload({ status }));
+      expect(errors).toEqual([]);
+    }
+  });
+
+  it('accepts a title exactly at MAX_MILESTONE_TITLE_LENGTH characters', () => {
+    const title = 'a'.repeat(MAX_MILESTONE_TITLE_LENGTH);
+    expect(validateMilestone(validPayload({ title }))).toEqual([]);
+  });
+
+  it('accepts a title with surrounding whitespace that trims to a valid length', () => {
+    const paddedTitle = `  ${'a'.repeat(MAX_MILESTONE_TITLE_LENGTH)}  `;
+    expect(validateMilestone(validPayload({ title: paddedTitle }))).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Title validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('title validation', () => {
+  it('returns a required error for an empty title', () => {
+    const errors = validateMilestone(validPayload({ title: '' }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toEqual({
+      fieldId: 'milestone-title',
+      message: 'Title is required',
+    });
+  });
+
+  it('returns a required error for a whitespace-only title', () => {
+    const errors = validateMilestone(validPayload({ title: '   ' }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toEqual({
+      fieldId: 'milestone-title',
+      message: 'Title is required',
+    });
+  });
+
+  it('returns a required error for a title containing only control characters', () => {
+    const errors = validateMilestone(validPayload({ title: '\u0000\u001F\u007F' }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0].fieldId).toBe('milestone-title');
+    expect(errors[0].message).toBe('Title is required');
+  });
+
+  it('returns an over-length error for a title one character beyond the max', () => {
+    const title = 'a'.repeat(MAX_MILESTONE_TITLE_LENGTH + 1);
+    const errors = validateMilestone(validPayload({ title }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toEqual({
+      fieldId: 'milestone-title',
+      message: `Title must be no more than ${MAX_MILESTONE_TITLE_LENGTH} characters`,
+    });
+  });
+
+  it('returns an over-length error even for a very long title', () => {
+    const title = 'a'.repeat(MAX_MILESTONE_TITLE_LENGTH + 100);
+    const errors = validateMilestone(validPayload({ title }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0].fieldId).toBe('milestone-title');
+  });
+
+  it('does not truncate an over-long title — it rejects it', () => {
+    // If the validator truncated, no error would be returned; we verify
+    // it rejects instead.
+    const title = 'a'.repeat(MAX_MILESTONE_TITLE_LENGTH + 1);
+    const errors = validateMilestone(validPayload({ title }));
+    const titleErrors = errors.filter((e) => e.fieldId === 'milestone-title');
+    expect(titleErrors).toHaveLength(1);
+    expect(titleErrors[0].message).toMatch(/no more than/i);
+  });
+
+  it('returns the required error before the length error (required takes priority)', () => {
+    // An empty string is caught by the required check, not the length check.
+    const errors = validateMilestone(validPayload({ title: '' }));
+    expect(errors[0].message).toBe('Title is required');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Payout validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('payout validation', () => {
+  describe('required', () => {
+    it('returns a required error for an empty payout', () => {
+      const errors = validateMilestone(validPayload({ payout: '' }));
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toEqual({
+        fieldId: 'milestone-payout',
+        message: 'Payout amount is required',
+      });
+    });
+
+    it('returns a required error for a whitespace-only payout', () => {
+      const errors = validateMilestone(validPayload({ payout: '   ' }));
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toEqual({
+        fieldId: 'milestone-payout',
+        message: 'Payout amount is required',
+      });
+    });
+  });
+
+  describe('must be a positive number', () => {
+    it.each([
+      ['non-numeric text', 'abc'],
+      ['letters mixed with digits', '12abc'],
+      ['NaN literal', 'NaN'],
+      ['Infinity literal', 'Infinity'],
+      ['-Infinity', '-Infinity'],
+      ['zero', '0'],
+      ['negative number', '-100'],
+      ['negative decimal', '-0.5'],
+    ])('returns a positive-number error for %s (%s)', (_, payout) => {
+      const errors = validateMilestone(validPayload({ payout }));
+      const payoutErrors = errors.filter((e) => e.fieldId === 'milestone-payout');
+      expect(payoutErrors).toHaveLength(1);
+      expect(payoutErrors[0].message).toBe('Payout must be a positive number');
+    });
+
+    it('accepts the smallest positive value (0.01)', () => {
+      const errors = validateMilestone(validPayload({ payout: '0.01' }));
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('maximum value', () => {
+    it('returns an over-max error when payout exceeds MAX_PAYOUT_VALUE', () => {
+      const errors = validateMilestone(
+        validPayload({ payout: String(MAX_PAYOUT_VALUE + 1) }),
+      );
+      const payoutErrors = errors.filter((e) => e.fieldId === 'milestone-payout');
+      expect(payoutErrors).toHaveLength(1);
+      expect(payoutErrors[0].message).toMatch(/no more than/i);
+      expect(payoutErrors[0].message).toContain(MAX_PAYOUT_VALUE.toLocaleString());
+    });
+
+    it('returns an over-max error for a very large value', () => {
+      const errors = validateMilestone(validPayload({ payout: '99999999' }));
+      const payoutErrors = errors.filter((e) => e.fieldId === 'milestone-payout');
+      expect(payoutErrors).toHaveLength(1);
+    });
+
+    it('accepts MAX_PAYOUT_VALUE exactly', () => {
+      const errors = validateMilestone(validPayload({ payout: String(MAX_PAYOUT_VALUE) }));
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('decimal precision', () => {
+    it('returns a precision error for more than MAX_PAYOUT_DECIMAL_PLACES decimal places', () => {
+      const errors = validateMilestone(validPayload({ payout: '100.123' }));
+      const payoutErrors = errors.filter((e) => e.fieldId === 'milestone-payout');
+      expect(payoutErrors).toHaveLength(1);
+      expect(payoutErrors[0].message).toMatch(/at most 2 decimal places/i);
+    });
+
+    it('returns a precision error for 3 decimal places', () => {
+      const errors = validateMilestone(validPayload({ payout: '9.999' }));
+      const payoutErrors = errors.filter((e) => e.fieldId === 'milestone-payout');
+      expect(payoutErrors).toHaveLength(1);
+    });
+
+    it('accepts exactly 2 decimal places', () => {
+      expect(validateMilestone(validPayload({ payout: '100.99' }))).toEqual([]);
+    });
+
+    it('accepts 1 decimal place', () => {
+      expect(validateMilestone(validPayload({ payout: '100.5' }))).toEqual([]);
+    });
+
+    it('accepts 0 decimal places (integer)', () => {
+      expect(validateMilestone(validPayload({ payout: '1000' }))).toEqual([]);
+    });
+
+    it('does not return a precision error for a zero-fractional suffix (100.)', () => {
+      // "100." has one trailing decimal point but 0 fractional digits — valid
+      const errors = validateMilestone(validPayload({ payout: '100.' }));
+      // "100." parses as 100 (positive, within range); we only check
+      // that the precision rule is not the one firing.
+      const precisionErrors = errors.filter(
+        (e) => e.fieldId === 'milestone-payout' && e.message.includes('decimal places'),
+      );
+      expect(precisionErrors).toHaveLength(0);
+    });
+  });
+
+  describe('priority ordering (required > positive > max > precision)', () => {
+    it('surfaces required error before positive-number error', () => {
+      const errors = validateMilestone(validPayload({ payout: '' }));
+      expect(errors[0].message).toBe('Payout amount is required');
+    });
+
+    it('surfaces positive-number error before max error', () => {
+      const errors = validateMilestone(validPayload({ payout: '-1' }));
+      expect(errors[0].message).toBe('Payout must be a positive number');
+    });
+
+    it('surfaces max error before precision error (when value is over max with bad precision)', () => {
+      // 10_000_001.999 is both > max and has 3 decimal places
+      const errors = validateMilestone(
+        validPayload({ payout: `${MAX_PAYOUT_VALUE + 1}.999` }),
+      );
+      expect(errors[0].message).toMatch(/no more than/i);
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Currency validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('currency validation', () => {
+  it('returns a required error for an empty currency', () => {
+    const errors = validateMilestone(validPayload({ currency: '' }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toEqual({
+      fieldId: 'milestone-currency',
+      message: 'Currency is required',
+    });
+  });
+
+  it('returns a required error for a whitespace-only currency', () => {
+    const errors = validateMilestone(validPayload({ currency: '   ' }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toEqual({
+      fieldId: 'milestone-currency',
+      message: 'Currency is required',
+    });
+  });
+
+  it('returns an invalid-currency error for an unrecognised code', () => {
+    const errors = validateMilestone(validPayload({ currency: 'JPY' }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toEqual({
+      fieldId: 'milestone-currency',
+      message: `Currency must be one of: ${ALLOWED_CURRENCIES.join(', ')}`,
+    });
+  });
+
+  it('returns an invalid-currency error for a made-up string', () => {
+    const errors = validateMilestone(validPayload({ currency: 'NOTREAL' }));
+    const currencyErrors = errors.filter((e) => e.fieldId === 'milestone-currency');
+    expect(currencyErrors).toHaveLength(1);
+  });
+
+  it.each(['USD', 'EUR', 'GBP', 'XLM'])('accepts the allowed currency %s', (currency) => {
+    const errors = validateMilestone(validPayload({ currency }));
+    const currencyErrors = errors.filter((e) => e.fieldId === 'milestone-currency');
+    expect(currencyErrors).toHaveLength(0);
+  });
+
+  it('is case-insensitive (accepts lowercase allowed codes)', () => {
+    const errors = validateMilestone(validPayload({ currency: 'usd' }));
+    const currencyErrors = errors.filter((e) => e.fieldId === 'milestone-currency');
+    expect(currencyErrors).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Due date validation (optional field)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('dueDate validation', () => {
+  describe('valid formats', () => {
+    it.each([
+      'Jan 1, 2025',
+      'Feb 28, 2025',
+      'Mar 5, 2026',
+      'Apr 01, 2025',
+      'May 15, 2025',
+      'Jun 1, 2025',
+      'Jul 4, 2026',
+      'Aug 31, 2025',
+      'Sep 9, 2025',
+      'Oct 10, 2025',
+      'Nov 11, 2025',
+      'Dec 25, 2025',
+    ])('accepts the canonical short-month format "%s"', (dueDate) => {
+      const errors = validateMilestone(validPayload({ dueDate }));
+      const dueDateErrors = errors.filter((e) => e.fieldId === 'milestone-dueDate');
+      expect(dueDateErrors).toHaveLength(0);
+    });
+
+    it.each([
+      'January 1, 2025',
+      'February 28, 2025',
+      'March 5, 2026',
+      'April 01, 2025',
+      'June 1, 2025',
+      'July 4, 2026',
+      'August 31, 2025',
+      'September 9, 2025',
+      'October 10, 2025',
+      'November 11, 2025',
+      'December 25, 2025',
+    ])('accepts the full-month format "%s"', (dueDate) => {
+      const errors = validateMilestone(validPayload({ dueDate }));
+      const dueDateErrors = errors.filter((e) => e.fieldId === 'milestone-dueDate');
+      expect(dueDateErrors).toHaveLength(0);
+    });
+
+    it('accepts an omitted dueDate field', () => {
+      const { dueDate: _d, ...rest } = validPayload();
+      expect(validateMilestone(rest)).toEqual([]);
+    });
+
+    it('accepts dueDate explicitly set to undefined', () => {
+      // Exercises the `values.dueDate ?? ''` null-coalescing fallback branch
+      expect(validateMilestone(validPayload({ dueDate: undefined }))).toEqual([]);
+    });
+
+    it('accepts an empty dueDate string', () => {
+      expect(validateMilestone(validPayload({ dueDate: '' }))).toEqual([]);
+    });
+
+    it('accepts a whitespace-only dueDate string', () => {
+      expect(validateMilestone(validPayload({ dueDate: '   ' }))).toEqual([]);
+    });
+  });
+
+  describe('invalid formats', () => {
+    it.each([
+      ['ISO date', '2025-06-01'],
+      ['US slash format', '06/01/2025'],
+      ['purely numeric', '01012025'],
+      ['free-form word', 'tomorrow'],
+      ['relative phrase', 'next week'],
+      ['ASAP', 'asap'],
+      ['day-month-year slash', '1/6/2025'],
+      ['missing year', 'Jun 1'],
+      ['missing day', 'Jun 2025'],
+      ['no comma', 'Jun 1 2025'],
+    ])('rejects the format "%s" (%s)', (_, dueDate) => {
+      const errors = validateMilestone(validPayload({ dueDate }));
+      const dueDateErrors = errors.filter((e) => e.fieldId === 'milestone-dueDate');
+      expect(dueDateErrors).toHaveLength(1);
+      expect(dueDateErrors[0].message).toMatch(/Jun 1, 2025/);
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Status validation (optional field)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('status validation', () => {
+  it.each(ALLOWED_STATUSES)('accepts the allowed status "%s"', (status) => {
+    const errors = validateMilestone(validPayload({ status }));
+    const statusErrors = errors.filter((e) => e.fieldId === 'milestone-status');
+    expect(statusErrors).toHaveLength(0);
+  });
+
+  it('returns an invalid-status error for an unrecognised value', () => {
+    const errors = validateMilestone(validPayload({ status: 'Unknown' }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toEqual({
+      fieldId: 'milestone-status',
+      message: `Status must be one of: ${ALLOWED_STATUSES.join(', ')}`,
+    });
+  });
+
+  it('does not validate an omitted status field (undefined)', () => {
+    // Explicitly pass undefined to exercise the `values.status ?? ''` branch
+    const errors = validateMilestone(validPayload({ status: undefined }));
+    const statusErrors = errors.filter((e) => e.fieldId === 'milestone-status');
+    expect(statusErrors).toHaveLength(0);
+  });
+
+  it('does not validate an empty status string', () => {
+    const errors = validateMilestone(validPayload({ status: '' }));
+    const statusErrors = errors.filter((e) => e.fieldId === 'milestone-status');
+    expect(statusErrors).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Multiple simultaneous errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('multiple errors', () => {
+  it('returns errors for all empty required fields in deterministic order', () => {
+    const errors = validateMilestone({
+      title: '',
+      payout: '',
+      currency: '',
+    });
+
+    expect(errors).toHaveLength(3);
+    expect(errors[0].fieldId).toBe('milestone-title');
+    expect(errors[1].fieldId).toBe('milestone-payout');
+    expect(errors[2].fieldId).toBe('milestone-currency');
+  });
+
+  it('accumulates title, payout, currency, and dueDate errors simultaneously', () => {
+    const errors = validateMilestone({
+      title: '',
+      payout: '-1',
+      currency: 'INVALID',
+      dueDate: '2025-01-01',
+      status: 'BadStatus',
+    });
+
+    const fieldIds = errors.map((e) => e.fieldId);
+    expect(fieldIds).toContain('milestone-title');
+    expect(fieldIds).toContain('milestone-payout');
+    expect(fieldIds).toContain('milestone-currency');
+    expect(fieldIds).toContain('milestone-dueDate');
+    expect(fieldIds).toContain('milestone-status');
+  });
+
+  it('returns errors in field-declaration order (title, payout, currency, dueDate, status)', () => {
+    const errors = validateMilestone({
+      title: '',
+      payout: '',
+      currency: '',
+      dueDate: '2025-01-01', // invalid format
+      status: 'Wrong',
+    });
+
+    const fieldIds = errors.map((e) => e.fieldId);
+    const titleIdx = fieldIds.indexOf('milestone-title');
+    const payoutIdx = fieldIds.indexOf('milestone-payout');
+    const currencyIdx = fieldIds.indexOf('milestone-currency');
+    const dueDateIdx = fieldIds.indexOf('milestone-dueDate');
+    const statusIdx = fieldIds.indexOf('milestone-status');
+
+    expect(titleIdx).toBeLessThan(payoutIdx);
+    expect(payoutIdx).toBeLessThan(currencyIdx);
+    expect(currencyIdx).toBeLessThan(dueDateIdx);
+    expect(dueDateIdx).toBeLessThan(statusIdx);
+  });
+
+  it('reports only one error per field even when multiple rules are violated', () => {
+    // An over-long title also satisfies "required"; only the more specific
+    // error (length) should be returned — but we just test no duplicate fields.
+    const title = 'a'.repeat(MAX_MILESTONE_TITLE_LENGTH + 1);
+    const errors = validateMilestone(validPayload({ title }));
+    const titleErrors = errors.filter((e) => e.fieldId === 'milestone-title');
+    expect(titleErrors).toHaveLength(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Edge / boundary cases
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('edge cases', () => {
+  it('accepts a title that is exactly one character long', () => {
+    expect(validateMilestone(validPayload({ title: 'x' }))).toEqual([]);
+  });
+
+  it('handles a payout string with leading/trailing whitespace', () => {
+    const errors = validateMilestone(validPayload({ payout: '  500  ' }));
+    // Trimming happens inside the validator; should be valid
+    expect(errors.filter((e) => e.fieldId === 'milestone-payout')).toHaveLength(0);
+  });
+
+  it('handles a dueDate string with leading/trailing whitespace that matches after trimming', () => {
+    const errors = validateMilestone(validPayload({ dueDate: '  Jun 1, 2025  ' }));
+    const dueDateErrors = errors.filter((e) => e.fieldId === 'milestone-dueDate');
+    expect(dueDateErrors).toHaveLength(0);
+  });
+
+  it('treats a payout of "0.00" as non-positive', () => {
+    const errors = validateMilestone(validPayload({ payout: '0.00' }));
+    const payoutErrors = errors.filter((e) => e.fieldId === 'milestone-payout');
+    expect(payoutErrors).toHaveLength(1);
+    expect(payoutErrors[0].message).toBe('Payout must be a positive number');
+  });
+
+  it('treats a payout of "0.001" as non-positive (0.001 > 0, so it is positive)', () => {
+    // 0.001 is positive but has 3 decimal places
+    const errors = validateMilestone(validPayload({ payout: '0.001' }));
+    const payoutErrors = errors.filter((e) => e.fieldId === 'milestone-payout');
+    expect(payoutErrors).toHaveLength(1);
+    expect(payoutErrors[0].message).toMatch(/decimal places/i);
+  });
+
+  it('returns an empty error array for a payout of "0.01" (boundary: smallest valid 2dp value)', () => {
+    expect(validateMilestone(validPayload({ payout: '0.01' }))).toEqual([]);
+  });
+
+  it('is a pure function — calling it twice with the same input returns the same result', () => {
+    const input = validPayload({ title: '', payout: '-5', currency: '' });
+    expect(validateMilestone(input)).toEqual(validateMilestone(input));
+  });
+
+  it('does not mutate the input values object', () => {
+    const input = validPayload({ title: '  My Milestone  ', payout: '100' });
+    const inputCopy = { ...input };
+    validateMilestone(input);
+    expect(input).toEqual(inputCopy);
+  });
+});

--- a/src/lib/validateMilestone.ts
+++ b/src/lib/validateMilestone.ts
@@ -1,0 +1,240 @@
+import { sanitizeUserText } from './sanitizeUserText';
+import type { ValidationError } from './validateLogin';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The maximum number of characters a milestone title may contain after
+ * sanitisation (control-char removal + whitespace normalisation).
+ *
+ * Kept in sync with `MAX_MILESTONE_TITLE_LENGTH` exported from
+ * `MilestoneCreationForm` — the form component uses this value so both
+ * the UI hint and the validator agree on the ceiling.
+ */
+export const MAX_MILESTONE_TITLE_LENGTH = 200;
+
+/**
+ * The maximum allowed payout value for a single milestone.
+ *
+ * Set to 10 000 000 (ten million) — a safe upper bound that prevents
+ * accidental multi-zero entry while leaving room for large contracts.
+ * Mirror this limit on any server-side handler that persists payouts.
+ */
+export const MAX_PAYOUT_VALUE = 10_000_000;
+
+/**
+ * The maximum number of decimal places allowed in a payout value.
+ * Two decimal places matches the smallest fiat currency subdivision
+ * (cents). XLM supports 7 decimal places natively; we use 2 here to
+ * keep the UI consistent with fiat currencies — increase if needed.
+ */
+export const MAX_PAYOUT_DECIMAL_PLACES = 2;
+
+/**
+ * Allowed currency codes the validator will accept.
+ * Mirrors the `CURRENCY_OPTIONS` array in `MilestoneCreationForm`.
+ */
+export const ALLOWED_CURRENCIES = ['USD', 'EUR', 'GBP', 'XLM'] as const;
+
+/**
+ * Allowed milestone status values.
+ * Mirrors the `STATUS_OPTIONS` array in `MilestoneCreationForm`.
+ */
+export const ALLOWED_STATUSES = [
+  'Pending',
+  'Active',
+  'Completed',
+  'Paid',
+  'Disputed',
+] as const;
+
+/**
+ * Due-date format accepted by the validator.
+ *
+ * The field is a free-text input that displays the placeholder
+ * "Jun 1, 2025". We accept two canonical variants:
+ *   - "Jun 1, 2025"  (abbreviated month, single-digit day)
+ *   - "Jun 01, 2025" (abbreviated month, zero-padded day)
+ *   - "June 1, 2025" (full month name)
+ *
+ * The regex is intentionally lenient on leading zeros and full-vs-short
+ * month names; it rejects clearly garbage strings (e.g. "yesterday",
+ * "asap", purely numeric strings) while accepting the valid formats that
+ * the UI documents.
+ */
+const DUE_DATE_REGEX =
+  /^(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2},\s+\d{4}$/i;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The raw string values captured from the Milestone creation form.
+ * All values are strings because HTML inputs always yield strings.
+ */
+export interface MilestoneFormValues {
+  /** The display title for the milestone. */
+  title: string;
+  /**
+   * The payout amount as a raw string from the input.
+   * Kept as a string to mirror the raw DOM value without pre-transforming.
+   */
+  payout: string;
+  /** The ISO 4217 currency code or blockchain token symbol (e.g. "USD", "XLM"). */
+  currency: string;
+  /**
+   * Optional due date in human-readable format (e.g. "Jun 1, 2025").
+   * An empty or whitespace-only string is treated as "not provided" and
+   * passes validation.
+   */
+  dueDate?: string;
+  /** Optional status value. When provided it must be one of {@link ALLOWED_STATUSES}. */
+  status?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validator
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Validates the milestone creation form fields.
+ *
+ * Rules applied per field (in priority order — most actionable error first):
+ *
+ * **title**
+ *   1. Required (non-empty after sanitisation).
+ *   2. Must not exceed {@link MAX_MILESTONE_TITLE_LENGTH} characters
+ *      after sanitisation (over-long → reject, not truncate).
+ *
+ * **payout**
+ *   1. Required (non-empty after trim).
+ *   2. Must parse as a finite, positive number.
+ *   3. Must not exceed {@link MAX_PAYOUT_VALUE}.
+ *   4. Must have at most {@link MAX_PAYOUT_DECIMAL_PLACES} decimal places.
+ *
+ * **currency**
+ *   1. Required (non-empty after trim).
+ *   2. Must be one of {@link ALLOWED_CURRENCIES}.
+ *
+ * **dueDate** (optional)
+ *   - When provided and non-empty, must match {@link DUE_DATE_REGEX}
+ *     (e.g. "Jun 1, 2025").
+ *
+ * **status** (optional)
+ *   - When provided and non-empty, must be one of {@link ALLOWED_STATUSES}.
+ *
+ * The function is pure and side-effect-free, safe to call from both the
+ * React form component and unit tests without any React context.
+ *
+ * Time complexity:  O(1) — field count is fixed; all checks are constant-time.
+ * Space complexity: O(1) — returned errors array is bounded by the fixed
+ *                   number of fields.
+ *
+ * @param values - Raw string values from the form inputs.
+ * @returns An array of {@link ValidationError} objects. An empty array means
+ *          the form is valid and can be submitted.
+ *
+ * @example
+ * ```ts
+ * validateMilestone({ title: '', payout: '', currency: 'USD' });
+ * // [
+ * //   { fieldId: 'milestone-title',  message: 'Title is required' },
+ * //   { fieldId: 'milestone-payout', message: 'Payout amount is required' },
+ * // ]
+ *
+ * validateMilestone({ title: 'Sprint 1', payout: '5000', currency: 'USD' });
+ * // []
+ * ```
+ */
+export function validateMilestone(values: MilestoneFormValues): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  // ── Title ────────────────────────────────────────────────────────────────
+  const sanitizedTitle = sanitizeUserText(values.title, MAX_MILESTONE_TITLE_LENGTH);
+  // Check the uncapped sanitised value to detect over-length titles rather
+  // than silently truncating them (mirrors the inline form logic).
+  const fullSanitizedTitle = sanitizeUserText(values.title, Number.MAX_SAFE_INTEGER);
+
+  if (!sanitizedTitle) {
+    errors.push({ fieldId: 'milestone-title', message: 'Title is required' });
+  } else if (fullSanitizedTitle.length > MAX_MILESTONE_TITLE_LENGTH) {
+    errors.push({
+      fieldId: 'milestone-title',
+      message: `Title must be no more than ${MAX_MILESTONE_TITLE_LENGTH} characters`,
+    });
+  }
+
+  // ── Payout ───────────────────────────────────────────────────────────────
+  const rawPayout = (values.payout ?? '').trim();
+
+  if (!rawPayout) {
+    errors.push({ fieldId: 'milestone-payout', message: 'Payout amount is required' });
+  } else {
+    // Require the value to be a purely numeric string (optional leading minus,
+    // optional decimal point) before parsing. This rejects inputs like "12abc"
+    // that parseFloat would otherwise accept by silently discarding the suffix.
+    const NUMERIC_RE = /^-?\d+(\.\d*)?$/;
+    const numericPayout = parseFloat(rawPayout);
+
+    if (!NUMERIC_RE.test(rawPayout) || isNaN(numericPayout) || !isFinite(numericPayout) || numericPayout <= 0) {
+      errors.push({
+        fieldId: 'milestone-payout',
+        message: 'Payout must be a positive number',
+      });
+    } else if (numericPayout > MAX_PAYOUT_VALUE) {
+      errors.push({
+        fieldId: 'milestone-payout',
+        message: `Payout must be no more than ${MAX_PAYOUT_VALUE.toLocaleString()}`,
+      });
+    } else {
+      // Check decimal precision: count digits after the decimal point
+      const decimalIndex = rawPayout.indexOf('.');
+      if (decimalIndex !== -1) {
+        const decimalPlaces = rawPayout.length - decimalIndex - 1;
+        if (decimalPlaces > MAX_PAYOUT_DECIMAL_PLACES) {
+          errors.push({
+            fieldId: 'milestone-payout',
+            message: `Payout must have at most ${MAX_PAYOUT_DECIMAL_PLACES} decimal places`,
+          });
+        }
+      }
+    }
+  }
+
+  // ── Currency ─────────────────────────────────────────────────────────────
+  const trimmedCurrency = (values.currency ?? '').trim();
+
+  if (!trimmedCurrency) {
+    errors.push({ fieldId: 'milestone-currency', message: 'Currency is required' });
+  } else if (!(ALLOWED_CURRENCIES as readonly string[]).includes(trimmedCurrency.toUpperCase())) {
+    errors.push({
+      fieldId: 'milestone-currency',
+      message: `Currency must be one of: ${ALLOWED_CURRENCIES.join(', ')}`,
+    });
+  }
+
+  // ── Due Date (optional) ──────────────────────────────────────────────────
+  const trimmedDueDate = (values.dueDate ?? '').trim();
+
+  if (trimmedDueDate && !DUE_DATE_REGEX.test(trimmedDueDate)) {
+    errors.push({
+      fieldId: 'milestone-dueDate',
+      message: 'Due date must be in the format "Jun 1, 2025"',
+    });
+  }
+
+  // ── Status (optional) ────────────────────────────────────────────────────
+  const trimmedStatus = (values.status ?? '').trim();
+
+  if (trimmedStatus && !(ALLOWED_STATUSES as readonly string[]).includes(trimmedStatus)) {
+    errors.push({
+      fieldId: 'milestone-status',
+      message: `Status must be one of: ${ALLOWED_STATUSES.join(', ')}`,
+    });
+  }
+
+  return errors;
+}


### PR DESCRIPTION
 Summary
  
  Extracts the inline milestone form validation into a standalone pure helper
  (src/lib/validateMilestone.ts) and wires it back into MilestoneCreationForm. All five fields
  now show accessible inline errors via the existing FormField / ErrorSummary pattern. Submit is
  blocked while any field is invalid.
  
  What changed
  
  src/lib/validateMilestone.ts (new)
  Pure, side-effect-free validator following the same pattern as validateLogin and
  validateContract. Exports validateMilestone(values) returning a ValidationError[] array.
  
  src/components/milestones/MilestoneCreationForm.tsx (updated)
  
  - Replaced the inline validateForm closure with a call to validateMilestone
  - Added error prop to the Status and Due Date FormField wrappers — these two fields were
  previously missing inline error wiring
  
  src/lib/__tests__/validateMilestone.test.ts (new)
  115 unit tests covering all rules, boundary values, priority ordering, multi-field errors, and
  edge cases.
  
  Validation rules
  
  ┌───────┬───────┐
  │ Field │ Rules │
  ├────────┼───────────────────────────────────────────────────────┤
  │ Title  │ Required · max 200 chars (rejects, does not truncate) │
  ├──────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ Payout   │ Required · must be a positive number · rejects mixed strings like 12abc · max  │
  │          │ 10,000,000 · max 2 decimal places                                              │
  ├──────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ Currency │ Required · must be one of USD, EUR, GBP, XLM (case-insensitive)                │
  ├──────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ Due Date │ Optional — when provided, must match "Jun 1, 2025" or "January 1, 2025" format │
  ├──────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ Status   │ Optional — when provided, must be one of the five allowed values               │
  └──────────┴────────────────────────────────────────────────────────────────────────────────┘
  
  Accessibility
  
  - FormField injects aria-invalid="true" and aria-describedby pointing to the inline error <p
  role="alert"> on each failing field
  - ErrorSummary (role="alert", tabIndex="-1") receives focus on invalid submit and contains
  anchor links jumping directly to each failing field
  - noValidate on the <form> suppresses native browser bubbles so only the custom accessible
  errors are shown
  
  Test results
  
  Test Suites: 74 passed, 74 total
  Tests:       1375 passed, 1375 total
  
  Coverage for validateMilestone.ts: 100% statements · 100% lines · 100% functions
  
  Checklist
  
  - [x] npm run lint — clean
  - [x] npm test — 1375/1375 passing
  - [x] tsc --noEmit — no type errors
  - [x] No server-side checks weakened — rules mirror or exceed existing behaviour
  - [x] Accessible inline errors on all five fields
  - [x] Submit blocked while form is invalid

closes #619 