### PR TITLE
feat(contracts): show relative creation time with absolute tooltip

### DIFF
--- a/src/app/contracts/__tests__/page.test.tsx
+++ b/src/app/contracts/__tests__/page.test.tsx
@@ -92,8 +92,10 @@ describe('ContractsPage', () => {
 
       expect(screen.getByText('Website Redesign')).toBeInTheDocument();
       expect(screen.getByText('Mobile App Development')).toBeInTheDocument();
-      expect(screen.getByText(/active.*jan 15, 2025/i)).toBeInTheDocument();
-      expect(screen.getByText(/pending.*feb 1, 2025/i)).toBeInTheDocument();
+      expect(screen.getByText(/^Active ·/)).toBeInTheDocument();
+      expect(screen.getByText(/^Pending ·/)).toBeInTheDocument();
+      expect(screen.getByTitle('Jan 15, 2025')).toBeInTheDocument();
+      expect(screen.getByTitle('Feb 1, 2025')).toBeInTheDocument();
     });
 
     it('does not show empty state when contracts exist', () => {
@@ -435,7 +437,8 @@ describe('ContractsPage', () => {
     render(<ContractsPage />);
 
     expect(screen.getByText('Existing Contract')).toBeInTheDocument();
-    expect(screen.getByText(/Active · Created Apr 20, 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/Active · Created/)).toBeInTheDocument();
+    expect(screen.getByTitle('Apr 20, 2026')).toBeInTheDocument();
   });
 
   it('calls saveContract and refreshes contracts on form submission', async () => {

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback } from 'react';
 import EmptyState from '../../components/EmptyState';
 import { ContractCreationForm } from '../../components/ContractCreationForm';
 import { listContracts, saveContract } from '@/lib/repository';
+import { getRelativeTime } from '@/lib/relativeTime';
 import type { Contract } from '@/types/domain';
 
 const ContractsPage: React.FC = () => {
@@ -70,7 +71,10 @@ const ContractsPage: React.FC = () => {
               >
                 <p className="font-semibold text-slate-900">{contract.contractName}</p>
                 <p className="text-sm text-slate-500">
-                  {contract.status} · Created {contract.createdAt}
+                  {contract.status} · Created{' '}
+                  <span title={contract.createdAt}>
+                    {getRelativeTime(contract.createdAt)}
+                  </span>
                 </p>
               </li>
             ))}
@@ -89,4 +93,3 @@ const ContractsPage: React.FC = () => {
 };
 
 export default ContractsPage;
-

--- a/src/lib/__tests__/relativeTime.test.ts
+++ b/src/lib/__tests__/relativeTime.test.ts
@@ -1,0 +1,58 @@
+// Pin timezone for deterministic tests
+process.env.TZ = 'UTC';
+
+import { getRelativeTime } from '../relativeTime';
+
+describe('getRelativeTime', () => {
+  const today = new Date(2026, 4, 10); // May 10, 2026
+
+  it('returns "Today" for a same-day creation date (just now)', () => {
+    expect(getRelativeTime('2026-05-10', today)).toBe('Today');
+  });
+
+  it('returns "Yesterday" for a one-day-old date', () => {
+    expect(getRelativeTime('2026-05-09', today)).toBe('Yesterday');
+  });
+
+  it('returns "N days ago" for dates within the last week', () => {
+    expect(getRelativeTime('2026-05-06', today)).toBe('4 days ago');
+  });
+
+  it('returns "N weeks ago" for dates within the last month', () => {
+    expect(getRelativeTime('2026-04-20', today)).toBe('2 weeks ago');
+  });
+
+  it('returns singular "1 week ago" correctly', () => {
+    expect(getRelativeTime('2026-05-03', today)).toBe('1 week ago');
+  });
+
+  it('returns "N months ago" for dates within the last year', () => {
+    expect(getRelativeTime('2026-01-10', today)).toBe('4 months ago');
+  });
+
+  it('returns singular "1 month ago" correctly', () => {
+    expect(getRelativeTime('2026-04-08', today)).toBe('1 month ago');
+  });
+
+  it('returns "N years ago" for far past dates', () => {
+    expect(getRelativeTime('2021-05-10', today)).toBe('5 years ago');
+  });
+
+  it('returns singular "1 year ago" correctly', () => {
+    expect(getRelativeTime('2025-05-01', today)).toBe('1 year ago');
+  });
+
+  it('handles the "Apr 20, 2026"-style formatted strings the app actually stores', () => {
+    expect(getRelativeTime('Apr 20, 2026', today)).toBe('2 weeks ago');
+  });
+
+  it('falls back to the raw string for an invalid date', () => {
+    expect(getRelativeTime('not-a-date', today)).toBe('not-a-date');
+    expect(getRelativeTime('2026-02-30', today)).toBe('2026-02-30');
+  });
+
+  it('falls back to "Unknown date" when no date is provided', () => {
+    expect(getRelativeTime(undefined, today)).toBe('Unknown date');
+    expect(getRelativeTime('', today)).toBe('Unknown date');
+  });
+});

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -1,0 +1,40 @@
+import { parseLocalDate } from './dueSoon';
+
+/**
+ * Formats a creation date string as a short, human-readable relative time
+ * label (e.g. "Today", "3 days ago", "2 years ago").
+ *
+ * Reuses `parseLocalDate` so the same calendar-date parsing rules (and the
+ * same invalid-date guarding) apply here as they do for milestone due dates.
+ *
+ * @param dateStr - The stored date string (e.g. "Apr 20, 2026" or "2026-04-20").
+ * @param now - The reference "current" date; defaults to `new Date()`. Exposed
+ *   as a parameter so tests can pin it for deterministic assertions.
+ * @returns A relative label, or the original string (unchanged) when the date
+ *   cannot be parsed, so callers never render nothing for malformed input.
+ */
+export function getRelativeTime(dateStr: string | undefined, now: Date = new Date()): string {
+  if (!dateStr) return 'Unknown date';
+
+  const parsed = parseLocalDate(dateStr);
+  if (!parsed) return dateStr;
+
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const diffMs = today.getTime() - parsed.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  // Future-dated or same-day creation both read naturally as "Today" here,
+  // since createdAt only carries day-level precision, not a time-of-day.
+  if (diffDays <= 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffDays < 30) return diffWeeks === 1 ? '1 week ago' : `${diffWeeks} weeks ago`;
+
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffDays < 365) return diffMonths === 1 ? '1 month ago' : `${diffMonths} months ago`;
+
+  const diffYears = Math.floor(diffDays / 365);
+  return diffYears === 1 ? '1 year ago' : `${diffYears} years ago`;
+}


### PR DESCRIPTION
Closes #495

Renders contract creation dates as a relative label (e.g. "3 days ago") 
with the absolute date exposed via a title tooltip on hover/focus.

- Reuses the existing `parseLocalDate` helper from `src/lib/dueSoon.ts` 
  — no new dependency added.
- New helper: `src/lib/relativeTime.ts` + tests in 
  `src/lib/__tests__/relativeTime.test.ts`, covering just-now (Today), 
  far-past, and invalid-date edge cases.
- Updated `src/app/contracts/page.tsx` and its existing tests to match.

Test output:
Test Suites: 74 passed, 74 total
Tests:       1272 passed, 1272 total