### PR TITLE
docs(forms): add data-flow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This repository keeps user-facing and implementation notes inside the `docs/` fo
 - `docs/components/Accessibility.md` — Accessibility testing, a11y helpers, and issue #383 notes
 - `docs/components/ReputationPage.md` — Reputation page implementation and rendering states
 - `docs/data-model.md` — Data model and persistence guide
+- `docs/forms-data-flow.md` — Forms data-flow diagram (fetch -> transform -> render) and implementation notes
 - `docs/persistence.md` — Persistence API and local storage patterns
 - `docs/preferences.md` — Preferences provider and currency/locale helpers
 - `docs/contexts/wallet-session.md` — Wallet session lifecycle and idle disconnect guidance

--- a/docs/forms-data-flow.md
+++ b/docs/forms-data-flow.md
@@ -1,0 +1,74 @@
+# Forms Data-Flow
+
+This document outlines the standard data-flow for forms in the TalentTrust frontend (e.g., login form, contract creation form). It covers how data is collected, validated, and rendered, ensuring consistent state management and accessibility.
+
+## Data-Flow Diagram (Fetch → Transform → Render)
+
+The following Mermaid diagram visualizes the lifecycle of form data within our components.
+
+```mermaid
+flowchart TD
+    %% Input Layer (Fetch/Collect)
+    subgraph Collect [1. Collect & State]
+        UI([User Input]) --> |onChange| State[React Local State<br/>e.g., useState]
+        State --> FormValues[(Raw Form Values)]
+    end
+
+    %% Transform & Validation Layer
+    subgraph Transform [2. Transform & Validate]
+        FormValues --> |onSubmit| Validation[Validation Logic<br/>e.g., validateLogin, validateForm]
+        Validation --> Sanitize[Sanitization<br/>e.g., sanitizeUserText]
+        Validation --> CustomCheck[Custom Rules<br/>e.g., isValidStellarAddress]
+        
+        Sanitize --> Decision{Are there errors?}
+        CustomCheck --> Decision
+    end
+
+    %% Render & Output Layer
+    subgraph Render [3. Render & Dispatch]
+        Decision -- "Yes" --> UpdateErrorState[setErrors(ValidationErrors)]
+        Decision -- "No" --> BuildDomain[Construct Domain Object<br/>e.g., Contract]
+        
+        UpdateErrorState --> UI_ErrorSummary[<ErrorSummary /><br/>role='alert' & auto-focus]
+        UpdateErrorState --> UI_FormField[<FormField /><br/>aria-invalid='true']
+        
+        BuildDomain --> Callback[onSubmit Callback<br/>Propagate to parent/API]
+        Callback --> ToastSuccess[useToast showSuccess]
+        Callback --> ResetState[Clear Form State]
+    end
+
+    %% Dependencies
+    classDef ui fill:#f8fafc,stroke:#cbd5e1,stroke-width:2px,color:#0f172a
+    classDef logic fill:#eff6ff,stroke:#bfdbfe,stroke-width:2px,color:#1e3a8a
+    classDef error fill:#fef2f2,stroke:#fecaca,stroke-width:2px,color:#991b1b
+    classDef success fill:#ecfdf5,stroke:#a7f3d0,stroke-width:2px,color:#065f46
+    
+    UI:::ui
+    UI_ErrorSummary:::error
+    UI_FormField:::error
+    ToastSuccess:::success
+    Validation:::logic
+```
+
+## Phase Breakdown
+
+### 1. Collect (Fetch)
+- Raw input is captured via `onChange` handlers and mapped directly into React local state (e.g., `useState`).
+- Input is purposefully untrimmed at this stage to prevent UI jitter during typing.
+
+### 2. Transform & Validate
+- Triggered synchronously on form submission (`onSubmit`).
+- Form values are passed to pure, isolated validation helpers (e.g., `validateLogin`, or `validateForm`).
+- **Transformations**: Strings are trimmed and sanitized (e.g., `sanitizeUserText`).
+- **Validations**: Formats and requirements are checked (e.g., `isValidStellarAddress`, length boundaries).
+- Outputs an array of `ValidationError` objects containing `fieldId` and `message`.
+
+### 3. Render
+- **Failure Path**: 
+  - The `errors` state is updated.
+  - The `<ErrorSummary />` component renders the list of errors, announces them to screen readers (`role="alert"`), and sets focus.
+  - Individual `<FormField />` wrappers associate errors with their respective inputs using `aria-invalid` and `aria-describedby`.
+- **Success Path**: 
+  - A domain object (e.g., `Contract`) is constructed and propagated upward.
+  - Success feedback is delivered via the accessible `useToast` hook.
+  - Form state is reset (if applicable).


### PR DESCRIPTION
## Description

This PR introduces a new documentation section detailing the data-flow for forms across the application (specifically the `fetch -> transform -> render` lifecycle). A Mermaid diagram has been included in the new `docs/forms-data-flow.md` file to help new contributors visualize how form data is captured in local state, transformed/validated through isolated pure functions, and subsequently rendered or submitted with error feedback managed via accessibility-first patterns.

The documentation has also been linked in the main `README.md` Documentation Index.

Closes #823

## Type of Change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [x] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [x] `npm run build` completes successfully

---

## Testing & Coverage

- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

N/A — Verify against code. This is purely a documentation update and does not alter any application logic or components. Verified that the existing test suite passes and the build remains green.

---

## Accessibility & Security Notes

### Accessibility

N/A — no UI changes. The documentation specifically highlights the existing accessibility mechanisms in our form data-flow, such as `aria-invalid` usage and `ErrorSummary`'s `role="alert"` for screen reader announcements.

### Security

N/A — This PR only contains documentation additions and does not touch authentication, authorization, or user-supplied input logic.
