### PR TITLE
fix: manage focus for dialog routes and transitions

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -56,6 +56,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
     dialogRef,
     initialFocusRef: cancelBtnRef,
     onEscape: onCancel,
+    restoreFocus: true,
   });
 
   useEffect(() => {

--- a/src/components/ContractCreationForm.tsx
+++ b/src/components/ContractCreationForm.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { useState, useCallback, FormEvent } from 'react';
+import React, { useState, useCallback, FormEvent, useRef } from 'react';
 import { FormField } from './FormField';
 import { ErrorSummary } from './ErrorSummary';
+import { useDialogFocusTrap } from '@/hooks/useDialogFocusTrap';
 import { isValidStellarAddress } from '@/lib/stellarAddress';
 import { sanitizeUserText } from '@/lib/sanitizeUserText';
 import type { Contract } from '@/types/domain';
@@ -47,6 +48,17 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
     { label: '', address: '' },
   ]);
   const [errors, setErrors] = useState<Array<{ fieldId: string; message: string }>>([]);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const firstInputRef = useRef<HTMLInputElement>(null);
+
+  useDialogFocusTrap({
+    isOpen: true,
+    dialogRef,
+    initialFocusRef: firstInputRef,
+    onEscape: onCancel,
+    restoreFocus: true,
+  });
 
   /**
    * Validates the form data and returns an array of error objects.
@@ -213,6 +225,7 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
 
   return (
     <div
+      ref={dialogRef}
       className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
       role="dialog"
       aria-labelledby="create-contract-title"
@@ -233,6 +246,7 @@ export const ContractCreationForm: React.FC<ContractCreationFormProps> = ({
             required
           >
             <input
+              ref={firstInputRef}
               type="text"
               value={contractName}
               onChange={e => setContractName(e.target.value)}

--- a/src/components/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/__tests__/ConfirmDialog.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ConfirmDialog } from '../ConfirmDialog';
 
@@ -208,5 +208,39 @@ describe('ConfirmDialog', () => {
     await user.tab({ shift: true });
 
     expect(buttons[1]).toHaveFocus();
+  });
+  it('moves focus to the cancel button on open and restores it to the trigger on close', async () => {
+    const Wrapper = () => {
+      const [isOpen, setIsOpen] = React.useState(false);
+      return (
+        <div>
+          <button onClick={() => setIsOpen(true)}>Open Confirm</button>
+          <ConfirmDialog
+            isOpen={isOpen}
+            title="Wrap focus"
+            description="Keep focus inside the dialog"
+            onConfirm={jest.fn()}
+            onCancel={() => setIsOpen(false)}
+          />
+        </div>
+      );
+    };
+
+    const user = userEvent.setup();
+    render(<Wrapper />);
+    
+    const trigger = screen.getByRole('button', { name: 'Open Confirm' });
+    trigger.focus();
+    await user.click(trigger);
+    
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+    });
+    
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
   });
 });

--- a/src/components/__tests__/ContractCreationForm.test.tsx
+++ b/src/components/__tests__/ContractCreationForm.test.tsx
@@ -510,4 +510,52 @@ describe('ContractCreationForm', () => {
       });
     });
   });
+  describe('Focus Management', () => {
+    it('moves focus to the first input on open and restores it to the trigger on close', async () => {
+      const Wrapper = () => {
+        const [isOpen, setIsOpen] = React.useState(false);
+        return (
+          <div>
+            <button onClick={() => setIsOpen(true)}>Open Dialog</button>
+            {isOpen && <ContractCreationForm onSubmit={mockOnSubmit} onCancel={() => setIsOpen(false)} />}
+          </div>
+        );
+      };
+      
+      const user = userEvent.setup();
+      render(<Wrapper />);
+      
+      const trigger = screen.getByRole('button', { name: 'Open Dialog' });
+      trigger.focus();
+      await user.click(trigger);
+      
+      await waitFor(() => {
+        expect(screen.getByLabelText(/contract name/i)).toHaveFocus();
+      });
+      
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+      
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
+      });
+    });
+
+    it('traps focus within the dialog', async () => {
+      const user = userEvent.setup();
+      render(<ContractCreationForm {...defaultProps} />);
+
+      const firstInput = screen.getByLabelText(/contract name/i);
+      
+      // Shift+Tab from the first input should wrap to the last focusable element
+      firstInput.focus();
+      await user.tab({ shift: true });
+      
+      // The "Create Contract" button is the last focusable element
+      expect(screen.getByRole('button', { name: /create contract/i })).toHaveFocus();
+      
+      // Tab from the last focusable element should wrap back to the first
+      await user.tab();
+      expect(firstInput).toHaveFocus();
+    });
+  });
 });

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { usePreferences, Theme, AmountFormat, ToastDensity } from '@/lib/preferences';
+import { useDialogFocusTrap } from '@/hooks/useDialogFocusTrap';
 
 const FOCUSABLE_SELECTORS =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -15,46 +16,15 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
   const { preferences, updatePreference } = usePreferences();
   const panelRef = useRef<HTMLDivElement>(null);
 
-  /**
-   * Focus management effect for modal dialog accessibility.
-   * - Sets initial focus to the close button when dialog opens
-   * - Implements focus trapping to prevent focus from leaving the dialog
-   * - Handles Tab key wrapping from last to first element
-   * - Handles Shift+Tab wrapping from first to last element
-   * - Closes dialog on Escape key press
-   */
-  useEffect(() => {
-    if (!isOpen) return;
-    const panel = panelRef.current;
-    if (!panel) return;
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
 
-    // Set initial focus to the close button
-    const closeBtn = panel.querySelector<HTMLElement>('[aria-label="Close settings"]');
-    closeBtn?.focus();
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-        return;
-      }
-      if (e.key === 'Tab') {
-        const els = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS));
-        if (els.length === 0) return;
-        const first = els[0];
-        const last = els[els.length - 1];
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
+  useDialogFocusTrap({
+    isOpen,
+    dialogRef: panelRef,
+    initialFocusRef: closeBtnRef,
+    onEscape: onClose,
+    restoreFocus: true,
+  });
 
   if (!isOpen) return null;
 
@@ -77,6 +47,7 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
         <div className="flex items-center justify-between p-6 border-b border-[var(--border)]">
           <h2 id="settings-panel-title" className="text-xl font-bold text-[var(--foreground)]">Settings</h2>
           <button 
+            ref={closeBtnRef}
             onClick={onClose}
             className="p-2 rounded-full hover:bg-[var(--accent)] text-[var(--muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
             aria-label="Close settings"


### PR DESCRIPTION
## What was done
- Added `restoreFocus: true` to `ConfirmDialog` to ensure focus is restored to the triggering element when the dialog closes.
- Added `useDialogFocusTrap` hook to `ContractCreationForm` to move focus to the first input on open, trap focus within the form, and restore focus on close.
- Replaced the custom focus trap logic in `SettingsPanel` with `useDialogFocusTrap` for consistency across dialogs and to properly restore focus to the trigger on close.
- Added automated accessibility tests to verify focus trapping, initial focus placement, and focus restoration behavior in `ContractCreationForm.test.tsx` and `ConfirmDialog.test.tsx`.
## Why it was done
To fix accessibility issues where focus was lost when dialogs opened and closed. This change ensures proper focus trapping for screen-reader and keyboard users, preventing disorientation and adhering to WCAG focus management guidelines.
## How it was verified
- Verified through jest/RTL unit tests in `ContractCreationForm.test.tsx` and `ConfirmDialog.test.tsx` simulating focus movement and trapping on open and close. 
Closes #714