### PR TITLE
feat(reputation): persist filter/sort in URL #762

### DIFF
--- a/docs/components/ReputationPage.md
+++ b/docs/components/ReputationPage.md
@@ -212,6 +212,30 @@ These bands scale proportionally if a custom `maxScore` is provided (e.g., if `m
 
 ---
 
+## URL filter / sort state
+
+When reputation history is present, `ReputationProfile` exposes:
+
+- **Filter** (`?type=`) — event type, default `All` (omitted from the URL)
+- **Sort** (`?dir=`) — `desc` (newest first, default, omitted) or `asc` (oldest first)
+
+Behaviour:
+
+1. State is **restored from the URL** on load and on back/forward navigation.
+2. Invalid `type` / `dir` / `sort` values are ignored and fall back to defaults.
+3. URL writes are **debounced** (250ms) via `router.replace` so rapid changes stay shareable without flooding history.
+4. Pure helpers live in `src/lib/reputationUrlState.ts` (validation, query build, filter+sort).
+
+Example shareable link: `/reputation?type=Verification&dir=asc`
+
+### URL sync tests
+
+```bash
+npm test -- --testPathPattern="reputation-filter-url|reputationUrlState"
+```
+
+---
+
 ## Testing
 
 ### Coverage Requirements
@@ -221,11 +245,13 @@ These bands scale proportionally if a custom `maxScore` is provided (e.g., if `m
 - ✓ Full reputation (score + history)
 - ✓ Heading hierarchy
 - ✓ ReputationProfile not rendered when no data
+- ✓ Restore filter/sort from URL; invalid params ignored; debounced shareable updates
 
 ### Running Tests
 
 ```bash
 npm test -- src/app/reputation/__tests__/page.test.tsx
+npm test -- --testPathPattern="reputation-filter-url|reputationUrlState|ReputationProfile.test"
 ```
 
 ---
@@ -234,5 +260,8 @@ npm test -- src/app/reputation/__tests__/page.test.tsx
 
 - **Page:** `src/app/reputation/page.tsx`
 - **Component:** `src/components/ReputationProfile.tsx`
+- **URL helpers:** `src/lib/reputationUrlState.ts`
 - **Tests:** `src/app/reputation/__tests__/page.test.tsx`
 - **Component Tests:** `src/components/ReputationProfile.test.tsx`
+- **URL Tests:** `src/app/__tests__/reputation-filter-url.test.tsx`
+- **Helper Tests:** `src/lib/__tests__/reputationUrlState.test.ts`

--- a/src/app/__tests__/reputation-filter-url.test.tsx
+++ b/src/app/__tests__/reputation-filter-url.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ReputationProfile, { type ReputationEvent } from '../../components/ReputationProfile';
+import { REPUTATION_URL_DEBOUNCE_MS } from '@/lib/reputationUrlState';
+
+jest.mock('next/navigation', () => {
+  const original = jest.requireActual('next/navigation');
+  return {
+    ...original,
+    useSearchParams: jest.fn(),
+    useRouter: jest.fn(),
+  };
+});
+
+import { useSearchParams, useRouter } from 'next/navigation';
+
+const HISTORY: ReputationEvent[] = [
+  {
+    id: 'ev-1',
+    type: 'Verification',
+    summary: 'Completed identity verification',
+    date: '2026-04-24',
+  },
+  {
+    id: 'ev-2',
+    type: 'On-chain review',
+    summary: 'Received positive trust signal',
+    date: '2026-04-23',
+  },
+  {
+    id: 'ev-3',
+    type: 'Referral',
+    summary: 'Referred two new community members',
+    date: '2026-04-20',
+  },
+];
+
+function mockSearchParams(query: string) {
+  const params = new URLSearchParams(query);
+  (useSearchParams as jest.Mock).mockReturnValue({
+    get: (key: string) => params.get(key),
+    toString: () => params.toString(),
+  });
+}
+
+describe('ReputationProfile URL filter/sort sync', () => {
+  const replaceMock = jest.fn();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    replaceMock.mockReset();
+    (useRouter as jest.Mock).mockReturnValue({ replace: replaceMock });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('restores filter and sort from the URL on load', () => {
+    mockSearchParams('type=Referral&dir=asc');
+    render(
+      <ReputationProfile name="URL User" score={80} history={HISTORY} />
+    );
+
+    expect(screen.getByTestId('reputation-type-filter')).toHaveValue('Referral');
+    expect(screen.getByTestId('reputation-sort-dir')).toHaveValue('asc');
+
+    const items = within(document.querySelector('ol')!).getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+    expect(within(items[0]).getByText(/Referred two new community members/i)).toBeInTheDocument();
+  });
+
+  it('ignores invalid URL params and falls back to defaults', () => {
+    mockSearchParams('type=NotReal&dir=sideways&sort=score');
+    render(
+      <ReputationProfile name="URL User" score={80} history={HISTORY} />
+    );
+
+    expect(screen.getByTestId('reputation-type-filter')).toHaveValue('All');
+    expect(screen.getByTestId('reputation-sort-dir')).toHaveValue('desc');
+
+    const items = within(document.querySelector('ol')!).getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+  });
+
+  it('debounces URL updates when filter/sort change (shareable query)', () => {
+    mockSearchParams('');
+    render(
+      <ReputationProfile name="URL User" score={80} history={HISTORY} />
+    );
+
+    fireEvent.change(screen.getByTestId('reputation-type-filter'), {
+      target: { value: 'Verification' },
+    });
+    fireEvent.change(screen.getByTestId('reputation-sort-dir'), {
+      target: { value: 'asc' },
+    });
+
+    expect(replaceMock).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(REPUTATION_URL_DEBOUNCE_MS);
+    });
+
+    expect(replaceMock).toHaveBeenCalledWith('?type=Verification&dir=asc');
+  });
+
+  it('does not write defaults back to the URL when already clean', () => {
+    mockSearchParams('');
+    render(
+      <ReputationProfile name="URL User" score={80} history={HISTORY} />
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(REPUTATION_URL_DEBOUNCE_MS);
+    });
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('round-trips: URL → UI → URL for a non-default state', () => {
+    mockSearchParams('type=On-chain review&dir=asc');
+    render(
+      <ReputationProfile name="URL User" score={80} history={HISTORY} />
+    );
+
+    expect(screen.getByTestId('reputation-type-filter')).toHaveValue('On-chain review');
+    expect(screen.getByTestId('reputation-sort-dir')).toHaveValue('asc');
+
+    fireEvent.change(screen.getByTestId('reputation-type-filter'), {
+      target: { value: 'Verification' },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(REPUTATION_URL_DEBOUNCE_MS);
+    });
+
+    expect(replaceMock).toHaveBeenCalledWith('?type=Verification&dir=asc');
+  });
+
+  it('skips URL writes when syncUrl is false', () => {
+    mockSearchParams('');
+    render(
+      <ReputationProfile
+        name="Local User"
+        score={80}
+        history={HISTORY}
+        syncUrl={false}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId('reputation-type-filter'), {
+      target: { value: 'Verification' },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(REPUTATION_URL_DEBOUNCE_MS);
+    });
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/reputation/page.tsx
+++ b/src/app/reputation/page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import EmptyState from '../../components/EmptyState';
 import ReputationProfile from '../../components/ReputationProfile';
 import type { Reputation } from '@/types/domain';
@@ -31,12 +31,14 @@ export function ReputationPageContent({
   return (
     <main className="min-h-screen p-8">
       <h1 className="text-2xl font-bold mb-6">Reputation</h1>
-      <ReputationProfile
-        name={userName}
-        score={score}
-        level={reputationData.level}
-        history={reputationData.history}
-      />
+      <Suspense fallback={null}>
+        <ReputationProfile
+          name={userName}
+          score={score}
+          level={reputationData.level}
+          history={reputationData.history}
+        />
+      </Suspense>
     </main>
   );
 }

--- a/src/components/ReputationProfile.test.tsx
+++ b/src/components/ReputationProfile.test.tsx
@@ -26,7 +26,7 @@
  */
 
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import ReputationProfile, {
   ReputationEvent,
   ReputationProfileProps,
@@ -59,8 +59,9 @@ const HISTORY_EVENTS: ReputationEvent[] = [
 ];
 
 // Convenience wrapper so every render call uses the exported prop type.
+// syncUrl is off here so unit tests stay isolated from next/navigation URL writes.
 function renderProfile(props: ReputationProfileProps) {
-  return render(<ReputationProfile {...props} />);
+  return render(<ReputationProfile syncUrl={false} {...props} />);
 }
 
 function getLevelText() {
@@ -256,8 +257,10 @@ describe('ReputationProfile – full reputation (score + history)', () => {
   });
 
   it('renders each event type label', () => {
-    HISTORY_EVENTS.forEach((ev) => {
-      expect(screen.getByText(ev.type)).toBeInTheDocument();
+    const ol = document.querySelector('ol');
+    const items = ol ? within(ol).getAllByRole('listitem') : [];
+    HISTORY_EVENTS.forEach((ev, idx) => {
+      expect(within(items[idx]).getByText(ev.type)).toBeInTheDocument();
     });
   });
 
@@ -268,12 +271,13 @@ describe('ReputationProfile – full reputation (score + history)', () => {
   });
 
   it('renders each event date', () => {
+    const ol = document.querySelector('ol');
     HISTORY_EVENTS.forEach((ev) => {
-      expect(screen.getByText(ev.date)).toBeInTheDocument();
+      expect(within(ol!).getByText(ev.date)).toBeInTheDocument();
     });
   });
 
-  it('renders events in DOM order matching the history array', () => {
+  it('renders events newest-first by default (matching history array order)', () => {
     const ol = document.querySelector('ol');
     const items = ol ? within(ol).getAllByRole('listitem') : [];
     HISTORY_EVENTS.forEach((ev, idx) => {
@@ -772,3 +776,97 @@ describe('ReputationProfile – reputation score meter (issue #245)', () => {
       await assertNoA11yViolations(container);
     });
   });
+
+// ---------------------------------------------------------------------------
+// 12. History filter + sort (local, syncUrl=false)
+// ---------------------------------------------------------------------------
+
+describe('ReputationProfile – history filtering and sorting', () => {
+  const FILTER_EVENTS: ReputationEvent[] = [
+    {
+      id: 'ev-1',
+      type: 'Verification',
+      summary: 'Completed identity verification',
+      date: '2026-04-24',
+    },
+    {
+      id: 'ev-2',
+      type: 'On-chain review',
+      summary: 'Received positive trust signal',
+      date: '2026-04-23',
+    },
+    {
+      id: 'ev-3',
+      type: 'On-chain review',
+      summary: 'Another trust signal',
+      date: '2026-04-20',
+    },
+  ];
+
+  it('renders filter with All and available types sorted', () => {
+    renderProfile({ name: 'Filter User', score: 80, history: FILTER_EVENTS });
+    const select = screen.getByLabelText(/Filter:/i);
+    const options = within(select).getAllByRole('option');
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveTextContent('All');
+    expect(options[1]).toHaveTextContent('On-chain review');
+    expect(options[2]).toHaveTextContent('Verification');
+  });
+
+  it('filter narrows entries and All restores them', () => {
+    renderProfile({ name: 'Filter User', score: 80, history: FILTER_EVENTS });
+    const select = screen.getByLabelText(/Filter:/i);
+
+    fireEvent.change(select, { target: { value: 'Verification' } });
+    let items = within(document.querySelector('ol')!).getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+    expect(screen.getByText('Completed identity verification')).toBeInTheDocument();
+    expect(screen.queryByText('Received positive trust signal')).not.toBeInTheDocument();
+
+    fireEvent.change(select, { target: { value: 'All' } });
+    items = within(document.querySelector('ol')!).getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+  });
+
+  it('shows empty guidance when filter matches nothing', () => {
+    const { rerender } = renderProfile({
+      name: 'Filter User',
+      score: 80,
+      history: FILTER_EVENTS,
+    });
+    fireEvent.change(screen.getByLabelText(/Filter:/i), {
+      target: { value: 'Verification' },
+    });
+
+    // History updates while a now-absent type remains selected.
+    rerender(
+      <ReputationProfile
+        syncUrl={false}
+        name="Filter User"
+        score={80}
+        history={[FILTER_EVENTS[1], FILTER_EVENTS[2]]}
+      />
+    );
+
+    expect(screen.getByText(/No events match this filter/i)).toBeInTheDocument();
+    expect(document.querySelector('ol')).not.toBeInTheDocument();
+  });
+
+  it('sorts oldest first when sort direction changes', () => {
+    renderProfile({ name: 'Sort User', score: 80, history: FILTER_EVENTS });
+    fireEvent.change(screen.getByLabelText(/Sort:/i), {
+      target: { value: 'asc' },
+    });
+    const items = within(document.querySelector('ol')!).getAllByRole('listitem');
+    expect(within(items[0]).getByText('Another trust signal')).toBeInTheDocument();
+    expect(within(items[2]).getByText('Completed identity verification')).toBeInTheDocument();
+  });
+
+  it('announces result count via aria-live', () => {
+    renderProfile({ name: 'Filter User', score: 80, history: FILTER_EVENTS });
+    fireEvent.change(screen.getByLabelText(/Filter:/i), {
+      target: { value: 'On-chain review' },
+    });
+    expect(screen.getByText(/Showing 2 events of type On-chain review/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/ReputationProfile.tsx
+++ b/src/components/ReputationProfile.tsx
@@ -1,3 +1,20 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  DEFAULT_DIR,
+  DEFAULT_TYPE,
+  REPUTATION_URL_DEBOUNCE_MS,
+  buildReputationQueryString,
+  filterAndSortHistory,
+  getAvailableHistoryTypes,
+  getValidDir,
+  getValidType,
+  isReputationUrlInSync,
+  type ReputationSortDir,
+} from '@/lib/reputationUrlState';
+
 export type ReputationEvent = {
   id: string;
   type: string;
@@ -12,6 +29,11 @@ export type ReputationProfileProps = {
   history?: ReputationEvent[];
   /** Maximum possible score value. Used for aria-valuemax on the meter role. */
   maxScore?: number;
+  /**
+   * When false, filter/sort stay local and are not written to the URL.
+   * Defaults to true so shareable links work on the reputation page.
+   */
+  syncUrl?: boolean;
 };
 
 export type ReputationBand = {
@@ -60,9 +82,52 @@ export default function ReputationProfile({
   level,
   history = [],
   maxScore = 5,
+  syncUrl = true,
 }: ReputationProfileProps) {
   const hasReputation = typeof score === 'number' && score >= 0;
   const showPartial = hasReputation && history.length === 0;
+
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const availableTypes = useMemo(() => getAvailableHistoryTypes(history), [history]);
+  const typeOptions = useMemo(() => [DEFAULT_TYPE, ...availableTypes], [availableTypes]);
+
+  const [selectedType, setSelectedType] = useState<string>(() =>
+    syncUrl ? getValidType(searchParams.get('type'), availableTypes) : DEFAULT_TYPE
+  );
+  const [sortDir, setSortDir] = useState<ReputationSortDir>(() =>
+    syncUrl ? getValidDir(searchParams.get('dir')) : DEFAULT_DIR
+  );
+
+  // Restore filter/sort from the URL on load and on back/forward navigation.
+  useEffect(() => {
+    if (!syncUrl) return;
+    setSelectedType(getValidType(searchParams.get('type'), availableTypes));
+    setSortDir(getValidDir(searchParams.get('dir')));
+  }, [searchParams, availableTypes, syncUrl]);
+
+  // Debounced write of filter/sort into the URL (shareable + reload-safe).
+  useEffect(() => {
+    if (!syncUrl) return;
+
+    const state = { type: selectedType, sort: 'date' as const, dir: sortDir };
+    if (isReputationUrlInSync((key) => searchParams.get(key), state, availableTypes)) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      const query = buildReputationQueryString(searchParams, state);
+      router.replace(query ? `?${query}` : '?');
+    }, REPUTATION_URL_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [selectedType, sortDir, router, searchParams, availableTypes, syncUrl]);
+
+  const filteredHistory = useMemo(
+    () => filterAndSortHistory(history, selectedType, sortDir),
+    [history, selectedType, sortDir]
+  );
 
   const resolvedLevel = level !== undefined
     ? level
@@ -193,16 +258,61 @@ export default function ReputationProfile({
        *   is omitted, keeping the markup valid.
        */}
       <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
-        <div className="mb-6 flex items-center justify-between gap-4">
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h2 className="text-xl font-semibold text-slate-950">Reputation history</h2>
             <p className="mt-1 text-sm text-slate-500">
               History is shown as safe, aggregated events with no wallet or personal metadata by default.
             </p>
           </div>
-          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600">
-            {history.length ? 'Visible' : 'Private by default'}
-          </span>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            {history.length > 0 && (
+              <>
+                <div className="flex items-center gap-2">
+                  <label htmlFor="history-type-filter" className="text-sm font-medium text-slate-700">
+                    Filter:
+                  </label>
+                  <select
+                    id="history-type-filter"
+                    data-testid="reputation-type-filter"
+                    className="rounded-lg border border-slate-300 py-1 pl-3 pr-8 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                    value={selectedType}
+                    onChange={(e) => setSelectedType(e.target.value)}
+                  >
+                    {typeOptions.map((type) => (
+                      <option key={type} value={type}>
+                        {type}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex items-center gap-2">
+                  <label htmlFor="history-sort-dir" className="text-sm font-medium text-slate-700">
+                    Sort:
+                  </label>
+                  <select
+                    id="history-sort-dir"
+                    data-testid="reputation-sort-dir"
+                    className="rounded-lg border border-slate-300 py-1 pl-3 pr-8 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                    value={sortDir}
+                    onChange={(e) => setSortDir(e.target.value as ReputationSortDir)}
+                  >
+                    <option value="desc">Newest first</option>
+                    <option value="asc">Oldest first</option>
+                  </select>
+                </div>
+                <div aria-live="polite" className="sr-only">
+                  Showing {filteredHistory.length}{' '}
+                  {filteredHistory.length === 1 ? 'event' : 'events'}
+                  {selectedType !== DEFAULT_TYPE ? ` of type ${selectedType}` : ''}
+                  , {sortDir === 'asc' ? 'oldest first' : 'newest first'}
+                </div>
+              </>
+            )}
+            <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600">
+              {history.length ? 'Visible' : 'Private by default'}
+            </span>
+          </div>
         </div>
 
         {history.length === 0 ? (
@@ -212,9 +322,16 @@ export default function ReputationProfile({
               Reputation history appears once you complete verified actions. Your profile remains safe and privacy-friendly until then.
             </p>
           </div>
+        ) : filteredHistory.length === 0 ? (
+          <div className="rounded-3xl border border-slate-200 bg-slate-50 p-6 text-slate-700">
+            <p className="font-semibold text-slate-900">No events match this filter.</p>
+            <p className="mt-2 text-sm leading-6">
+              Try choosing a different event type, or select All to see the full reputation history.
+            </p>
+          </div>
         ) : (
           <ol className="space-y-4">
-            {history.map((event) => {
+            {filteredHistory.map((event) => {
               // Determine whether the date string is a parseable ISO date.
               // If it is, expose the ISO value via dateTime for machine readability.
               const isValidDate = event.date && !Number.isNaN(Date.parse(event.date));

--- a/src/lib/__tests__/reputationUrlState.test.ts
+++ b/src/lib/__tests__/reputationUrlState.test.ts
@@ -1,0 +1,190 @@
+import {
+  DEFAULT_DIR,
+  DEFAULT_SORT,
+  DEFAULT_TYPE,
+  REPUTATION_DIR_PARAM,
+  REPUTATION_SORT_PARAM,
+  REPUTATION_TYPE_PARAM,
+  buildReputationQueryString,
+  filterAndSortHistory,
+  getAvailableHistoryTypes,
+  getValidDir,
+  getValidSort,
+  getValidType,
+  isReputationUrlInSync,
+  parseReputationUrlState,
+} from '../reputationUrlState';
+
+const HISTORY = [
+  { id: 'a', type: 'Verification', summary: 'Verified', date: '2026-04-24' },
+  { id: 'b', type: 'Referral', summary: 'Referred', date: '2026-04-20' },
+  { id: 'c', type: 'On-chain review', summary: 'Reviewed', date: '2026-04-23' },
+  { id: 'd', type: 'Referral', summary: 'Another', date: '2026-04-21' },
+];
+
+describe('reputationUrlState validators', () => {
+  const types = getAvailableHistoryTypes(HISTORY);
+
+  it('getValidType defaults and accepts known types', () => {
+    expect(getValidType(null, types)).toBe(DEFAULT_TYPE);
+    expect(getValidType('', types)).toBe(DEFAULT_TYPE);
+    expect(getValidType('All', types)).toBe(DEFAULT_TYPE);
+    expect(getValidType('Verification', types)).toBe('Verification');
+    expect(getValidType('Referral', types)).toBe('Referral');
+  });
+
+  it('getValidType ignores unknown types when availability is known', () => {
+    expect(getValidType('NotARealType', types)).toBe(DEFAULT_TYPE);
+    expect(getValidType('bogus', types)).toBe(DEFAULT_TYPE);
+  });
+
+  it('getValidType keeps the raw value when availability is empty (pre-data)', () => {
+    expect(getValidType('Verification', [])).toBe('Verification');
+  });
+
+  it('getValidSort accepts only date and falls back', () => {
+    expect(getValidSort(null)).toBe(DEFAULT_SORT);
+    expect(getValidSort('date')).toBe('date');
+    expect(getValidSort('score')).toBe(DEFAULT_SORT);
+    expect(getValidSort('')).toBe(DEFAULT_SORT);
+  });
+
+  it('getValidDir accepts asc/desc and falls back', () => {
+    expect(getValidDir(null)).toBe(DEFAULT_DIR);
+    expect(getValidDir('asc')).toBe('asc');
+    expect(getValidDir('desc')).toBe('desc');
+    expect(getValidDir('up')).toBe(DEFAULT_DIR);
+  });
+});
+
+describe('reputationUrlState parse / build round-trip', () => {
+  const types = getAvailableHistoryTypes(HISTORY);
+
+  it('parses a shareable query into validated state', () => {
+    const params = new URLSearchParams('type=Referral&dir=asc&sort=date');
+    expect(parseReputationUrlState((k) => params.get(k), types)).toEqual({
+      type: 'Referral',
+      sort: 'date',
+      dir: 'asc',
+    });
+  });
+
+  it('ignores invalid params when parsing', () => {
+    const params = new URLSearchParams('type=Nope&dir=sideways&sort=name');
+    expect(parseReputationUrlState((k) => params.get(k), types)).toEqual({
+      type: DEFAULT_TYPE,
+      sort: DEFAULT_SORT,
+      dir: DEFAULT_DIR,
+    });
+  });
+
+  it('omits default values from the built query string', () => {
+    expect(
+      buildReputationQueryString('', {
+        type: DEFAULT_TYPE,
+        sort: DEFAULT_SORT,
+        dir: DEFAULT_DIR,
+      })
+    ).toBe('');
+  });
+
+  it('writes only non-default params and preserves unrelated params', () => {
+    const query = buildReputationQueryString('utm=campaign', {
+      type: 'Verification',
+      sort: DEFAULT_SORT,
+      dir: 'asc',
+    });
+    const params = new URLSearchParams(query);
+    expect(params.get(REPUTATION_TYPE_PARAM)).toBe('Verification');
+    expect(params.get(REPUTATION_DIR_PARAM)).toBe('asc');
+    expect(params.get(REPUTATION_SORT_PARAM)).toBeNull();
+    expect(params.get('utm')).toBe('campaign');
+  });
+
+  it('includes a non-default sort field when provided', () => {
+    const query = buildReputationQueryString('', {
+      type: DEFAULT_TYPE,
+      // Cast: only "date" is validated today; builder still serialises other fields.
+      sort: 'score' as typeof DEFAULT_SORT,
+      dir: DEFAULT_DIR,
+    });
+    expect(new URLSearchParams(query).get(REPUTATION_SORT_PARAM)).toBe('score');
+  });
+
+  it('accepts URLSearchParams instances as the current query source', () => {
+    const current = new URLSearchParams('keep=1');
+    const query = buildReputationQueryString(current, {
+      type: 'Referral',
+      sort: DEFAULT_SORT,
+      dir: DEFAULT_DIR,
+    });
+    const params = new URLSearchParams(query);
+    expect(params.get('keep')).toBe('1');
+    expect(params.get(REPUTATION_TYPE_PARAM)).toBe('Referral');
+  });
+
+  it('round-trips filter/sort state through query string', () => {
+    const state = { type: 'On-chain review', sort: DEFAULT_SORT, dir: 'asc' as const };
+    const query = buildReputationQueryString('', state);
+    const params = new URLSearchParams(query);
+    expect(parseReputationUrlState((k) => params.get(k), types)).toEqual(state);
+  });
+
+  it('isReputationUrlInSync treats missing defaults as in sync', () => {
+    const params = new URLSearchParams('');
+    expect(
+      isReputationUrlInSync(
+        (k) => params.get(k),
+        { type: DEFAULT_TYPE, sort: DEFAULT_SORT, dir: DEFAULT_DIR },
+        types
+      )
+    ).toBe(true);
+  });
+
+  it('isReputationUrlInSync detects drift', () => {
+    const params = new URLSearchParams('type=Referral');
+    expect(
+      isReputationUrlInSync(
+        (k) => params.get(k),
+        { type: DEFAULT_TYPE, sort: DEFAULT_SORT, dir: DEFAULT_DIR },
+        types
+      )
+    ).toBe(false);
+  });
+});
+
+describe('filterAndSortHistory', () => {
+  it('returns a shallow copy and does not mutate the source', () => {
+    const original = [...HISTORY];
+    const result = filterAndSortHistory(HISTORY, DEFAULT_TYPE, 'asc');
+    expect(HISTORY).toEqual(original);
+    expect(result).not.toBe(HISTORY);
+  });
+
+  it('filters by type', () => {
+    const result = filterAndSortHistory(HISTORY, 'Referral', 'desc');
+    expect(result.map((e) => e.id)).toEqual(['d', 'b']);
+  });
+
+  it('sorts newest first by default', () => {
+    const result = filterAndSortHistory(HISTORY, DEFAULT_TYPE, 'desc');
+    expect(result.map((e) => e.id)).toEqual(['a', 'c', 'd', 'b']);
+  });
+
+  it('sorts oldest first when dir is asc', () => {
+    const result = filterAndSortHistory(HISTORY, DEFAULT_TYPE, 'asc');
+    expect(result.map((e) => e.id)).toEqual(['b', 'd', 'c', 'a']);
+  });
+
+  it('returns an empty list when filter matches nothing', () => {
+    expect(filterAndSortHistory(HISTORY, 'Missing', 'desc')).toEqual([]);
+  });
+
+  it('lists available types alphabetically without All', () => {
+    expect(getAvailableHistoryTypes(HISTORY)).toEqual([
+      'On-chain review',
+      'Referral',
+      'Verification',
+    ]);
+  });
+});

--- a/src/lib/reputationUrlState.ts
+++ b/src/lib/reputationUrlState.ts
@@ -1,0 +1,154 @@
+/** Minimal history event shape needed for filter/sort helpers. */
+export type ReputationHistoryItem = {
+  id: string;
+  type: string;
+  date: string;
+};
+
+/** Query param keys used by the reputation page. */
+export const REPUTATION_TYPE_PARAM = 'type';
+export const REPUTATION_SORT_PARAM = 'sort';
+export const REPUTATION_DIR_PARAM = 'dir';
+
+/** Debounce delay (ms) before writing filter/sort changes to the URL. */
+export const REPUTATION_URL_DEBOUNCE_MS = 250;
+
+export type ReputationSortField = 'date';
+export type ReputationSortDir = 'asc' | 'desc';
+
+export const DEFAULT_TYPE = 'All';
+export const DEFAULT_SORT: ReputationSortField = 'date';
+export const DEFAULT_DIR: ReputationSortDir = 'desc';
+
+const VALID_SORTS: ReputationSortField[] = ['date'];
+const VALID_DIRS: ReputationSortDir[] = ['asc', 'desc'];
+
+/**
+ * Validate a type filter query value.
+ * Unknown or empty values fall back to {@link DEFAULT_TYPE}.
+ * When `availableTypes` is provided (excluding "All"), the value must be in that set.
+ */
+export function getValidType(
+  param: string | null | undefined,
+  availableTypes: readonly string[] = []
+): string {
+  if (!param || param === DEFAULT_TYPE) return DEFAULT_TYPE;
+  if (availableTypes.length === 0) return param;
+  return availableTypes.includes(param) ? param : DEFAULT_TYPE;
+}
+
+/** Validate a sort-field query value; invalid → {@link DEFAULT_SORT}. */
+export function getValidSort(param: string | null | undefined): ReputationSortField {
+  return param && (VALID_SORTS as string[]).includes(param)
+    ? (param as ReputationSortField)
+    : DEFAULT_SORT;
+}
+
+/** Validate a sort-direction query value; invalid → {@link DEFAULT_DIR}. */
+export function getValidDir(param: string | null | undefined): ReputationSortDir {
+  return param && (VALID_DIRS as string[]).includes(param)
+    ? (param as ReputationSortDir)
+    : DEFAULT_DIR;
+}
+
+export type ReputationUrlState = {
+  type: string;
+  sort: ReputationSortField;
+  dir: ReputationSortDir;
+};
+
+/** Parse and validate reputation URL state from a search-params-like object. */
+export function parseReputationUrlState(
+  getParam: (key: string) => string | null,
+  availableTypes: readonly string[] = []
+): ReputationUrlState {
+  return {
+    type: getValidType(getParam(REPUTATION_TYPE_PARAM), availableTypes),
+    sort: getValidSort(getParam(REPUTATION_SORT_PARAM)),
+    dir: getValidDir(getParam(REPUTATION_DIR_PARAM)),
+  };
+}
+
+/**
+ * Build a query string for the given reputation state.
+ * Default values are omitted so shareable URLs stay compact.
+ * Unrelated existing params are preserved.
+ */
+export function buildReputationQueryString(
+  current: { toString(): string } | URLSearchParams | string,
+  state: ReputationUrlState
+): string {
+  const params = new URLSearchParams(
+    typeof current === 'string' ? current : current.toString()
+  );
+
+  if (state.type === DEFAULT_TYPE) {
+    params.delete(REPUTATION_TYPE_PARAM);
+  } else {
+    params.set(REPUTATION_TYPE_PARAM, state.type);
+  }
+
+  if (state.sort === DEFAULT_SORT) {
+    params.delete(REPUTATION_SORT_PARAM);
+  } else {
+    params.set(REPUTATION_SORT_PARAM, state.sort);
+  }
+
+  if (state.dir === DEFAULT_DIR) {
+    params.delete(REPUTATION_DIR_PARAM);
+  } else {
+    params.set(REPUTATION_DIR_PARAM, state.dir);
+  }
+
+  return params.toString();
+}
+
+/**
+ * Whether the URL already reflects `state` (after normalisation).
+ * Used to avoid redundant `router.replace` calls.
+ */
+export function isReputationUrlInSync(
+  getParam: (key: string) => string | null,
+  state: ReputationUrlState,
+  availableTypes: readonly string[] = []
+): boolean {
+  const parsed = parseReputationUrlState(getParam, availableTypes);
+  return (
+    parsed.type === state.type &&
+    parsed.sort === state.sort &&
+    parsed.dir === state.dir
+  );
+}
+
+/** Unique event types present in history, sorted alphabetically (no "All"). */
+export function getAvailableHistoryTypes(history: readonly ReputationHistoryItem[]): string[] {
+  return Array.from(new Set(history.map((event) => event.type))).sort();
+}
+
+/**
+ * Filter by event type then sort by date without mutating the source array.
+ * Non-parseable dates sort as `0` so they stay stable relative to each other.
+ */
+export function filterAndSortHistory<T extends ReputationHistoryItem>(
+  history: readonly T[],
+  type: string,
+  dir: ReputationSortDir = DEFAULT_DIR,
+  _sort: ReputationSortField = DEFAULT_SORT
+): T[] {
+  const filtered =
+    type === DEFAULT_TYPE
+      ? [...history]
+      : history.filter((event) => event.type === type);
+
+  const multiplier = dir === 'asc' ? 1 : -1;
+  filtered.sort((a, b) => {
+    const aTime = Date.parse(a.date);
+    const bTime = Date.parse(b.date);
+    const aVal = Number.isNaN(aTime) ? 0 : aTime;
+    const bVal = Number.isNaN(bTime) ? 0 : bTime;
+    if (aVal === bVal) return a.id.localeCompare(b.id);
+    return (aVal - bVal) * multiplier;
+  });
+
+  return filtered;
+}


### PR DESCRIPTION
## Overview

This PR persists reputation history **filter and sort state in the URL query**, so choices survive reload, stay shareable, and work with the browser back/forward buttons. Invalid params are validated away, and URL writes are debounced.

## Related Issue

Closes #762

## Changes

### 🔗 URL-persisted reputation state

* **[ADD]** `src/lib/reputationUrlState.ts`
  * Validates `type` / `sort` / `dir` query params with safe defaults (`All`, `date`, `desc`).
  * Builds compact shareable query strings (defaults omitted).
  * Filters by event type and sorts by date without mutating the source history array.
  * Debounce constant (`250ms`) for URL writes.

* **[MODIFY]** `src/components/ReputationProfile.tsx`
  * Client-side **Filter** (event type) and **Sort** (newest/oldest) controls on the history section.
  * Restores state from `useSearchParams` on load and on back/forward navigation.
  * Debounced `router.replace` sync for shareable, history-friendly URLs.
  * Empty-filter guidance when no events match the selected type.
  * Optional `syncUrl={false}` for isolated unit tests.

* **[MODIFY]** `src/app/reputation/page.tsx`
  * Wraps `ReputationProfile` in `<Suspense>` for App Router `useSearchParams` compatibility.

* **[ADD]** Tests
  * `src/lib/__tests__/reputationUrlState.test.ts` — validators, round-trip, invalid params, filter/sort.
  * `src/app/__tests__/reputation-filter-url.test.tsx` — restore from URL, ignore invalid params, debounced shareable updates.
  * Extended `ReputationProfile.test.tsx` for filter/sort UI behaviour.

* **[MODIFY]** `docs/components/ReputationPage.md`
  * Documents URL params, debounce behaviour, and how to run the new tests.

## Verification Results

```
npm run lint
✅ passed

npx jest --testPathPattern="reputationUrlState|reputation-filter-url|ReputationProfile.test|reputation/__tests__/page" --coverage=false
✅ Test Suites: 4 passed, 4 total
✅ Tests:       127 passed, 127 total

npm test -- --coverage=false
✅ Test Suites: 75 passed, 75 total
✅ Tests:       1291 passed, 1291 total
✅ Snapshots:   7 passed, 7 total

npm run build
✅ Next.js production build succeeded (`/reputation` static)
```

| Acceptance Criteria | Status |
| --- | --- |
| Reflect filter/sort in URL query params and restore on load | ✅ `?type=` / `?dir=` restored via `useSearchParams` |
| Shareable / back-button friendly | ✅ `router.replace` + searchParams sync on navigation |
| Debounce updates | ✅ 250ms debounce before URL write |
| Validate incoming params | ✅ Unknown `type`/`dir`/`sort` fall back to defaults |
| Round-trip + invalid params covered in tests | ✅ `reputation-filter-url` + `reputationUrlState` suites |