### PR TITLE
 feat(wallet): add density toggle

### DIFF
--- a/src/components/WalletConnectButton.tsx
+++ b/src/components/WalletConnectButton.tsx
@@ -3,12 +3,25 @@
 import React from 'react';
 import { useWallet } from '@/contexts/WalletContext';
 import { useToast } from '@/components/toast/toast-provider';
+import { usePreferences } from '@/lib/preferences';
 import { truncateAddress } from '@/lib/truncateAddress';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 
 export const WalletConnectButton = () => {
   const { address, isConnecting, error, connect, disconnect } = useWallet();
   const { showError } = useToast();
+  const { preferences, updatePreference } = usePreferences();
+
+  const isCompact = preferences.walletDensity === 'compact';
+
+  const containerGap = isCompact ? 'gap-1.5' : 'gap-2';
+  const containerPadding = isCompact ? 'p-0.5' : 'p-1';
+  const addressPadding = isCompact ? 'px-2 py-1' : 'px-3 py-1.5';
+  const btnPadding = isCompact ? 'p-1' : 'p-1.5';
+
+  const toggleDensity = () => {
+    updatePreference('walletDensity', isCompact ? 'comfortable' : 'compact');
+  };
 
   const { copied, copy } = useCopyToClipboard({
     delay: 2000,
@@ -64,17 +77,40 @@ export const WalletConnectButton = () => {
   }
 
   if (address) {
+    const densityLabel = isCompact ? 'Switch to comfortable view' : 'Switch to compact view';
     return (
-      <div className="flex items-center gap-2 rounded-xl bg-slate-100 p-1 ring-1 ring-slate-200">
-        <div className="flex items-center gap-2 px-3 py-1.5">
+      <div className={`flex items-center ${containerGap} rounded-xl bg-slate-100 ${containerPadding} ring-1 ring-slate-200`}>
+        <div className={`flex items-center ${containerGap} ${addressPadding}`}>
           <div className="h-2 w-2 rounded-full bg-green-500" aria-hidden="true" />
           <span className="text-sm font-medium text-slate-700 font-mono">
             {truncateAddress(address)}
           </span>
         </div>
         <button
+          onClick={toggleDensity}
+          className={`rounded-lg ${btnPadding} text-slate-500 hover:bg-slate-200 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500`}
+          aria-label={densityLabel}
+          title={densityLabel}
+          data-testid="wallet-density-btn"
+        >
+          {isCompact ? (
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <line x1="4" y1="5" x2="20" y2="5" />
+              <line x1="4" y1="9" x2="20" y2="9" />
+              <line x1="4" y1="13" x2="20" y2="13" />
+              <line x1="4" y1="17" x2="20" y2="17" />
+            </svg>
+          ) : (
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <line x1="4" y1="5" x2="20" y2="5" />
+              <line x1="4" y1="12" x2="20" y2="12" />
+              <line x1="4" y1="19" x2="20" y2="19" />
+            </svg>
+          )}
+        </button>
+        <button
           onClick={handleCopy}
-          className="rounded-lg p-1.5 text-slate-500 hover:bg-slate-200 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className={`rounded-lg ${btnPadding} text-slate-500 hover:bg-slate-200 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500`}
           aria-label="Copy address to clipboard"
           title="Copy address"
         >
@@ -90,7 +126,7 @@ export const WalletConnectButton = () => {
         </button>
         <button
           onClick={disconnect}
-          className="rounded-lg p-1.5 text-slate-500 hover:bg-red-100 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500"
+          className={`rounded-lg ${btnPadding} text-slate-500 hover:bg-red-100 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500`}
           aria-label="Disconnect wallet"
           title="Disconnect wallet"
         >

--- a/src/components/__tests__/WalletConnectButton.test.tsx
+++ b/src/components/__tests__/WalletConnectButton.test.tsx
@@ -6,6 +6,7 @@ import { WalletConnectButton } from '../WalletConnectButton';
 import { WalletContextType, useWallet } from '@/contexts/WalletContext';
 import * as truncateAddressModule from '@/lib/truncateAddress';
 import { testA11y } from '@/test-utils/a11y';
+import { PreferencesProvider } from '@/lib/preferences';
 
 jest.mock('@/contexts/WalletContext', () => ({
   useWallet: jest.fn(),
@@ -49,6 +50,7 @@ function getButtonIconPath(button: HTMLElement) {
 
 describe('WalletConnectButton', () => {
   beforeEach(() => {
+    localStorage.clear();
     jest.clearAllMocks();
     jest.useFakeTimers();
   });
@@ -383,5 +385,84 @@ describe('WalletConnectButton', () => {
     await testA11y(<WalletConnectButton />);
 
     jest.useFakeTimers();
+  });
+
+  describe('density toggle', () => {
+    function renderConnected(address = '0x71C7656EC7ab88b098defB751B7401B5f6d8976F') {
+      mockUseWallet.mockReturnValue(createWalletState({ address }));
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+      return render(<WalletConnectButton />, { wrapper: PreferencesProvider });
+    }
+
+    it('shows density toggle button in the connected state with default comfortable label', () => {
+      renderConnected();
+
+      const densityBtn = screen.getByTestId('wallet-density-btn');
+      expect(densityBtn).toBeInTheDocument();
+      expect(densityBtn).toHaveAttribute('aria-label', 'Switch to compact view');
+    });
+
+    it('toggles density and persists across re-renders', () => {
+      const { rerender } = renderConnected();
+
+      const btn = screen.getByTestId('wallet-density-btn');
+      act(() => { btn.click(); });
+      expect(screen.getByTestId('wallet-density-btn')).toHaveAttribute('aria-label', 'Switch to comfortable view');
+
+      act(() => { screen.getByTestId('wallet-density-btn').click(); });
+      expect(screen.getByTestId('wallet-density-btn')).toHaveAttribute('aria-label', 'Switch to compact view');
+
+      rerender(<WalletConnectButton />);
+      expect(screen.getByTestId('wallet-density-btn')).toHaveAttribute('aria-label', 'Switch to compact view');
+    });
+
+    it('falls back to comfortable when an invalid stored value is loaded', () => {
+      localStorage.setItem(
+        'talenttrust-user-preferences',
+        JSON.stringify({ walletDensity: 'ultra-compact' }),
+      );
+      renderConnected();
+
+      expect(screen.getByTestId('wallet-density-btn')).toHaveAttribute('aria-label', 'Switch to compact view');
+    });
+
+    it('density button is not rendered in disconnected state', () => {
+      mockUseWallet.mockReturnValue(createWalletState({ address: null }));
+      render(<WalletConnectButton />, { wrapper: PreferencesProvider });
+
+      expect(screen.queryByTestId('wallet-density-btn')).not.toBeInTheDocument();
+    });
+
+    it('density button is not rendered in error state', () => {
+      mockUseWallet.mockReturnValue(createWalletState({ error: 'Something went wrong' }));
+      render(<WalletConnectButton />, { wrapper: PreferencesProvider });
+
+      expect(screen.queryByTestId('wallet-density-btn')).not.toBeInTheDocument();
+    });
+
+    it('density button is not rendered in connecting state', () => {
+      mockUseWallet.mockReturnValue(createWalletState({ isConnecting: true }));
+      render(<WalletConnectButton />, { wrapper: PreferencesProvider });
+
+      expect(screen.queryByTestId('wallet-density-btn')).not.toBeInTheDocument();
+    });
+
+    it('has no accessibility violations with density toggle present', async () => {
+      jest.useRealTimers();
+      mockUseWallet.mockReturnValue(createWalletState({
+        address: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+      }));
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+      await testA11y(<WalletConnectButton />, { wrapper: PreferencesProvider });
+      jest.useFakeTimers();
+    });
   });
 });

--- a/src/lib/__tests__/preferences.test.tsx
+++ b/src/lib/__tests__/preferences.test.tsx
@@ -74,6 +74,7 @@ describe('PreferencesProvider', () => {
       theme: 'system',
       amountFormat: 'usd',
       toastDensity: 'relaxed',
+      walletDensity: 'comfortable',
       quietMode: false,
       toastDuration: 'normal',
       idleDisconnectMs: 0,
@@ -142,13 +143,14 @@ describe('PreferencesProvider', () => {
     expect(r2.current.preferences.quietMode).toBe(false);
   });
 
-  it('persists only the six known keys even after a malicious payload round-trips', async () => {
+  it('persists only the seven known keys even after a malicious payload round-trips', async () => {
     localStorage.setItem(
       'talenttrust-user-preferences',
       JSON.stringify({
         theme: 'dark',
         amountFormat: 'ngn',
         toastDensity: 'compact',
+        walletDensity: 'compact',
         quietMode: true,
         toastDuration: 'long',
         idleDisconnectMs: 10000,
@@ -171,6 +173,7 @@ describe('PreferencesProvider', () => {
       'theme',
       'toastDensity',
       'toastDuration',
+      'walletDensity',
     ]);
   });
 
@@ -220,6 +223,7 @@ describe('sanitizePreferences (pure helper)', () => {
     theme: 'system',
     amountFormat: 'usd',
     toastDensity: 'relaxed',
+    walletDensity: 'comfortable',
     quietMode: false,
     toastDuration: 'normal',
     idleDisconnectMs: 0,
@@ -251,6 +255,7 @@ describe('sanitizePreferences (pure helper)', () => {
         theme: 'dark',
         amountFormat: 'compact',
         toastDensity: 'compact',
+        walletDensity: 'compact',
         quietMode: true,
         toastDuration: 'long',
         idleDisconnectMs: 15000,
@@ -259,6 +264,7 @@ describe('sanitizePreferences (pure helper)', () => {
       theme: 'dark',
       amountFormat: 'compact',
       toastDensity: 'compact',
+      walletDensity: 'compact',
       quietMode: true,
       toastDuration: 'long',
       idleDisconnectMs: 15000,
@@ -272,6 +278,7 @@ describe('sanitizePreferences (pure helper)', () => {
       theme: 'light',
       amountFormat: 'usd',
       toastDensity: 'relaxed',
+      walletDensity: 'comfortable',
       quietMode: true,
       toastDuration: 'normal',
       idleDisconnectMs: 0,
@@ -358,6 +365,7 @@ describe('sanitizePreferences (pure helper)', () => {
       theme: 'dark',
       amountFormat: '???', // invalid
       toastDensity: 'compact',
+      walletDensity: 'invalid', // invalid
       quietMode: 'yes', // invalid
       toastDuration: 'persistent', // valid
       idleDisconnectMs: 10000, // valid
@@ -368,6 +376,7 @@ describe('sanitizePreferences (pure helper)', () => {
       theme: 'dark',
       amountFormat: 'usd',
       toastDensity: 'compact',
+      walletDensity: 'comfortable',
       quietMode: false,
       toastDuration: 'persistent',
       idleDisconnectMs: 10000,

--- a/src/lib/preferences.tsx
+++ b/src/lib/preferences.tsx
@@ -7,6 +7,7 @@ import { getItem, setItem } from './safeStorage';
 export type Theme = 'light' | 'dark' | 'system';
 export type AmountFormat = 'usd' | 'ngn' | 'compact';
 export type ToastDensity = 'relaxed' | 'compact';
+export type WalletDensity = 'comfortable' | 'compact';
 /**
  * Controls the default auto-dismiss duration for toasts when the caller does
  * not supply an explicit `duration`.
@@ -49,6 +50,7 @@ export interface UserPreferences {
   theme: Theme;
   amountFormat: AmountFormat;
   toastDensity: ToastDensity;
+  walletDensity: WalletDensity;
   quietMode: boolean;
   toastDuration: ToastDuration;
   /**
@@ -62,6 +64,7 @@ const DEFAULT_PREFERENCES: UserPreferences = {
   theme: 'system',
   amountFormat: 'usd',
   toastDensity: 'relaxed',
+  walletDensity: 'comfortable',
   quietMode: false,
   toastDuration: 'normal',
   idleDisconnectMs: 0,
@@ -77,6 +80,7 @@ const KNOWN_KEYS: ReadonlySet<keyof UserPreferences> = new Set([
   'theme',
   'amountFormat',
   'toastDensity',
+  'walletDensity',
   'quietMode',
   'toastDuration',
   'idleDisconnectMs',
@@ -99,6 +103,7 @@ const DANGEROUS_KEYS: ReadonlySet<string> = new Set(['__proto__', 'constructor',
 const ALLOWED_THEMES: ReadonlySet<Theme> = new Set(['light', 'dark', 'system']);
 const ALLOWED_AMOUNT_FORMATS: ReadonlySet<AmountFormat> = new Set(['usd', 'ngn', 'compact']);
 const ALLOWED_TOAST_DENSITIES: ReadonlySet<ToastDensity> = new Set(['relaxed', 'compact']);
+const ALLOWED_WALLET_DENSITIES: ReadonlySet<WalletDensity> = new Set(['comfortable', 'compact']);
 const ALLOWED_TOAST_DURATIONS: ReadonlySet<ToastDuration> = new Set(['short', 'normal', 'long', 'persistent']);
 
 interface PreferencesContextType {
@@ -150,6 +155,7 @@ export function sanitizePreferences(raw: unknown): UserPreferences {
   let theme: Theme = DEFAULT_PREFERENCES.theme;
   let amountFormat: AmountFormat = DEFAULT_PREFERENCES.amountFormat;
   let toastDensity: ToastDensity = DEFAULT_PREFERENCES.toastDensity;
+  let walletDensity: WalletDensity = DEFAULT_PREFERENCES.walletDensity;
   let quietMode: boolean = DEFAULT_PREFERENCES.quietMode;
   let toastDuration: ToastDuration = DEFAULT_PREFERENCES.toastDuration;
   let idleDisconnectMs: number = DEFAULT_PREFERENCES.idleDisconnectMs;
@@ -184,6 +190,11 @@ export function sanitizePreferences(raw: unknown): UserPreferences {
           toastDensity = value as ToastDensity;
         }
         break;
+      case 'walletDensity':
+        if (typeof value === 'string' && ALLOWED_WALLET_DENSITIES.has(value as WalletDensity)) {
+          walletDensity = value as WalletDensity;
+        }
+        break;
       case 'quietMode':
         if (typeof value === 'boolean') {
           quietMode = value;
@@ -208,7 +219,7 @@ export function sanitizePreferences(raw: unknown): UserPreferences {
     }
   }
 
-  return { theme, amountFormat, toastDensity, quietMode, toastDuration, idleDisconnectMs };
+  return { theme, amountFormat, toastDensity, walletDensity, quietMode, toastDuration, idleDisconnectMs };
 }
 
 /**


### PR DESCRIPTION
## Description

Adds a density toggle to the wallet connected state, letting users switch between comfortable (default) and compact layouts. The preference is persisted to localStorage via the existing `PreferencesProvider`.

Closes #817 

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

---

## Pre-flight Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [x] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
- [x] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

- `preferences.test.tsx` – serialization, sanitization, and fallback for `walletDensity`
- `WalletConnectButton.test.tsx` – toggle switches density, aria-label updates, persistence across re-renders, invalid stored value falls back to `comfortable`, button hidden in disconnected/error/connecting states, and a11y with density toggle present

---

## Accessibility & Security Notes

### Accessibility

New toggle button has an `aria-label` that reflects the current state (`"Switch to compact view"` / `"Switch to comfortable view"`) and a `title` attribute. A11y tests via `testA11y` pass.

### Security

No auth, wallet logic, API calls, or user input touched. The preference value is sanitized through `ALLOWED_WALLET_DENSITIES` before reaching React state.