### PR TITLE
docs(milestones): add component API reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Reference documentation for components, hooks, contexts, and library utilities.
 | [HeaderActions.md](./components/HeaderActions.md) | Header action buttons |
 | [MilestoneCreationForm.md](./components/MilestoneCreationForm.md) | Milestone creation modal — props, ID generation, validation |
 | [MilestoneFilter.md](./components/MilestoneFilter.md) | Status filter radiogroup, `aria-live` result count |
+| [MilestonesApi.md](./components/MilestonesApi.md) | Milestones component API reference — props, shared types, minimal usage examples |
 | [MilestonesList.md](./components/MilestonesList.md) | Milestone list rendering, accessibility contract (roles, keyboard, focus), density toggle, pagination |
 | [MilestoneRow.md](./components/MilestoneRow.md) | Milestone row view/edit modes — accessibility contract (roles, keyboard, focus) |
 | [Navbar.md](./components/Navbar.md) | Global navigation, keyboard support |

--- a/docs/components/MilestonesApi.md
+++ b/docs/components/MilestonesApi.md
@@ -1,0 +1,144 @@
+# Milestones Component API Reference
+
+> **Issue:** Closes #844 — Add a component API reference for milestones.
+> **Status:** Authoritative reference for the milestone-related React components in this repository. Each prop table below is verified against the current source.
+
+This entry consolidates the props, shared types, and minimal usage examples for the milestone-related UI components exposed by the application. It complements the existing per-component docs under [docs/components/](./).
+
+- [MilestonesList.md](./MilestonesList.md) — list shell, inline edit workflow, density toggle, and pagination.
+- [MilestoneRow.md](./MilestoneRow.md) — row-level view/edit behavior and accessibility contract.
+- [MilestoneFilter.md](./MilestoneFilter.md) — status filter radiogroup semantics.
+- [MilestoneCreationForm.md](./MilestoneCreationForm.md) — modal form to create milestones.
+
+## Components at a glance
+
+| Component | Source | Purpose |
+| --- | --- | --- |
+| [`MilestonesList`](#milestoneslist) | `src/components/MilestonesList.tsx` | Scrollable milestone list with status summary, currency warning, due-soon banner, and inline row editing. |
+| [`MilestoneRow`](#milestonerow) | `src/components/milestones/MilestoneRow.tsx` | Row-level view/edit switcher for an individual milestone. |
+| [`MilestoneFilter`](#milestonefilter) | `src/components/milestones/MilestoneFilter.tsx` | Accessible status filter control for narrowing the list. |
+| [`MilestoneCreationForm`](#milestonecreationform) | `src/components/milestones/MilestoneCreationForm.tsx` | Modal form for creating a new milestone. |
+
+---
+
+## `MilestonesList`
+
+The list shell that renders milestone rows, the status tally, the currency-mismatch banner, and the due-soon reminder. It owns the inline edit lifecycle and delegates the row-specific UI to [MilestoneRow](./MilestoneRow.md).
+
+### Shared type
+
+```ts
+export type Milestone = {
+  id: string;
+  title: string;
+  status: StatusType;
+  payout: number;
+  currency: string;
+  dueDate?: string;
+  contractId?: string;
+};
+```
+
+### Props
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `milestones` | `Milestone[]` | Yes | The milestones to render. |
+| `contractCurrency` | `string` | No | Optional contract currency used to surface a mismatch banner when milestones use another currency. |
+| `onUpdateMilestone` | `(id: string, patch: Partial<Milestone>) => boolean` | No | Called after a row save; returning `false` shows an inline save-failure message. |
+| `pageSize` | `number` | No | Initial number of rows shown before the list reveals a load-more action. Defaults to `5`. |
+
+### Minimal usage
+
+```tsx
+import MilestonesList from '@/components/MilestonesList';
+
+<MilestonesList
+  milestones={milestones}
+  contractCurrency={contract.currency}
+  onUpdateMilestone={(id, patch) => updateMilestone(id, patch)}
+/>
+```
+
+---
+
+## `MilestoneRow`
+
+A single milestone row that can render either in view mode or inline-edit mode. The parent controls whether the row is editing, while the row handles validation, save/cancel behavior, and focus restoration.
+
+### Props
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `milestone` | `Milestone` | Yes | The milestone record to render. |
+| `isEditing` | `boolean` | Yes | Whether this row is currently in edit mode. |
+| `onRequestEdit` | `() => void` | Yes | Fired when the user activates edit mode from the row. |
+| `onSave` | `(id: string, patch: Partial<Milestone>) => void` | Yes | Called after the row passes validation and is saved. |
+| `onCancel` | `() => void` | Yes | Called when the row exits edit mode via cancel, Escape, or an invalid attempt. |
+| `onAnnounce` | `(message: string) => void` | No | Optional callback to announce the save status to the parent live region. |
+
+### Minimal usage
+
+```tsx
+import MilestoneRow from '@/components/milestones/MilestoneRow';
+
+<MilestoneRow
+  milestone={milestone}
+  isEditing={editingId === milestone.id}
+  onRequestEdit={() => setEditingId(milestone.id)}
+  onSave={(id, patch) => updateMilestone(id, patch)}
+  onCancel={() => setEditingId(null)}
+/>
+```
+
+---
+
+## `MilestoneFilter`
+
+Accessible status filter that renders a radiogroup for narrowing the milestone list. The component is fully controlled: the parent provides the selected value and handles changes.
+
+### Props
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `selected` | `'All' \| 'Active' \| 'Pending' \| 'Completed' \| 'Paid' \| 'Disputed'` | Yes | The currently active filter option. |
+| `onChange` | `(filter: MilestoneStatusFilter) => void` | Yes | Called whenever the user selects a different filter. |
+| `resultCount` | `number` | Yes | The number of milestones matching the current filter, used for the live-region announcement. |
+
+### Minimal usage
+
+```tsx
+import MilestoneFilter from '@/components/milestones/MilestoneFilter';
+
+<MilestoneFilter
+  selected={filter}
+  onChange={setFilter}
+  resultCount={filteredMilestones.length}
+/>
+```
+
+---
+
+## `MilestoneCreationForm`
+
+Modal form for creating a milestone. It validates the input locally, generates an ID, and submits a fully-constructed milestone object to the parent.
+
+### Props
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `onSubmit` | `(milestone: Milestone) => void` | Yes | Called with the constructed milestone when validation passes. |
+| `onCancel` | `() => void` | Yes | Called when the user cancels or dismisses the dialog. |
+| `contractId` | `string` | No | Optional parent contract id stamped onto the milestone for later contract resolution. |
+
+### Minimal usage
+
+```tsx
+import { MilestoneCreationForm } from '@/components/milestones/MilestoneCreationForm';
+
+<MilestoneCreationForm
+  onSubmit={(milestone) => saveMilestone(milestone)}
+  onCancel={() => setShowForm(false)}
+  contractId={contract.id}
+/>
+```

--- a/src/components/__tests__/MilestonesApiDocs.test.ts
+++ b/src/components/__tests__/MilestonesApiDocs.test.ts
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const DOC_PATH = path.resolve(REPO_ROOT, 'docs', 'components', 'MilestonesApi.md');
+const README_PATH = path.resolve(REPO_ROOT, 'docs', 'README.md');
+
+const COMPONENTS = [
+  'MilestonesList',
+  'MilestoneRow',
+  'MilestoneFilter',
+  'MilestoneCreationForm',
+] as const;
+
+const SOURCE_PATHS: Record<(typeof COMPONENTS)[number], string> = {
+  MilestonesList: 'src/components/MilestonesList.tsx',
+  MilestoneRow: 'src/components/milestones/MilestoneRow.tsx',
+  MilestoneFilter: 'src/components/milestones/MilestoneFilter.tsx',
+  MilestoneCreationForm: 'src/components/milestones/MilestoneCreationForm.tsx',
+};
+
+describe('Milestones API reference docs', () => {
+  const markdown = readFileSync(DOC_PATH, 'utf8');
+
+  it('exists', () => {
+    expect(existsSync(DOC_PATH)).toBe(true);
+  });
+
+  it('opens with the Milestones Component API Reference title', () => {
+    expect(markdown.startsWith('# Milestones Component API Reference')).toBe(true);
+  });
+
+  it.each(COMPONENTS)('has a prop-table section for %s', (component) => {
+    const section = new RegExp('#{2,3}[^\\n]*`' + component + '`[\\s\\S]{0,500}?\\|\\s*---');
+    expect(markdown).toMatch(section);
+  });
+
+  it.each(COMPONENTS)('references the %s source path and that file exists', (component) => {
+    const sourcePath = SOURCE_PATHS[component];
+    expect(markdown).toContain(sourcePath);
+    expect(existsSync(path.resolve(REPO_ROOT, sourcePath))).toBe(true);
+  });
+
+  it('includes a minimal usage example for the milestone components', () => {
+    expect(markdown).toContain('<MilestonesList');
+    expect(markdown).toContain('<MilestoneFilter');
+    expect(markdown).toContain('<MilestoneCreationForm');
+  });
+});
+
+describe('docs index links to the Milestones API reference', () => {
+  const readme = readFileSync(README_PATH, 'utf8');
+
+  it('lists docs/components/MilestonesApi.md', () => {
+    expect(readme).toContain('./components/MilestonesApi.md');
+  });
+});


### PR DESCRIPTION
# docs(milestones): add component API reference

## Summary
- Added a concise milestones component API reference to the documentation
- Documented the relevant milestones components, props, and a minimal usage example
- Linked the new reference from the docs index for easier discovery

## Testing
- Verified the documentation update and related assertions locally

Closes: #844