### PR TITLE
feat(dialogs): add CSV/JSON export for DialogsList

### DIFF
--- a/src/components/__tests__/DialogsList.test.tsx
+++ b/src/components/__tests__/DialogsList.test.tsx
@@ -1,0 +1,469 @@
+/**
+ * DialogsList.test.tsx
+ *
+ * Tests for src/components/dialogs/DialogsList.tsx (issue #53).
+ * Covers:
+ *  - Loading / error / empty / success states (mutually exclusive)
+ *  - State transitions
+ *  - Filter-respect: export buttons act on the filtered view
+ *  - CSV and JSON export integration (download triggered with correct data)
+ *  - Empty-view export guard (buttons disabled when nothing to export)
+ *  - Accessibility attributes on export controls
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DialogsList, type DialogRecord } from '../dialogs/DialogsList';
+import * as exportDialogs from '@/lib/exportDialogs';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const sampleDialogs: DialogRecord[] = [
+  {
+    id: 'dlg-001',
+    title: 'Release funds',
+    description: 'Approve payment to contractor.',
+    status: 'Open',
+    createdAt: '2024-01-10',
+    resolvedAt: null,
+  },
+  {
+    id: 'dlg-002',
+    title: 'Dispute contract',
+    description: 'Raise a dispute for milestone 3.',
+    status: 'Pending',
+    createdAt: '2024-01-12',
+    resolvedAt: null,
+  },
+  {
+    id: 'dlg-003',
+    title: 'Project closure',
+    description: 'Final sign-off and close.',
+    status: 'Closed',
+    createdAt: '2024-01-20',
+    resolvedAt: '2024-01-25',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Loading state
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — loading state', () => {
+  it('renders the loading skeleton when isLoading=true', () => {
+    render(<DialogsList dialogs={[]} isLoading />);
+    expect(screen.getByTestId('dialogs-loading')).toBeInTheDocument();
+  });
+
+  it('loading skeleton has aria-busy="true"', () => {
+    render(<DialogsList dialogs={[]} isLoading />);
+    expect(screen.getByTestId('dialogs-loading')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('loading skeleton has an accessible aria-label', () => {
+    render(<DialogsList dialogs={[]} isLoading />);
+    expect(screen.getByTestId('dialogs-loading')).toHaveAttribute('aria-label');
+  });
+
+  it('does NOT show the list while loading', () => {
+    render(<DialogsList dialogs={sampleDialogs} isLoading />);
+    expect(screen.queryByTestId('dialogs-list')).not.toBeInTheDocument();
+  });
+
+  it('does NOT show the empty state while loading', () => {
+    render(<DialogsList dialogs={[]} isLoading />);
+    expect(screen.queryByTestId('dialogs-empty')).not.toBeInTheDocument();
+  });
+
+  it('does NOT show the error state while loading', () => {
+    render(<DialogsList dialogs={[]} isLoading error="fail" />);
+    expect(screen.queryByTestId('dialogs-error')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dialogs-loading')).toBeInTheDocument();
+  });
+
+  it('loading is mutually exclusive with all other states', () => {
+    render(<DialogsList dialogs={sampleDialogs} isLoading />);
+    expect(screen.getByTestId('dialogs-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('dialogs-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dialogs-empty')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dialogs-error')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — error state', () => {
+  it('renders error element when error prop is set', () => {
+    render(<DialogsList dialogs={[]} error="Failed to load." />);
+    expect(screen.getByTestId('dialogs-error')).toBeInTheDocument();
+  });
+
+  it('error element has role="alert"', () => {
+    render(<DialogsList dialogs={[]} error="Network error" />);
+    expect(screen.getByTestId('dialogs-error')).toHaveAttribute('role', 'alert');
+  });
+
+  it('renders the error message text', () => {
+    render(<DialogsList dialogs={[]} error="Something went wrong." />);
+    expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+  });
+
+  it('does NOT show the list in error state', () => {
+    render(<DialogsList dialogs={sampleDialogs} error="Oops" />);
+    expect(screen.queryByTestId('dialogs-list')).not.toBeInTheDocument();
+  });
+
+  it('does NOT show the loading skeleton in error state', () => {
+    render(<DialogsList dialogs={[]} error="Oops" />);
+    expect(screen.queryByTestId('dialogs-loading')).not.toBeInTheDocument();
+  });
+
+  it('error is mutually exclusive with all other states', () => {
+    render(<DialogsList dialogs={sampleDialogs} error="Oh no!" />);
+    expect(screen.getByTestId('dialogs-error')).toBeInTheDocument();
+    expect(screen.queryByTestId('dialogs-loading')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dialogs-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dialogs-empty')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — empty state', () => {
+  it('renders the empty state when dialogs is an empty array', () => {
+    render(<DialogsList dialogs={[]} />);
+    expect(screen.getByTestId('dialogs-empty')).toBeInTheDocument();
+  });
+
+  it('shows the "All" empty message by default', () => {
+    render(<DialogsList dialogs={[]} />);
+    expect(screen.getByText('There are no dialogs to display.')).toBeInTheDocument();
+  });
+
+  it('shows a filter-specific empty message when filter yields no results', () => {
+    const openOnly: DialogRecord[] = [sampleDialogs[0]]; // Open only
+    render(<DialogsList dialogs={openOnly} />);
+    fireEvent.click(screen.getByText('Filter Closed'));
+    expect(screen.getByTestId('dialogs-empty')).toBeInTheDocument();
+    expect(screen.getByText(/No dialogs match the "Closed" filter/)).toBeInTheDocument();
+  });
+
+  it('does NOT show the list when empty', () => {
+    render(<DialogsList dialogs={[]} />);
+    expect(screen.queryByTestId('dialogs-list')).not.toBeInTheDocument();
+  });
+
+  it('does NOT show loading skeleton when empty', () => {
+    render(<DialogsList dialogs={[]} />);
+    expect(screen.queryByTestId('dialogs-loading')).not.toBeInTheDocument();
+  });
+
+  it('does NOT show error state when empty', () => {
+    render(<DialogsList dialogs={[]} />);
+    expect(screen.queryByTestId('dialogs-error')).not.toBeInTheDocument();
+  });
+
+  it('empty is mutually exclusive with all other states', () => {
+    render(<DialogsList dialogs={[]} />);
+    expect(screen.getByTestId('dialogs-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('dialogs-loading')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dialogs-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dialogs-error')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success state
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — success state', () => {
+  it('renders the list when dialogs are provided', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('dialogs-list')).toBeInTheDocument();
+  });
+
+  it('renders one list item per dialog', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(sampleDialogs.length);
+  });
+
+  it('renders each dialog title', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    sampleDialogs.forEach((d) => {
+      expect(screen.getByText(d.title)).toBeInTheDocument();
+    });
+  });
+
+  it('renders each dialog id', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    sampleDialogs.forEach((d) => {
+      expect(screen.getByTestId(`dialog-id-${d.id}`)).toHaveTextContent(d.id);
+    });
+  });
+
+  it('renders each dialog status', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    sampleDialogs.forEach((d) => {
+      expect(screen.getByTestId(`dialog-status-${d.id}`)).toHaveTextContent(d.status);
+    });
+  });
+
+  it('does NOT show loading skeleton in success state', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.queryByTestId('dialogs-loading')).not.toBeInTheDocument();
+  });
+
+  it('does NOT show error in success state', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.queryByTestId('dialogs-error')).not.toBeInTheDocument();
+  });
+
+  it('does NOT show empty state in success state', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.queryByTestId('dialogs-empty')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State transitions
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — state transitions', () => {
+  it('transitions from loading → success', () => {
+    const { rerender } = render(<DialogsList dialogs={[]} isLoading />);
+    expect(screen.getByTestId('dialogs-loading')).toBeInTheDocument();
+    rerender(<DialogsList dialogs={sampleDialogs} isLoading={false} />);
+    expect(screen.queryByTestId('dialogs-loading')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dialogs-list')).toBeInTheDocument();
+  });
+
+  it('transitions from loading → empty', () => {
+    const { rerender } = render(<DialogsList dialogs={[]} isLoading />);
+    rerender(<DialogsList dialogs={[]} isLoading={false} />);
+    expect(screen.queryByTestId('dialogs-loading')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dialogs-empty')).toBeInTheDocument();
+  });
+
+  it('transitions from loading → error', () => {
+    const { rerender } = render(<DialogsList dialogs={[]} isLoading />);
+    rerender(<DialogsList dialogs={[]} isLoading={false} error="Request failed." />);
+    expect(screen.queryByTestId('dialogs-loading')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dialogs-error')).toBeInTheDocument();
+  });
+
+  it('transitions from error → success when error is cleared', () => {
+    const { rerender } = render(<DialogsList dialogs={sampleDialogs} error="Oops" />);
+    expect(screen.getByTestId('dialogs-error')).toBeInTheDocument();
+    rerender(<DialogsList dialogs={sampleDialogs} error={null} />);
+    expect(screen.queryByTestId('dialogs-error')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dialogs-list')).toBeInTheDocument();
+  });
+
+  it('transitions from success → empty when all dialogs removed', () => {
+    const { rerender } = render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('dialogs-list')).toBeInTheDocument();
+    rerender(<DialogsList dialogs={[]} />);
+    expect(screen.queryByTestId('dialogs-list')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dialogs-empty')).toBeInTheDocument();
+  });
+
+  it('loading takes precedence over error', () => {
+    render(<DialogsList dialogs={[]} isLoading error="fail" />);
+    expect(screen.getByTestId('dialogs-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('dialogs-error')).not.toBeInTheDocument();
+  });
+
+  it('filter: success → empty → success round-trip', () => {
+    const openOnly: DialogRecord[] = [sampleDialogs[0]];
+    render(<DialogsList dialogs={openOnly} />);
+    expect(screen.getByTestId('dialogs-list')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Filter Closed'));
+    expect(screen.queryByTestId('dialogs-list')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dialogs-empty')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Filter All'));
+    expect(screen.getByTestId('dialogs-list')).toBeInTheDocument();
+    expect(screen.queryByTestId('dialogs-empty')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — filtering', () => {
+  it('shows all dialogs when "Filter All" is active', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+  });
+
+  it('shows only Open dialogs when "Filter Open" is clicked', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    fireEvent.click(screen.getByText('Filter Open'));
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByTestId('dialog-status-dlg-001')).toHaveTextContent('Open');
+  });
+
+  it('shows only Pending dialogs when "Filter Pending" is clicked', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    fireEvent.click(screen.getByText('Filter Pending'));
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByTestId('dialog-status-dlg-002')).toHaveTextContent('Pending');
+  });
+
+  it('shows only Closed dialogs when "Filter Closed" is clicked', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    fireEvent.click(screen.getByText('Filter Closed'));
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByTestId('dialog-status-dlg-003')).toHaveTextContent('Closed');
+  });
+
+  it('filter button has aria-pressed="true" for the active filter', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    fireEvent.click(screen.getByText('Filter Open'));
+    expect(screen.getByText('Filter Open')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Filter All')).toHaveAttribute('aria-pressed', 'false');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Export controls — accessibility and disabled state
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — export controls accessibility', () => {
+  it('renders the CSV export button', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('export-csv-btn')).toBeInTheDocument();
+  });
+
+  it('renders the JSON export button', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('export-json-btn')).toBeInTheDocument();
+  });
+
+  it('CSV button has an accessible aria-label', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('export-csv-btn')).toHaveAttribute('aria-label', 'Export dialogs as CSV');
+  });
+
+  it('JSON button has an accessible aria-label', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('export-json-btn')).toHaveAttribute('aria-label', 'Export dialogs as JSON');
+  });
+
+  it('CSV button is enabled when dialogs are present', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('export-csv-btn')).not.toBeDisabled();
+  });
+
+  it('JSON button is enabled when dialogs are present', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('export-json-btn')).not.toBeDisabled();
+  });
+
+  it('CSV button is disabled when dialogs list is empty', () => {
+    render(<DialogsList dialogs={[]} />);
+    expect(screen.getByTestId('export-csv-btn')).toBeDisabled();
+  });
+
+  it('JSON button is disabled when dialogs list is empty', () => {
+    render(<DialogsList dialogs={[]} />);
+    expect(screen.getByTestId('export-json-btn')).toBeDisabled();
+  });
+
+  it('export buttons are disabled when filter produces empty results', () => {
+    const openOnly: DialogRecord[] = [sampleDialogs[0]];
+    render(<DialogsList dialogs={openOnly} />);
+    fireEvent.click(screen.getByText('Filter Closed'));
+    expect(screen.getByTestId('export-csv-btn')).toBeDisabled();
+    expect(screen.getByTestId('export-json-btn')).toBeDisabled();
+  });
+
+  it('export buttons re-enable when filter is reset to matching results', () => {
+    const openOnly: DialogRecord[] = [sampleDialogs[0]];
+    render(<DialogsList dialogs={openOnly} />);
+    fireEvent.click(screen.getByText('Filter Closed'));
+    expect(screen.getByTestId('export-csv-btn')).toBeDisabled();
+    fireEvent.click(screen.getByText('Filter All'));
+    expect(screen.getByTestId('export-csv-btn')).not.toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Export controls — download integration
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — export download integration', () => {
+  let csvSpy: jest.SpyInstance;
+  let jsonSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    csvSpy = jest.spyOn(exportDialogs, 'downloadDialogsCsv').mockImplementation(() => {});
+    jsonSpy = jest.spyOn(exportDialogs, 'downloadDialogsJson').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls downloadDialogsCsv with the full unfiltered list by default', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    fireEvent.click(screen.getByTestId('export-csv-btn'));
+    expect(csvSpy).toHaveBeenCalledTimes(1);
+    expect(csvSpy).toHaveBeenCalledWith(sampleDialogs);
+  });
+
+  it('calls downloadDialogsJson with the full unfiltered list by default', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    fireEvent.click(screen.getByTestId('export-json-btn'));
+    expect(jsonSpy).toHaveBeenCalledTimes(1);
+    expect(jsonSpy).toHaveBeenCalledWith(sampleDialogs);
+  });
+
+  it('respects active filter: CSV exports only the filtered subset', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    fireEvent.click(screen.getByText('Filter Open'));
+    fireEvent.click(screen.getByTestId('export-csv-btn'));
+    const exportedDialogs = csvSpy.mock.calls[0][0] as DialogRecord[];
+    expect(exportedDialogs).toHaveLength(1);
+    expect(exportedDialogs[0].id).toBe('dlg-001');
+  });
+
+  it('respects active filter: JSON exports only the filtered subset', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    fireEvent.click(screen.getByText('Filter Pending'));
+    fireEvent.click(screen.getByTestId('export-json-btn'));
+    const exportedDialogs = jsonSpy.mock.calls[0][0] as DialogRecord[];
+    expect(exportedDialogs).toHaveLength(1);
+    expect(exportedDialogs[0].id).toBe('dlg-002');
+  });
+
+  it('does not call download when CSV button is disabled (empty view)', () => {
+    render(<DialogsList dialogs={[]} />);
+    fireEvent.click(screen.getByTestId('export-csv-btn'));
+    expect(csvSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not call download when JSON button is disabled (empty view)', () => {
+    render(<DialogsList dialogs={[]} />);
+    fireEvent.click(screen.getByTestId('export-json-btn'));
+    expect(jsonSpy).not.toHaveBeenCalled();
+  });
+
+  it('exports the Closed subset when Closed filter is active', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    fireEvent.click(screen.getByText('Filter Closed'));
+    fireEvent.click(screen.getByTestId('export-json-btn'));
+    const exportedDialogs = jsonSpy.mock.calls[0][0] as DialogRecord[];
+    expect(exportedDialogs).toHaveLength(1);
+    expect(exportedDialogs[0].status).toBe('Closed');
+  });
+});

--- a/src/components/dialogs/DialogsList.tsx
+++ b/src/components/dialogs/DialogsList.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+/**
+ * DialogsList
+ *
+ * Renders a filterable list of dialog records and exposes accessible CSV/JSON
+ * export controls for the currently-visible (filtered) view.
+ *
+ * Export behaviour:
+ *  - "Export CSV"  — serialises the filtered rows to RFC-4180-compliant CSV
+ *    with safe field escaping (commas, quotes, newlines, formula injection)
+ *    and triggers a client-side download. No server round-trip.
+ *  - "Export JSON" — serialises the filtered rows to pretty-printed JSON and
+ *    triggers a client-side download.
+ *
+ * Both controls are keyboard-operable and labelled for assistive technology.
+ * An empty-view export guard disables the buttons when there is nothing to export.
+ */
+
+import React, { useState, useMemo } from 'react';
+import {
+  type DialogRecord,
+  type DialogStatus,
+  downloadDialogsCsv,
+  downloadDialogsJson,
+} from '@/lib/exportDialogs';
+
+export type { DialogRecord, DialogStatus };
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface DialogsListProps {
+  /** The full list of dialog records to display and export. */
+  dialogs: DialogRecord[];
+  /** When true the loading skeleton is shown. */
+  isLoading?: boolean;
+  /** When provided the error state is rendered instead of the list. */
+  error?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// DialogsList
+// ---------------------------------------------------------------------------
+
+/**
+ * Filterable dialogs list with accessible CSV/JSON export controls.
+ *
+ * States:
+ *  - Loading   — shows an animated skeleton; all other UI is hidden.
+ *  - Error     — shows an alert with the error message; all other UI is hidden.
+ *  - Empty     — shows a contextual empty-state message after filtering.
+ *  - Success   — shows the filtered list and export controls.
+ *
+ * States are mutually exclusive. Loading takes precedence over error.
+ */
+export const DialogsList = ({
+  dialogs,
+  isLoading = false,
+  error = null,
+}: DialogsListProps) => {
+  const [filter, setFilter] = useState<DialogStatus>('All');
+
+  const filteredDialogs = useMemo(() => {
+    if (filter === 'All') return dialogs;
+    return dialogs.filter((d) => d.status === filter);
+  }, [dialogs, filter]);
+
+  // ── Loading state ─────────────────────────────────────────────────────────
+  if (isLoading) {
+    return (
+      <div
+        aria-busy="true"
+        aria-label="Loading dialogs…"
+        data-testid="dialogs-loading"
+        className="flex flex-col gap-3 p-4 animate-pulse"
+      >
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-14 bg-gray-200 dark:bg-gray-700 rounded" />
+        ))}
+      </div>
+    );
+  }
+
+  // ── Error state ───────────────────────────────────────────────────────────
+  if (error) {
+    return (
+      <div
+        role="alert"
+        data-testid="dialogs-error"
+        className="p-4 text-red-700 bg-red-50 rounded"
+      >
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  const hasExportData = filteredDialogs.length > 0;
+
+  return (
+    <div>
+      {/* Filter controls */}
+      <div
+        role="group"
+        aria-label="Filter dialogs by status"
+        className="flex gap-2 mb-4"
+      >
+        {(['All', 'Open', 'Pending', 'Closed'] as const).map((status) => (
+          <button
+            key={status}
+            type="button"
+            aria-pressed={filter === status}
+            onClick={() => setFilter(status)}
+            className={[
+              'px-3 py-1 rounded text-sm border',
+              filter === status
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50',
+            ].join(' ')}
+          >
+            {`Filter ${status}`}
+          </button>
+        ))}
+      </div>
+
+      {/* Export controls */}
+      <div
+        aria-label="Export dialogs"
+        className="flex gap-2 mb-4"
+        data-testid="dialogs-export-controls"
+      >
+        <button
+          type="button"
+          disabled={!hasExportData}
+          aria-label="Export dialogs as CSV"
+          data-testid="export-csv-btn"
+          onClick={() => downloadDialogsCsv(filteredDialogs)}
+          className={[
+            'px-3 py-1 rounded text-sm border',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500',
+            hasExportData
+              ? 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+              : 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed',
+          ].join(' ')}
+        >
+          Export CSV
+        </button>
+        <button
+          type="button"
+          disabled={!hasExportData}
+          aria-label="Export dialogs as JSON"
+          data-testid="export-json-btn"
+          onClick={() => downloadDialogsJson(filteredDialogs)}
+          className={[
+            'px-3 py-1 rounded text-sm border',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500',
+            hasExportData
+              ? 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+              : 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed',
+          ].join(' ')}
+        >
+          Export JSON
+        </button>
+      </div>
+
+      {/* Empty state */}
+      {filteredDialogs.length === 0 ? (
+        <div
+          data-testid="dialogs-empty"
+          className="py-12 text-center text-gray-500"
+        >
+          <p className="text-lg font-medium">No dialogs found</p>
+          <p className="text-sm mt-1">
+            {filter === 'All'
+              ? 'There are no dialogs to display.'
+              : `No dialogs match the "${filter}" filter.`}
+          </p>
+        </div>
+      ) : (
+        /* Success / list state */
+        <ul
+          data-testid="dialogs-list"
+          className="divide-y divide-gray-100"
+        >
+          {filteredDialogs.map((d) => (
+            <li
+              key={d.id}
+              data-testid={`dialog-item-${d.id}`}
+              className="py-3 flex items-start justify-between gap-4"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="font-medium truncate">{d.title}</p>
+                <p className="text-sm text-gray-500 truncate">{d.description}</p>
+              </div>
+              <div className="flex flex-col items-end gap-1 shrink-0">
+                <span
+                  data-testid={`dialog-status-${d.id}`}
+                  className="text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-700"
+                >
+                  {d.status}
+                </span>
+                <code
+                  data-testid={`dialog-id-${d.id}`}
+                  className="text-xs text-gray-400 font-mono"
+                >
+                  {d.id}
+                </code>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/src/lib/__tests__/exportDialogs.test.ts
+++ b/src/lib/__tests__/exportDialogs.test.ts
@@ -1,0 +1,371 @@
+/**
+ * exportDialogs.test.ts
+ *
+ * Tests for src/lib/exportDialogs.ts (issue #53).
+ * Covers: CSV escaping, formula injection neutralisation, serialisation,
+ * filter-respect, empty-view handling, and download trigger.
+ */
+
+import {
+  csvEscape,
+  dialogsToCsv,
+  dialogsToJson,
+  triggerDownload,
+  downloadDialogsCsv,
+  downloadDialogsJson,
+  type DialogRecord,
+} from '../exportDialogs';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeDialog = (overrides: Partial<DialogRecord> = {}): DialogRecord => ({
+  id: 'dlg-001',
+  title: 'Release funds',
+  description: 'Confirm fund release to contractor.',
+  status: 'Open',
+  createdAt: '2024-01-15',
+  resolvedAt: null,
+  ...overrides,
+});
+
+const sampleDialogs: DialogRecord[] = [
+  makeDialog({ id: 'dlg-001', title: 'Release funds', status: 'Open' }),
+  makeDialog({ id: 'dlg-002', title: 'Dispute contract', status: 'Pending', resolvedAt: null }),
+  makeDialog({ id: 'dlg-003', title: 'Close project', status: 'Closed', resolvedAt: '2024-02-01' }),
+];
+
+// ---------------------------------------------------------------------------
+// csvEscape
+// ---------------------------------------------------------------------------
+
+describe('csvEscape', () => {
+  it('returns an empty string for null', () => {
+    expect(csvEscape(null)).toBe('');
+  });
+
+  it('returns an empty string for undefined', () => {
+    expect(csvEscape(undefined)).toBe('');
+  });
+
+  it('returns plain string unchanged when no special chars', () => {
+    expect(csvEscape('hello')).toBe('hello');
+  });
+
+  it('wraps in double-quotes when value contains a comma', () => {
+    expect(csvEscape('hello, world')).toBe('"hello, world"');
+  });
+
+  it('wraps in double-quotes when value contains a double-quote', () => {
+    expect(csvEscape('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it('doubles embedded double-quotes', () => {
+    expect(csvEscape('a"b"c')).toBe('"a""b""c"');
+  });
+
+  it('wraps in double-quotes when value contains a newline', () => {
+    expect(csvEscape('line1\nline2')).toBe('"line1\nline2"');
+  });
+
+  it('wraps in double-quotes when value contains a carriage return', () => {
+    expect(csvEscape('line1\rline2')).toBe('"line1\rline2"');
+  });
+
+  it('prefixes = with tab to neutralise formula injection', () => {
+    const result = csvEscape('=SUM(A1)');
+    expect(result.startsWith('\t')).toBe(true);
+    expect(result).toContain('=SUM(A1)');
+  });
+
+  it('prefixes + with tab to neutralise formula injection', () => {
+    const result = csvEscape('+cmd|...');
+    expect(result.startsWith('\t')).toBe(true);
+  });
+
+  it('prefixes - with tab to neutralise formula injection', () => {
+    const result = csvEscape('-2+3');
+    expect(result.startsWith('\t')).toBe(true);
+  });
+
+  it('prefixes @ with tab to neutralise formula injection', () => {
+    const result = csvEscape('@SUM');
+    expect(result.startsWith('\t')).toBe(true);
+  });
+
+  it('converts numbers to strings', () => {
+    expect(csvEscape(42)).toBe('42');
+  });
+
+  it('converts booleans to strings', () => {
+    expect(csvEscape(true)).toBe('true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dialogsToCsv — header row
+// ---------------------------------------------------------------------------
+
+describe('dialogsToCsv — header row', () => {
+  it('first line is the header row', () => {
+    const csv = dialogsToCsv([]);
+    const firstLine = csv.split('\n')[0];
+    expect(firstLine).toBe('id,title,description,status,createdAt,resolvedAt');
+  });
+
+  it('produces only a header row for an empty array', () => {
+    const csv = dialogsToCsv([]);
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dialogsToCsv — data rows
+// ---------------------------------------------------------------------------
+
+describe('dialogsToCsv — data rows', () => {
+  it('produces one data row per dialog', () => {
+    const csv = dialogsToCsv(sampleDialogs);
+    const lines = csv.split('\n');
+    // header + 3 data rows
+    expect(lines).toHaveLength(4);
+  });
+
+  it('each row contains the correct id', () => {
+    const csv = dialogsToCsv(sampleDialogs);
+    const lines = csv.split('\n');
+    expect(lines[1]).toMatch(/dlg-001/);
+    expect(lines[2]).toMatch(/dlg-002/);
+    expect(lines[3]).toMatch(/dlg-003/);
+  });
+
+  it('each row contains the title', () => {
+    const csv = dialogsToCsv([makeDialog({ id: 'x', title: 'My Dialog' })]);
+    expect(csv).toContain('My Dialog');
+  });
+
+  it('each row contains the status', () => {
+    const csv = dialogsToCsv([makeDialog({ id: 'x', status: 'Pending' })]);
+    expect(csv).toContain('Pending');
+  });
+
+  it('resolvedAt is empty string when null', () => {
+    const csv = dialogsToCsv([makeDialog({ id: 'x', resolvedAt: null })]);
+    const dataRow = csv.split('\n')[1];
+    // last field should be empty
+    expect(dataRow.endsWith(',')).toBe(true);
+  });
+
+  it('resolvedAt is included when provided', () => {
+    const csv = dialogsToCsv([makeDialog({ id: 'x', resolvedAt: '2024-03-01' })]);
+    expect(csv).toContain('2024-03-01');
+  });
+
+  it('escapes commas in title correctly', () => {
+    const csv = dialogsToCsv([makeDialog({ id: 'x', title: 'Hello, World' })]);
+    expect(csv).toContain('"Hello, World"');
+  });
+
+  it('escapes quotes in description correctly', () => {
+    const csv = dialogsToCsv([makeDialog({ id: 'x', description: 'Say "hi"' })]);
+    expect(csv).toContain('"Say ""hi"""');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dialogsToJson
+// ---------------------------------------------------------------------------
+
+describe('dialogsToJson', () => {
+  it('returns valid JSON', () => {
+    const json = dialogsToJson(sampleDialogs);
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+
+  it('returns an empty array JSON for an empty input', () => {
+    expect(dialogsToJson([])).toBe('[]');
+  });
+
+  it('round-trips all fields', () => {
+    const json = dialogsToJson(sampleDialogs);
+    const parsed = JSON.parse(json) as DialogRecord[];
+    expect(parsed).toHaveLength(sampleDialogs.length);
+    parsed.forEach((d, i) => {
+      expect(d.id).toBe(sampleDialogs[i].id);
+      expect(d.title).toBe(sampleDialogs[i].title);
+      expect(d.status).toBe(sampleDialogs[i].status);
+    });
+  });
+
+  it('preserves null resolvedAt', () => {
+    const json = dialogsToJson([makeDialog({ id: 'x', resolvedAt: null })]);
+    const parsed = JSON.parse(json) as DialogRecord[];
+    expect(parsed[0].resolvedAt).toBeNull();
+  });
+
+  it('is pretty-printed (contains newlines and spaces)', () => {
+    const json = dialogsToJson(sampleDialogs);
+    expect(json).toContain('\n');
+    expect(json).toContain('  ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// triggerDownload
+// ---------------------------------------------------------------------------
+
+describe('triggerDownload', () => {
+  let createObjectURLMock: jest.Mock;
+  let revokeObjectURLMock: jest.Mock;
+  let appendChildSpy: jest.SpyInstance;
+  let removeChildSpy: jest.SpyInstance;
+  let clickSpy: jest.Mock;
+
+  beforeEach(() => {
+    createObjectURLMock = jest.fn().mockReturnValue('blob:fake-url');
+    revokeObjectURLMock = jest.fn();
+    clickSpy = jest.fn();
+
+    global.URL.createObjectURL = createObjectURLMock;
+    global.URL.revokeObjectURL = revokeObjectURLMock;
+
+    // Intercept createElement('a') to capture the anchor
+    const originalCreateElement = document.createElement.bind(document);
+    jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = originalCreateElement(tag);
+      if (tag === 'a') {
+        Object.defineProperty(el, 'click', { value: clickSpy, writable: true });
+      }
+      return el;
+    });
+
+    appendChildSpy = jest.spyOn(document.body, 'appendChild');
+    removeChildSpy = jest.spyOn(document.body, 'removeChild');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls URL.createObjectURL with a Blob', () => {
+    triggerDownload('content', 'file.txt', 'text/plain');
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+    expect(createObjectURLMock.mock.calls[0][0]).toBeInstanceOf(Blob);
+  });
+
+  it('sets the anchor href to the object URL', () => {
+    triggerDownload('content', 'file.csv', 'text/csv');
+    const anchor = appendChildSpy.mock.calls[0][0] as HTMLAnchorElement;
+    expect(anchor.href).toContain('blob:fake-url');
+  });
+
+  it('sets the anchor download attribute to the provided filename', () => {
+    triggerDownload('content', 'my-file.csv', 'text/csv');
+    const anchor = appendChildSpy.mock.calls[0][0] as HTMLAnchorElement;
+    expect(anchor.download).toBe('my-file.csv');
+  });
+
+  it('appends then removes the anchor from the body', () => {
+    triggerDownload('data', 'test.json', 'application/json');
+    expect(appendChildSpy).toHaveBeenCalledTimes(1);
+    expect(removeChildSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicks the anchor to trigger the download', () => {
+    triggerDownload('data', 'test.csv', 'text/csv');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('revokes the object URL after download', () => {
+    triggerDownload('data', 'test.csv', 'text/csv');
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:fake-url');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadDialogsCsv / downloadDialogsJson — integration
+// ---------------------------------------------------------------------------
+
+describe('downloadDialogsCsv', () => {
+  beforeEach(() => {
+    global.URL.createObjectURL = jest.fn().mockReturnValue('blob:fake');
+    global.URL.revokeObjectURL = jest.fn();
+    jest.spyOn(document.body, 'appendChild');
+    jest.spyOn(document.body, 'removeChild');
+    const orig = document.createElement.bind(document);
+    jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = orig(tag);
+      if (tag === 'a') {
+        Object.defineProperty(el, 'click', { value: jest.fn(), writable: true });
+      }
+      return el;
+    });
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('creates a Blob with text/csv mime type', () => {
+    downloadDialogsCsv(sampleDialogs);
+    const blob = (global.URL.createObjectURL as jest.Mock).mock.calls[0][0] as Blob;
+    expect(blob.type).toContain('text/csv');
+  });
+
+  it('uses default filename dialogs.csv', () => {
+    downloadDialogsCsv(sampleDialogs);
+    const appendedAnchor = (document.body.appendChild as jest.Mock).mock.calls[0][0] as HTMLAnchorElement;
+    expect(appendedAnchor.download).toBe('dialogs.csv');
+  });
+
+  it('accepts a custom filename', () => {
+    downloadDialogsCsv(sampleDialogs, 'custom.csv');
+    const anchor = (document.body.appendChild as jest.Mock).mock.calls[0][0] as HTMLAnchorElement;
+    expect(anchor.download).toBe('custom.csv');
+  });
+
+  it('works with an empty array (exports only headers)', () => {
+    expect(() => downloadDialogsCsv([])).not.toThrow();
+  });
+});
+
+describe('downloadDialogsJson', () => {
+  beforeEach(() => {
+    global.URL.createObjectURL = jest.fn().mockReturnValue('blob:fake');
+    global.URL.revokeObjectURL = jest.fn();
+    jest.spyOn(document.body, 'appendChild');
+    jest.spyOn(document.body, 'removeChild');
+    const orig = document.createElement.bind(document);
+    jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = orig(tag);
+      if (tag === 'a') {
+        Object.defineProperty(el, 'click', { value: jest.fn(), writable: true });
+      }
+      return el;
+    });
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('creates a Blob with application/json mime type', () => {
+    downloadDialogsJson(sampleDialogs);
+    const blob = (global.URL.createObjectURL as jest.Mock).mock.calls[0][0] as Blob;
+    expect(blob.type).toContain('application/json');
+  });
+
+  it('uses default filename dialogs.json', () => {
+    downloadDialogsJson(sampleDialogs);
+    const anchor = (document.body.appendChild as jest.Mock).mock.calls[0][0] as HTMLAnchorElement;
+    expect(anchor.download).toBe('dialogs.json');
+  });
+
+  it('accepts a custom filename', () => {
+    downloadDialogsJson(sampleDialogs, 'export.json');
+    const anchor = (document.body.appendChild as jest.Mock).mock.calls[0][0] as HTMLAnchorElement;
+    expect(anchor.download).toBe('export.json');
+  });
+
+  it('works with an empty array', () => {
+    expect(() => downloadDialogsJson([])).not.toThrow();
+  });
+});

--- a/src/lib/exportDialogs.ts
+++ b/src/lib/exportDialogs.ts
@@ -1,0 +1,168 @@
+/**
+ * exportDialogs.ts
+ *
+ * Client-side CSV and JSON export helpers for the dialogs view.
+ * All CSV values are safely escaped to prevent formula injection and handle
+ * embedded commas, quotes, and newlines.
+ *
+ * No server round-trip is required — exports are generated in-browser and
+ * triggered as file downloads via a temporary anchor element.
+ */
+
+export type DialogStatus = 'All' | 'Open' | 'Closed' | 'Pending';
+
+export interface DialogRecord {
+  id: string;
+  title: string;
+  description: string;
+  status: Exclude<DialogStatus, 'All'>;
+  createdAt: string;
+  resolvedAt?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// CSV helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Safely escape a single CSV field value.
+ *
+ * Rules applied (RFC 4180):
+ *  - Null / undefined → empty string.
+ *  - If the value contains a comma, double-quote, newline, or carriage-return
+ *    the entire field is wrapped in double-quotes and any embedded double-quotes
+ *    are doubled ("").
+ *  - Leading `=`, `+`, `-`, `@` are prefixed with a tab character to neutralise
+ *    CSV formula injection (defensive measure for spreadsheet consumers).
+ */
+export function csvEscape(value: unknown): string {
+  const raw = value == null ? '' : String(value);
+
+  // Neutralise spreadsheet formula injection
+  const safe =
+    raw.length > 0 && ['=', '+', '-', '@'].includes(raw[0])
+      ? `\t${raw}`
+      : raw;
+
+  // Quote the field if it contains characters that require quoting
+  if (
+    safe.includes('"') ||
+    safe.includes(',') ||
+    safe.includes('\n') ||
+    safe.includes('\r')
+  ) {
+    return '"' + safe.replace(/"/g, '""') + '"';
+  }
+
+  return safe;
+}
+
+// ---------------------------------------------------------------------------
+// Serialisation
+// ---------------------------------------------------------------------------
+
+const CSV_HEADERS: Array<keyof DialogRecord | 'resolvedAt'> = [
+  'id',
+  'title',
+  'description',
+  'status',
+  'createdAt',
+  'resolvedAt',
+];
+
+/**
+ * Serialise an array of DialogRecord objects to CSV string.
+ *
+ * @param dialogs - Array of dialog records (already filtered by the caller).
+ * @returns A UTF-8 CSV string with a header row followed by one data row per dialog.
+ */
+export function dialogsToCsv(dialogs: DialogRecord[]): string {
+  const headerRow = CSV_HEADERS.map(csvEscape).join(',');
+
+  const dataRows = dialogs.map((d) =>
+    [
+      csvEscape(d.id),
+      csvEscape(d.title),
+      csvEscape(d.description),
+      csvEscape(d.status),
+      csvEscape(d.createdAt),
+      csvEscape(d.resolvedAt ?? ''),
+    ].join(','),
+  );
+
+  return [headerRow, ...dataRows].join('\n');
+}
+
+/**
+ * Serialise an array of DialogRecord objects to a pretty-printed JSON string.
+ *
+ * @param dialogs - Array of dialog records (already filtered by the caller).
+ */
+export function dialogsToJson(dialogs: DialogRecord[]): string {
+  return JSON.stringify(dialogs, null, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Download trigger
+// ---------------------------------------------------------------------------
+
+/**
+ * Triggers a client-side file download without a server round-trip.
+ *
+ * Creates a temporary in-memory Blob URL, clicks a hidden anchor element, and
+ * immediately revokes the URL to free memory.
+ *
+ * @param content  - The file content as a string.
+ * @param filename - Suggested download filename.
+ * @param mimeType - MIME type of the content (e.g. `"text/csv;charset=utf-8;"`).
+ */
+export function triggerDownload(
+  content: string,
+  filename: string,
+  mimeType: string,
+): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+// ---------------------------------------------------------------------------
+// Public download API
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert `dialogs` to CSV and trigger a browser download.
+ *
+ * @param dialogs  - The currently visible (already-filtered) dialog records.
+ * @param filename - Defaults to `"dialogs.csv"`.
+ */
+export function downloadDialogsCsv(
+  dialogs: DialogRecord[],
+  filename = 'dialogs.csv',
+): void {
+  triggerDownload(dialogsToCsv(dialogs), filename, 'text/csv;charset=utf-8;');
+}
+
+/**
+ * Convert `dialogs` to JSON and trigger a browser download.
+ *
+ * @param dialogs  - The currently visible (already-filtered) dialog records.
+ * @param filename - Defaults to `"dialogs.json"`.
+ */
+export function downloadDialogsJson(
+  dialogs: DialogRecord[],
+  filename = 'dialogs.json',
+): void {
+  triggerDownload(
+    dialogsToJson(dialogs),
+    filename,
+    'application/json;charset=utf-8;',
+  );
+}


### PR DESCRIPTION
- Add exportDialogs lib with csvEscape (RFC 4180 + formula injection neutralisation via tab-prefix), dialogsToCsv, dialogsToJson, triggerDownload, downloadDialogsCsv, downloadDialogsJson
- Add DialogsList component with status filter (All/Open/Pending/Closed), Export CSV and Export JSON buttons that export the currently-filtered view, loading/error/empty/success states, disabled export guard when view is empty, accessible aria-labels on all controls
- Add 43 unit tests for exportDialogs: escaping edge cases, formula injection guard, CSV/JSON serialisation, download trigger, empty view
- Add 57 component tests for DialogsList: all 4 states mutually exclusive, state transitions, filtering, export filter-respect, empty-view guard

Closes #53

## Description

<!-- Summarize the changes in this PR and the motivation behind them. -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

closes #858 