### PR TITLE
docs: add accessibility notes for contracts components

### DIFF
--- a/docs/CONTRACTS_ACCESSIBILITY.md
+++ b/docs/CONTRACTS_ACCESSIBILITY.md
@@ -1,0 +1,45 @@
+# Contracts Components Accessibility (a11y) Notes
+
+This document provides accessibility guidelines, interactive patterns, and focus management behavior for the **Contracts** components in Talenttrust-Frontend.
+
+## Overview
+
+The contracts module components are built to ensure compatibility with screen readers, keyboard-only navigation, and assistive technology tools.
+
+---
+
+## 1. ARIA Roles and Attributes
+
+- **Main Views & Containers:**
+  - Contract lists and card views use semantic sectioning (`<section>`, `<article>`) or `role="region"` with distinct `aria-label` tags.
+  - Interactive contract status badges utilize `role="status"` or `aria-live="polite"` where dynamic updates occur.
+
+- **Actions & Controls:**
+  - Action buttons (e.g., *Sign*, *Review*, *Download*) use native `<button>` elements with clear textual labels.
+  - Icon-only controls include an explicit `aria-label` attribute (e.g., `aria-label="View contract details"`).
+
+---
+
+## 2. Keyboard Navigation & Interactions
+
+- **Tab Flow (`Tab` / `Shift + Tab`):**
+  - Logical tab ordering follows the DOM hierarchy from header controls to contract list items and modal actions.
+- **Activation (`Enter` / `Space`):**
+  - Triggers actionable items, buttons, and row expansions identically across device pointer types.
+- **Dismissal (`Escape`):**
+  - Closes active contract previews, filter dropdowns, or confirmation modals.
+
+---
+
+## 3. Focus Management
+
+- **Visible Focus States:**
+  - All interactive controls retain a high-contrast focus ring (`outline` state) when navigated via keyboard.
+- **Modal & Dialog Trapping:**
+  - Opening a contract detail modal traps keyboard focus inside the dialog until dismissed, returning focus to the original triggering button upon exit.
+
+---
+
+## 4. Color & Contrast Standards
+
+- Status indicators (e.g., Pending, Active, Terminated) do not rely solely on color to convey information; text badges and icons accompany visual indicators.


### PR DESCRIPTION
## Description

Adds accessibility (a11y) notes for the contracts components under the docs directory.

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [x] Documentation update

---

## Pre-flight Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage

- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**

### What was tested?

- Verified markdown formatting and link structure for the newly created accessibility documentation file.

---

## Accessibility & Security Notes

### Accessibility

N/A – Documentation changes only.

### Security

N/A – Documentation changes only.

CLOSE #753 