### PR TITLE
test(milestones): cover pagination behavior

### DIFF
--- a/src/components/MilestonesList.tsx
+++ b/src/components/MilestonesList.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import StatusBadge, { StatusType, statusColorMap, statusIconMap } from './StatusBadge';
 import { usePreferences } from '@/lib/preferences';
 import { isDueSoon } from '@/lib/dueSoon';
@@ -16,19 +16,29 @@ export type Milestone = {
   contractId?: string;
 };
 
+export const PAGE_SIZE_DEFAULT = 5;
+
 export type MilestonesListProps = {
   milestones: Milestone[];
   contractCurrency?: string;
+  pageSize?: number;
 };
 
 export const REMINDER_WINDOW_DAYS = 7;
 
-const MilestonesList = ({ milestones, contractCurrency }: MilestonesListProps) => {
+const MilestonesList = ({ milestones, contractCurrency, pageSize = PAGE_SIZE_DEFAULT }: MilestonesListProps) => {
   const { formatAmount } = usePreferences();
+  const [displayCount, setDisplayCount] = useState(pageSize);
   const [isDismissed, setIsDismissed] = useState(false);
   const listContainerRef = useRef<HTMLDivElement>(null);
 
+  useEffect(() => {
+    setDisplayCount(pageSize);
+  }, [milestones, pageSize]);
+
   const today = new Date();
+  const visibleMilestones = milestones.slice(0, displayCount);
+  const hasMore = displayCount < milestones.length;
 
   const mismatchedMilestoneIds = contractCurrency
     ? new Set(findCurrencyMismatches(contractCurrency, milestones))
@@ -173,7 +183,7 @@ const MilestonesList = ({ milestones, contractCurrency }: MilestonesListProps) =
         tabIndex={milestones.length > 0 ? 0 : undefined}
         className="mt-6 space-y-4 max-h-[calc(100vh-260px)] overflow-y-auto pr-2 rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2"
       >
-        {milestones.map((milestone) => (
+        {visibleMilestones.map((milestone) => (
           <article
             key={milestone.id}
             id={`milestone-${milestone.id}`}
@@ -194,6 +204,18 @@ const MilestonesList = ({ milestones, contractCurrency }: MilestonesListProps) =
             </div>
           </article>
         ))}
+        {hasMore && (
+          <div className="flex justify-center pt-2">
+            <button
+              type="button"
+              onClick={() => setDisplayCount((prev) => Math.min(prev + pageSize, milestones.length))}
+              data-testid="load-more-btn"
+              className="w-full rounded-xl border border-slate-200 bg-white py-2.5 text-sm font-medium text-slate-600 transition hover:bg-slate-50 hover:text-slate-900 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+            >
+              Load More ({milestones.length - displayCount} remaining)
+            </button>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/components/__tests__/MilestonesList.test.tsx
+++ b/src/components/__tests__/MilestonesList.test.tsx
@@ -255,4 +255,85 @@ describe('MilestonesList', () => {
       expect(isDueSoon('not-a-date', today, 7)).toBe(false);
     });
   });
+
+  describe('pagination / load-more', () => {
+    const SEVEN_MILESTONES: Milestone[] = [
+      { id: 'a', title: 'Alpha',   status: 'Pending',   payout: 100, currency: 'USD', dueDate: 'May 10, 2026' },
+      { id: 'b', title: 'Bravo',   status: 'Active',    payout: 200, currency: 'USD', dueDate: 'May 11, 2026' },
+      { id: 'c', title: 'Charlie', status: 'Completed', payout: 300, currency: 'USD', dueDate: 'May 12, 2026' },
+      { id: 'd', title: 'Delta',   status: 'Pending',   payout: 400, currency: 'USD', dueDate: 'May 13, 2026' },
+      { id: 'e', title: 'Echo',    status: 'Paid',      payout: 500, currency: 'USD', dueDate: 'May 14, 2026' },
+      { id: 'f', title: 'Foxtrot', status: 'Pending',   payout: 600, currency: 'USD', dueDate: 'May 15, 2026' },
+      { id: 'g', title: 'Golf',    status: 'Disputed',  payout: 700, currency: 'USD', dueDate: 'May 16, 2026' },
+    ];
+
+    it('shows only the first page (pageSize items) on initial render', () => {
+      render(<MilestonesList milestones={SEVEN_MILESTONES} pageSize={3} />);
+
+      expect(screen.getByText('Alpha')).toBeInTheDocument();
+      expect(screen.getByText('Bravo')).toBeInTheDocument();
+      expect(screen.getByText('Charlie')).toBeInTheDocument();
+      expect(screen.queryByText('Delta')).not.toBeInTheDocument();
+      expect(screen.queryByText('Echo')).not.toBeInTheDocument();
+      expect(screen.queryByText('Foxtrot')).not.toBeInTheDocument();
+      expect(screen.queryByText('Golf')).not.toBeInTheDocument();
+      expect(screen.getByTestId('load-more-btn')).toBeInTheDocument();
+    });
+
+    it('load-more button displays the remaining count', () => {
+      render(<MilestonesList milestones={SEVEN_MILESTONES} pageSize={3} />);
+
+      const btn = screen.getByTestId('load-more-btn');
+      expect(btn).toHaveTextContent('Load More (4 remaining)');
+    });
+
+    it('clicking load-more appends the next page of milestones', () => {
+      render(<MilestonesList milestones={SEVEN_MILESTONES} pageSize={3} />);
+
+      fireEvent.click(screen.getByTestId('load-more-btn'));
+
+      expect(screen.getByText('Alpha')).toBeInTheDocument();
+      expect(screen.getByText('Bravo')).toBeInTheDocument();
+      expect(screen.getByText('Charlie')).toBeInTheDocument();
+      expect(screen.getByText('Delta')).toBeInTheDocument();
+      expect(screen.getByText('Echo')).toBeInTheDocument();
+      expect(screen.getByText('Foxtrot')).toBeInTheDocument();
+      expect(screen.queryByText('Golf')).not.toBeInTheDocument();
+      expect(screen.getByTestId('load-more-btn')).toHaveTextContent('Load More (1 remaining)');
+    });
+
+    it('load-more button disappears when all milestones are visible', () => {
+      render(<MilestonesList milestones={SEVEN_MILESTONES} pageSize={3} />);
+
+      fireEvent.click(screen.getByTestId('load-more-btn'));
+      fireEvent.click(screen.getByTestId('load-more-btn'));
+
+      expect(screen.getByText('Golf')).toBeInTheDocument();
+      expect(screen.queryByTestId('load-more-btn')).not.toBeInTheDocument();
+    });
+
+    it('no load-more button when total milestones equals or is less than pageSize', () => {
+      render(<MilestonesList milestones={SEVEN_MILESTONES.slice(0, 3)} pageSize={3} />);
+
+      expect(screen.queryByTestId('load-more-btn')).not.toBeInTheDocument();
+    });
+
+    it('resets pagination when milestones prop changes (filter change)', () => {
+      const { rerender } = render(<MilestonesList milestones={SEVEN_MILESTONES} pageSize={3} />);
+
+      expect(screen.queryByText('Delta')).not.toBeInTheDocument();
+      expect(screen.getByTestId('load-more-btn')).toBeInTheDocument();
+
+      rerender(<MilestonesList milestones={SEVEN_MILESTONES.slice(0, 4)} pageSize={3} />);
+
+      expect(screen.getByText('Alpha')).toBeInTheDocument();
+      expect(screen.queryByText('Delta')).not.toBeInTheDocument();
+      expect(screen.getByTestId('load-more-btn')).toHaveTextContent('Load More (1 remaining)');
+    });
+
+    it('passes axe accessibility checks with load-more button visible', async () => {
+      const { container } = render(<MilestonesList milestones={SEVEN_MILESTONES} pageSize={3} />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
 });


### PR DESCRIPTION

## Description

Adds pagination/load-more to MilestonesList.tsx via a PAGE_SIZE_DEFAULT = 5 constant and optional pageSize prop, tracking a displayCount state that slices the rendered list while a "Load More (X remaining)" button appears in the scroll region when items remain; a useEffect on [milestones, pageSize] resets to the first page on filter changes, and tallies/currency-mismatch/due-soon calculations continue to use the full milestone list rather than the paginated slice. 

Closes #806 

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage

- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [x] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

Adds 7 new tests covering first-page rendering with the load-more button present, the remaining-count display in the button text, appending the next page on click, the button disappearing once all milestones are shown, no button rendering when total items are at or below the page size, pagination resetting on filter/prop change, and axe compliance with the button visible — all 1267 tests pass across 73 suites, lint clean, build compiles successfully.

## Accessibility & Security Notes

### Accessibility

Automated a11y checks (`jest-axe`) pass for the paginated state with the load-more button visible. The button is placed inside the existing keyboard-scrollable region and carries `focus-visible` ring styles matching the component's existing patterns. Milestone rendering and scroll-region ARIA attributes (`role="region"`, `aria-labelledby`, `tabIndex`) are unchanged.

### Security

N/A — this change is purely client-side rendering logic with no network, auth, wallet, or user-input changes.