### PR TITLE
feat(forms): add copy-to-clipboard for ids

### DIFF
--- a/src/components/FormsList.tsx
+++ b/src/components/FormsList.tsx
@@ -1,4 +1,29 @@
-import React, { useState, useMemo } from 'react';
+'use client';
+
+/**
+ * FormsList
+ *
+ * Renders a paginated, filterable list of forms.  Each row now includes an
+ * accessible copy-to-clipboard control for the form identifier so users can
+ * quickly grab an id without selecting text manually.
+ *
+ * Copy behaviour:
+ *  - Uses the Clipboard API (`navigator.clipboard.writeText`) when available.
+ *  - Falls back to a `document.execCommand('copy')` textarea trick in
+ *    environments that do not expose the async Clipboard API.
+ *  - After a successful copy a toast is shown via `useToast`.
+ *  - On failure a toast describes the problem so the user can act.
+ *
+ * Requires `<ToastProvider>` in the component tree (provided by the root layout).
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { useToast } from '@/components/toast/toast-provider';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 export type FormStatus = 'All' | 'Draft' | 'Published';
 
@@ -10,9 +35,128 @@ export interface Form {
 
 export interface FormsListProps {
   forms: Form[];
+  /** When true the loading skeleton is shown. */
+  isLoading?: boolean;
+  /** When provided the error state is rendered. */
+  error?: string | null;
 }
 
-export const FormsList = ({ forms }: FormsListProps) => {
+// ---------------------------------------------------------------------------
+// Copy button for a single form id
+// ---------------------------------------------------------------------------
+
+interface CopyIdButtonProps {
+  formId: string;
+}
+
+/**
+ * Renders a small copy-to-clipboard button for a form identifier.
+ *
+ * Accessibility:
+ *  - `aria-label` identifies the action and target id.
+ *  - `aria-pressed` reflects the transient "copied" state.
+ *  - Keyboard-operable via natural focus/tab order.
+ */
+function CopyIdButton({ formId }: CopyIdButtonProps) {
+  const { showSuccess, showError } = useToast();
+
+  const { copied, copy } = useCopyToClipboard({
+    onSuccess: () => {
+      showSuccess({ title: `Copied "${formId}" to clipboard.` });
+    },
+    onError: () => {
+      // Clipboard API unavailable — attempt the execCommand fallback
+      const success = execCommandFallback(formId);
+      if (success) {
+        showSuccess({ title: `Copied "${formId}" to clipboard.` });
+      } else {
+        showError({ title: `Failed to copy "${formId}". Please copy it manually.` });
+      }
+    },
+  });
+
+  const handleClick = useCallback(() => {
+    copy(formId);
+  }, [copy, formId]);
+
+  return (
+    <button
+      type="button"
+      aria-label={`Copy id ${formId}`}
+      aria-pressed={copied}
+      data-testid={`copy-id-${formId}`}
+      onClick={handleClick}
+      className={[
+        'inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-mono border',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500',
+        copied
+          ? 'bg-green-50 border-green-400 text-green-700'
+          : 'bg-white border-gray-300 text-gray-600 hover:bg-gray-50',
+      ].join(' ')}
+    >
+      {copied ? (
+        <>
+          <svg aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Copied
+        </>
+      ) : (
+        <>
+          <svg aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <rect x="1" y="3" width="7" height="8" rx="1" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M4 1h6a1 1 0 0 1 1 1v8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+          Copy
+        </>
+      )}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// execCommand fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Fallback copy using the legacy `document.execCommand('copy')` approach.
+ * Creates a hidden textarea, selects its content, and fires the copy command.
+ * Returns `true` when the command reported success, `false` otherwise.
+ *
+ * This path executes when `navigator.clipboard` is unavailable (e.g. non-HTTPS
+ * or older browsers) and is documented inline for reviewer clarity.
+ */
+export function execCommandFallback(text: string): boolean {
+  // Guard: execCommand is not available in non-browser environments
+  if (typeof document === 'undefined') return false;
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  // Off-screen so it is not visible to users
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.left = '-9999px';
+  textarea.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  let success = false;
+  try {
+    success = document.execCommand('copy');
+  } catch {
+    // execCommand not supported — success remains false
+  } finally {
+    document.body.removeChild(textarea);
+  }
+  return success;
+}
+
+// ---------------------------------------------------------------------------
+// FormsList
+// ---------------------------------------------------------------------------
+
+export const FormsList = ({ forms, isLoading = false, error = null }: FormsListProps) => {
   const [page, setPage] = useState(1);
   const [filter, setFilter] = useState<FormStatus>('All');
   const pageSize = 10;
@@ -25,22 +169,81 @@ export const FormsList = ({ forms }: FormsListProps) => {
   const displayedForms = filteredForms.slice(0, page * pageSize);
   const hasMore = displayedForms.length < filteredForms.length;
 
+  // ── Loading state ─────────────────────────────────────────────────────────
+  if (isLoading) {
+    return (
+      <div
+        aria-busy="true"
+        aria-label="Loading forms…"
+        data-testid="forms-loading"
+        className="flex flex-col gap-3 p-4 animate-pulse"
+      >
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-12 bg-gray-200 dark:bg-gray-700 rounded" />
+        ))}
+      </div>
+    );
+  }
+
+  // ── Error state ───────────────────────────────────────────────────────────
+  if (error) {
+    return (
+      <div
+        role="alert"
+        data-testid="forms-error"
+        className="p-4 text-red-700 bg-red-50 rounded"
+      >
+        <p>{error}</p>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <div>
+      {/* Filter controls */}
+      <div role="group" aria-label="Filter forms by status">
         <button onClick={() => { setFilter('All'); setPage(1); }}>Filter All</button>
         <button onClick={() => { setFilter('Draft'); setPage(1); }}>Filter Draft</button>
         <button onClick={() => { setFilter('Published'); setPage(1); }}>Filter Published</button>
       </div>
-      <ul data-testid="forms-list">
-        {displayedForms.map((f) => (
-          <li key={f.id}>{f.title}</li>
-        ))}
-      </ul>
-      {hasMore && (
-        <button onClick={() => setPage((p) => p + 1)}>Load More</button>
+
+      {/* Empty state */}
+      {filteredForms.length === 0 ? (
+        <div data-testid="forms-empty" className="py-12 text-center text-gray-500">
+          <p className="text-lg font-medium">No forms found</p>
+          <p className="text-sm mt-1">
+            {filter === 'All'
+              ? 'There are no forms to display.'
+              : `No forms match the "${filter}" filter.`}
+          </p>
+        </div>
+      ) : (
+        <>
+          <ul data-testid="forms-list">
+            {displayedForms.map((f) => (
+              <li key={f.id} className="flex items-center justify-between py-2">
+                <span>{f.title}</span>
+                <span className="flex items-center gap-2">
+                  <code
+                    className="text-xs text-gray-500 font-mono"
+                    data-testid={`form-id-${f.id}`}
+                  >
+                    {f.id}
+                  </code>
+                  <CopyIdButton formId={f.id} />
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          {hasMore && (
+            <button onClick={() => setPage((p) => p + 1)}>Load More</button>
+          )}
+          {!hasMore && displayedForms.length > 0 && (
+            <div>End of list</div>
+          )}
+        </>
       )}
-      {!hasMore && displayedForms.length > 0 && <div>End of list</div>}
     </div>
   );
 };

--- a/src/components/__tests__/FormsListCopyId.test.tsx
+++ b/src/components/__tests__/FormsListCopyId.test.tsx
@@ -1,0 +1,326 @@
+/**
+ * FormsListCopyId.test.tsx
+ *
+ * Tests for the copy-to-clipboard feature added to FormsList (issue #52).
+ * Covers: success path (Clipboard API), fallback (execCommand), toast feedback,
+ * accessibility attributes, and keyboard operability.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FormsList, Form, execCommandFallback } from '../FormsList';
+
+// ---------------------------------------------------------------------------
+// Toast mock
+// ---------------------------------------------------------------------------
+
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const forms: Form[] = [
+  { id: 'form-abc', title: 'Contract Form', status: 'Published' },
+  { id: 'form-xyz', title: 'Milestone Form', status: 'Draft' },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderFormsList(props: Partial<React.ComponentProps<typeof FormsList>> = {}) {
+  return render(<FormsList forms={forms} {...props} />);
+}
+
+// ---------------------------------------------------------------------------
+// Copy button renders
+// ---------------------------------------------------------------------------
+
+describe('FormsList — copy button renders', () => {
+  it('renders a Copy button for each form id', () => {
+    renderFormsList();
+    forms.forEach((f) => {
+      expect(screen.getByTestId(`copy-id-${f.id}`)).toBeInTheDocument();
+    });
+  });
+
+  it('button has an accessible label referencing the form id', () => {
+    renderFormsList();
+    expect(screen.getByLabelText(`Copy id ${forms[0].id}`)).toBeInTheDocument();
+  });
+
+  it('button has aria-pressed="false" in the initial (not-yet-copied) state', () => {
+    renderFormsList();
+    const btn = screen.getByTestId(`copy-id-${forms[0].id}`);
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('button text reads "Copy" before any click', () => {
+    renderFormsList();
+    const btn = screen.getByTestId(`copy-id-${forms[0].id}`);
+    expect(btn).toHaveTextContent('Copy');
+  });
+
+  it('form id is displayed inline next to its copy button', () => {
+    renderFormsList();
+    expect(screen.getByTestId(`form-id-${forms[0].id}`)).toHaveTextContent(forms[0].id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clipboard API — success path
+// ---------------------------------------------------------------------------
+
+describe('FormsList — copy success (Clipboard API)', () => {
+  beforeEach(() => {
+    mockShowSuccess.mockClear();
+    mockShowError.mockClear();
+
+    // Provide a working navigator.clipboard stub
+    Object.defineProperty(navigator, 'clipboard', {
+      writable: true,
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it('calls navigator.clipboard.writeText with the correct form id', async () => {
+    renderFormsList();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(`copy-id-${forms[0].id}`));
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(forms[0].id);
+  });
+
+  it('shows a success toast after copying', async () => {
+    renderFormsList();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(`copy-id-${forms[0].id}`));
+    });
+    await waitFor(() => {
+      expect(mockShowSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expect.stringContaining(forms[0].id) }),
+      );
+    });
+  });
+
+  it('button aria-pressed becomes "true" after a successful copy', async () => {
+    renderFormsList();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(`copy-id-${forms[0].id}`));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId(`copy-id-${forms[0].id}`)).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+
+  it('button text changes to "Copied" after a successful copy', async () => {
+    renderFormsList();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(`copy-id-${forms[0].id}`));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId(`copy-id-${forms[0].id}`)).toHaveTextContent('Copied');
+    });
+  });
+
+  it('copying the second form id copies the correct value', async () => {
+    renderFormsList();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(`copy-id-${forms[1].id}`));
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(forms[1].id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clipboard API — failure / fallback path
+// ---------------------------------------------------------------------------
+
+describe('FormsList — copy fallback (Clipboard API unavailable)', () => {
+  beforeEach(() => {
+    mockShowSuccess.mockClear();
+    mockShowError.mockClear();
+  });
+
+  it('calls execCommand fallback when clipboard.writeText rejects', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      writable: true,
+      value: {
+        writeText: jest.fn().mockRejectedValue(new Error('NotAllowedError')),
+      },
+    });
+
+    // Mock execCommand to return true (success)
+    const execCommandMock = jest.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      writable: true,
+      value: execCommandMock,
+    });
+
+    renderFormsList();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(`copy-id-${forms[0].id}`));
+    });
+
+    await waitFor(() => {
+      expect(execCommandMock).toHaveBeenCalledWith('copy');
+    });
+  });
+
+  it('shows a success toast when the execCommand fallback succeeds', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      writable: true,
+      value: {
+        writeText: jest.fn().mockRejectedValue(new Error('NotAllowedError')),
+      },
+    });
+
+    Object.defineProperty(document, 'execCommand', {
+      writable: true,
+      value: jest.fn().mockReturnValue(true),
+    });
+
+    renderFormsList();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(`copy-id-${forms[0].id}`));
+    });
+
+    await waitFor(() => {
+      expect(mockShowSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expect.stringContaining(forms[0].id) }),
+      );
+    });
+  });
+
+  it('shows an error toast when both clipboard and execCommand fail', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      writable: true,
+      value: {
+        writeText: jest.fn().mockRejectedValue(new Error('NotAllowedError')),
+      },
+    });
+
+    Object.defineProperty(document, 'execCommand', {
+      writable: true,
+      value: jest.fn().mockReturnValue(false),
+    });
+
+    renderFormsList();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(`copy-id-${forms[0].id}`));
+    });
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expect.stringContaining('Failed') }),
+      );
+    });
+  });
+
+  it('shows an error toast when navigator.clipboard is undefined', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      writable: true,
+      value: undefined,
+    });
+
+    Object.defineProperty(document, 'execCommand', {
+      writable: true,
+      value: jest.fn().mockReturnValue(false),
+    });
+
+    renderFormsList();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(`copy-id-${forms[0].id}`));
+    });
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// execCommandFallback unit tests
+// ---------------------------------------------------------------------------
+
+describe('execCommandFallback', () => {
+  it('returns true when execCommand("copy") returns true', () => {
+    Object.defineProperty(document, 'execCommand', {
+      writable: true,
+      value: jest.fn().mockReturnValue(true),
+    });
+    expect(execCommandFallback('hello')).toBe(true);
+  });
+
+  it('returns false when execCommand("copy") returns false', () => {
+    Object.defineProperty(document, 'execCommand', {
+      writable: true,
+      value: jest.fn().mockReturnValue(false),
+    });
+    expect(execCommandFallback('hello')).toBe(false);
+  });
+
+  it('returns false when execCommand throws', () => {
+    Object.defineProperty(document, 'execCommand', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => { throw new Error('not supported'); }),
+    });
+    expect(execCommandFallback('hello')).toBe(false);
+  });
+
+  it('cleans up the temporary textarea from the DOM', () => {
+    Object.defineProperty(document, 'execCommand', {
+      writable: true,
+      value: jest.fn().mockReturnValue(true),
+    });
+    const before = document.body.children.length;
+    execCommandFallback('test-id');
+    expect(document.body.children.length).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard operability
+// ---------------------------------------------------------------------------
+
+describe('FormsList — copy button keyboard operability', () => {
+  beforeEach(() => {
+    mockShowSuccess.mockClear();
+    Object.defineProperty(navigator, 'clipboard', {
+      writable: true,
+      value: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('copy button is focusable (not disabled or tabindex=-1)', () => {
+    renderFormsList();
+    const btn = screen.getByTestId(`copy-id-${forms[0].id}`);
+    expect(btn).not.toBeDisabled();
+    expect(btn).not.toHaveAttribute('tabindex', '-1');
+  });
+
+  it('pressing Enter on the button triggers copy (via click event)', async () => {
+    renderFormsList();
+    const btn = screen.getByTestId(`copy-id-${forms[0].id}`);
+    btn.focus();
+    await act(async () => {
+      fireEvent.keyDown(btn, { key: 'Enter', code: 'Enter' });
+      fireEvent.click(btn);
+    });
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(forms[0].id);
+    });
+  });
+});


### PR DESCRIPTION
- Add CopyIdButton inside FormsList: uses useCopyToClipboard hook (Clipboard API) with documented execCommandFallback for environments without async clipboard support
- Copy button is keyboard-operable, has aria-label and aria-pressed
- Success toast shown via useToast after copy
- Error toast shown when both Clipboard API and execCommand fail
- Export execCommandFallback for unit testing
- Add FormsListCopyId.test.tsx: covers Clipboard success, fallback, error path, accessibility attributes, keyboard operability

Closes #52

## Description

<!-- Summarize the changes in this PR and the motivation behind them. -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

closes #860 