### PR TITLE
a11y(forms): add aria-hidden to decorative SVGs in icon-only buttons

### DIFF
--- a/src/components/ContractSummary.tsx
+++ b/src/components/ContractSummary.tsx
@@ -188,11 +188,11 @@ const ContractSummary = ({
                       title={isCopied ? `${party.label} address copied` : 'Copy address'}
                     >
                       {isCopied ? (
-                        <svg className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <svg aria-hidden="true" className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                         </svg>
                       ) : (
-                        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                         </svg>
                       )}

--- a/src/components/WalletConnectButton.tsx
+++ b/src/components/WalletConnectButton.tsx
@@ -84,14 +84,14 @@ export const WalletConnectButton = () => {
           data-testid="wallet-density-btn"
         >
           {isCompact ? (
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <line x1="4" y1="5" x2="20" y2="5" />
               <line x1="4" y1="9" x2="20" y2="9" />
               <line x1="4" y1="13" x2="20" y2="13" />
               <line x1="4" y1="17" x2="20" y2="17" />
             </svg>
           ) : (
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <line x1="4" y1="5" x2="20" y2="5" />
               <line x1="4" y1="12" x2="20" y2="12" />
               <line x1="4" y1="19" x2="20" y2="19" />
@@ -105,11 +105,11 @@ export const WalletConnectButton = () => {
           title="Copy address"
         >
           {copied ? (
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
             </svg>
           ) : (
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
             </svg>
           )}
@@ -120,7 +120,7 @@ export const WalletConnectButton = () => {
           aria-label="Disconnect wallet"
           title="Disconnect wallet"
         >
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
           </svg>
         </button>

--- a/src/components/__tests__/icon-button-a11y.test.tsx
+++ b/src/components/__tests__/icon-button-a11y.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+    addToast: jest.fn(),
+  }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/contexts/WalletContext', () => ({
+  useWallet: () => ({
+    address: null,
+    isConnecting: false,
+    error: null,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('a11y: icon button semantics', () => {
+  it('ContractRow copy button has no axe violations', async () => {
+    const { ContractRow } = require('@/components/contracts/ContractRow');
+    const contract = {
+      id: '0xABCDEF1234567890',
+      contractName: 'Test Contract',
+      status: 'Active',
+      createdAt: 'Jan 1, 2026',
+    };
+    const { container } = render(
+      <ul><ContractRow contract={contract} /></ul>,
+    );
+    const results = await axe(container);
+    expect(results.violations).toHaveLength(0);
+  });
+
+  it('WalletConnectButton unconnected state has no axe violations', async () => {
+    const { WalletConnectButton } = require('@/components/WalletConnectButton');
+    const { container } = render(<WalletConnectButton />);
+    const results = await axe(container);
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/src/components/contracts/ContractRow.tsx
+++ b/src/components/contracts/ContractRow.tsx
@@ -40,11 +40,11 @@ export const ContractRow: React.FC<ContractRowProps> = ({ contract }) => {
           className="p-1.5 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           {copied ? (
-            <svg className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg aria-hidden="true" className="h-4 w-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
             </svg>
           ) : (
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
             </svg>
           )}

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -186,12 +186,13 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
         <div className="flex items-center justify-between p-6 border-b border-[var(--border)]">
           <h2 id="settings-panel-title" className="text-xl font-bold text-[var(--foreground)]">Settings</h2>
           <button 
+            type="button"
             ref={closeButtonRef}
             onClick={onClose}
             className="p-2 rounded-full hover:bg-[var(--accent)] text-[var(--muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
             aria-label="Close settings"
           >
-            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg aria-hidden="true" className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>

--- a/src/components/settings/SettingsTrigger.tsx
+++ b/src/components/settings/SettingsTrigger.tsx
@@ -29,11 +29,13 @@ export function SettingsTrigger() {
   return (
     <>
       <button
+        type="button"
         onClick={() => setIsOpen(true)}
         className="fixed bottom-6 right-6 p-3 rounded-full bg-[var(--primary)] text-[var(--primary-foreground)] shadow-lg hover:scale-110 transition-transform z-40 focus:outline-none focus:ring-2 focus:ring-[var(--ring)] focus:ring-offset-2"
         aria-label="Open Settings"
       >
         <svg 
+          aria-hidden="true"
           className="w-6 h-6" 
           fill="none" 
           viewBox="0 0 24 24" 


### PR DESCRIPTION
Closes #856

# Summary

- Mark decorative SVGs with aria-hidden='true' to prevent screen readers from announcing redundant icon content in buttons that already have accessible names (aria-label, title, or sr-only text)
- Add type='button' to SettingsTrigger and SettingsPanel buttons
- Add jest-axe regression tests for ContractRow and WalletConnectButton icon button accessibility

Files changed:
- ContractSummary.tsx: 2 SVGs (copy/checkmark)
- WalletConnectButton.tsx: 5 SVGs (density toggle, copy, disconnect)
- ContractRow.tsx: 2 SVGs (copy/checkmark)
- SettingsPanel.tsx: 1 SVG (close) + type='button'
- SettingsTrigger.tsx: 1 SVG (gear) + type='button'

## Description

<!-- Summarize the changes in this PR and the motivation behind them. -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

<!-- Briefly describe the test cases you added or updated, and any manual testing performed. -->

---

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->

### Security

<!-- Does this PR touch authentication, authorization, wallet logic, API calls, or
     user-supplied input? Describe any security considerations or "N/A" if not applicable. -->
