### PR TITLE
a11y(dialogs): label icon buttons

### DIFF
--- a/src/components/__tests__/DialogsListCopyId.test.tsx
+++ b/src/components/__tests__/DialogsListCopyId.test.tsx
@@ -1,0 +1,411 @@
+/**
+ * DialogsListCopyId.test.tsx
+ *
+ * Tests for issue #51 (icon-only button accessible names) and the copy-to-clipboard
+ * feature added to DialogsList.
+ * Covers:
+ *  - Every icon-only button has an accessible name (aria-label)
+ *  - Filter buttons have aria-label
+ *  - Copy button renders per dialog item
+ *  - Clipboard API success → toast + aria-pressed state change
+ *  - execCommand fallback when Clipboard API is absent
+ *  - Both paths fail → error toast
+ *  - execCommandFallback utility unit tests
+ *  - Keyboard operability
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DialogsList, execCommandFallback, type DialogRecord } from '../dialogs/DialogsList';
+import * as exportDialogs from '@/lib/exportDialogs';
+
+// ---------------------------------------------------------------------------
+// Toast mock
+// ---------------------------------------------------------------------------
+
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+  }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const sampleDialogs: DialogRecord[] = [
+  {
+    id: 'dlg-001',
+    title: 'Release funds',
+    description: 'Approve payment.',
+    status: 'Open',
+    createdAt: '2024-01-10',
+    resolvedAt: null,
+  },
+  {
+    id: 'dlg-002',
+    title: 'Dispute contract',
+    description: 'Raise a dispute.',
+    status: 'Pending',
+    createdAt: '2024-01-12',
+    resolvedAt: null,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Clipboard helpers
+// ---------------------------------------------------------------------------
+
+let originalClipboard: typeof navigator.clipboard;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  originalClipboard = navigator.clipboard;
+  mockShowSuccess.mockClear();
+  mockShowError.mockClear();
+});
+
+afterEach(() => {
+  act(() => { jest.runAllTimers(); });
+  jest.useRealTimers();
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: originalClipboard });
+});
+
+function mockClipboard(impl: () => Promise<void> = () => Promise.resolve()) {
+  const writeText = jest.fn().mockImplementation(impl);
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+  return writeText;
+}
+
+function removeClipboard() {
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
+}
+
+// ---------------------------------------------------------------------------
+// Issue #51: Icon-only button accessible names
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — icon-only button accessible names (issue #51)', () => {
+  it('every copy-ID button has an aria-label', () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    sampleDialogs.forEach((d) => {
+      const btn = screen.getByTestId(`copy-dialog-id-btn-${d.id}`);
+      expect(btn).toHaveAttribute('aria-label');
+      expect(btn.getAttribute('aria-label')).not.toBe('');
+    });
+  });
+
+  it('copy-ID button aria-label references the dialog ID', () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    sampleDialogs.forEach((d) => {
+      expect(
+        screen.getByRole('button', { name: new RegExp(`Copy dialog ID ${d.id}`, 'i') }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('filter buttons have aria-label attributes', () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    (['All', 'Open', 'Pending', 'Closed'] as const).forEach((status) => {
+      const btn = screen.getByText(`Filter ${status}`);
+      expect(btn).toHaveAttribute('aria-label');
+      expect(btn.getAttribute('aria-label')).not.toBe('');
+    });
+  });
+
+  it('filter button aria-label references the status', () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    (['All', 'Open', 'Pending', 'Closed'] as const).forEach((status) => {
+      const btn = screen.getByText(`Filter ${status}`);
+      expect(btn.getAttribute('aria-label')).toMatch(new RegExp(status, 'i'));
+    });
+  });
+
+  it('export CSV button has an accessible aria-label', () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('export-csv-btn')).toHaveAttribute('aria-label', 'Export dialogs as CSV');
+  });
+
+  it('export JSON button has an accessible aria-label', () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('export-json-btn')).toHaveAttribute('aria-label', 'Export dialogs as JSON');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Copy button renders
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — copy ID button renders', () => {
+  it('renders a copy button for each dialog item', () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    sampleDialogs.forEach((d) => {
+      expect(screen.getByTestId(`copy-dialog-id-btn-${d.id}`)).toBeInTheDocument();
+    });
+  });
+
+  it('button has aria-pressed="false" before any copy', () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('copy-dialog-id-btn-dlg-001')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('button text reads "Copy ID" before any click', () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('copy-dialog-id-btn-dlg-001')).toHaveTextContent('Copy ID');
+  });
+
+  it('dialog ID is rendered as a code element next to the copy button', () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('dialog-id-dlg-001')).toHaveTextContent('dlg-001');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clipboard API success path
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — Clipboard API success', () => {
+  it('calls navigator.clipboard.writeText with the dialog ID', async () => {
+    const writeText = mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-dialog-id-btn-dlg-001'));
+    });
+
+    expect(writeText).toHaveBeenCalledWith('dlg-001');
+  });
+
+  it('shows a success toast after copying', async () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-dialog-id-btn-dlg-001'));
+    });
+
+    expect(mockShowSuccess).toHaveBeenCalledTimes(1);
+    expect(mockShowSuccess.mock.calls[0][0]).toMatchObject({ title: expect.stringContaining('dlg-001') });
+  });
+
+  it('button shows "Copied" and aria-pressed="true" after copy', async () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-dialog-id-btn-dlg-001'));
+    });
+
+    const btn = screen.getByTestId('copy-dialog-id-btn-dlg-001');
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    expect(btn).toHaveTextContent('Copied');
+  });
+
+  it('button resets to "Copy ID" after the delay', async () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-dialog-id-btn-dlg-001'));
+    });
+
+    act(() => { jest.advanceTimersByTime(2000); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('copy-dialog-id-btn-dlg-001')).toHaveTextContent('Copy ID');
+    });
+  });
+
+  it('only the clicked button shows "Copied"; others are unaffected', async () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-dialog-id-btn-dlg-001'));
+    });
+
+    expect(screen.getByTestId('copy-dialog-id-btn-dlg-001')).toHaveTextContent('Copied');
+    expect(screen.getByTestId('copy-dialog-id-btn-dlg-002')).toHaveTextContent('Copy ID');
+  });
+
+  it('does not show error toast on success', async () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-dialog-id-btn-dlg-001'));
+    });
+
+    expect(mockShowError).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clipboard API unavailable — execCommand fallback
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — execCommand fallback', () => {
+  it('falls back to execCommand when clipboard is absent', async () => {
+    removeClipboard();
+    document.execCommand = jest.fn().mockReturnValue(true);
+    render(<DialogsList dialogs={sampleDialogs} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-dialog-id-btn-dlg-001'));
+    });
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(mockShowSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error toast when both Clipboard API and execCommand fail', async () => {
+    removeClipboard();
+    document.execCommand = jest.fn().mockReturnValue(false);
+    render(<DialogsList dialogs={sampleDialogs} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-dialog-id-btn-dlg-001'));
+    });
+
+    expect(mockShowError).toHaveBeenCalledTimes(1);
+    expect(mockShowError.mock.calls[0][0]).toMatchObject({ title: expect.stringContaining('dlg-001') });
+  });
+
+  it('shows error toast when Clipboard API rejects', async () => {
+    mockClipboard(() => Promise.reject(new Error('denied')));
+    document.execCommand = jest.fn().mockReturnValue(false);
+    render(<DialogsList dialogs={sampleDialogs} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-dialog-id-btn-dlg-001'));
+    });
+
+    expect(mockShowError).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard operability
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — copy button keyboard operability', () => {
+  it('button is not disabled (keyboard reachable)', () => {
+    mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    expect(screen.getByTestId('copy-dialog-id-btn-dlg-001')).not.toBeDisabled();
+  });
+
+  it('pressing Enter on button triggers the copy', async () => {
+    const writeText = mockClipboard();
+    render(<DialogsList dialogs={sampleDialogs} />);
+    const btn = screen.getByTestId('copy-dialog-id-btn-dlg-001');
+
+    await act(async () => {
+      btn.focus();
+      fireEvent.keyDown(btn, { key: 'Enter' });
+      fireEvent.click(btn);
+    });
+
+    expect(writeText).toHaveBeenCalledWith('dlg-001');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Copy button absent in empty/loading/error states
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — copy button not shown when no items', () => {
+  it('copy buttons do not appear in empty state', () => {
+    render(<DialogsList dialogs={[]} />);
+    expect(screen.queryByTestId('copy-dialog-id-btn-dlg-001')).not.toBeInTheDocument();
+  });
+
+  it('copy buttons do not appear in loading state', () => {
+    render(<DialogsList dialogs={sampleDialogs} isLoading />);
+    expect(screen.queryByTestId('copy-dialog-id-btn-dlg-001')).not.toBeInTheDocument();
+  });
+
+  it('copy buttons do not appear in error state', () => {
+    render(<DialogsList dialogs={sampleDialogs} error="Failed" />);
+    expect(screen.queryByTestId('copy-dialog-id-btn-dlg-001')).not.toBeInTheDocument();
+  });
+
+  it('copy buttons not shown when filter yields no results', () => {
+    const openOnly: DialogRecord[] = [sampleDialogs[0]]; // Open only
+    render(<DialogsList dialogs={openOnly} />);
+    fireEvent.click(screen.getByText('Filter Closed'));
+    expect(screen.queryByTestId('copy-dialog-id-btn-dlg-001')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// execCommandFallback unit tests
+// ---------------------------------------------------------------------------
+
+describe('execCommandFallback (DialogsList)', () => {
+  it('returns true when execCommand succeeds', () => {
+    document.execCommand = jest.fn().mockReturnValue(true);
+    expect(execCommandFallback('hello')).toBe(true);
+  });
+
+  it('returns false when execCommand returns false', () => {
+    document.execCommand = jest.fn().mockReturnValue(false);
+    expect(execCommandFallback('hello')).toBe(false);
+  });
+
+  it('returns false when execCommand throws', () => {
+    document.execCommand = jest.fn().mockImplementation(() => { throw new Error('nope'); });
+    expect(execCommandFallback('hello')).toBe(false);
+  });
+
+  it('removes the textarea from the DOM after completion', () => {
+    document.execCommand = jest.fn().mockReturnValue(true);
+    execCommandFallback('test');
+    expect(document.body.querySelectorAll('textarea').length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Export integration (regression: existing behaviour still works)
+// ---------------------------------------------------------------------------
+
+describe('DialogsList — export controls still work after refactor', () => {
+  let csvSpy: jest.SpyInstance;
+  let jsonSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    csvSpy = jest.spyOn(exportDialogs, 'downloadDialogsCsv').mockImplementation(() => {});
+    jsonSpy = jest.spyOn(exportDialogs, 'downloadDialogsJson').mockImplementation(() => {});
+    mockClipboard();
+  });
+
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  it('CSV export still works', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    fireEvent.click(screen.getByTestId('export-csv-btn'));
+    expect(csvSpy).toHaveBeenCalledWith(sampleDialogs);
+  });
+
+  it('JSON export still works', () => {
+    render(<DialogsList dialogs={sampleDialogs} />);
+    fireEvent.click(screen.getByTestId('export-json-btn'));
+    expect(jsonSpy).toHaveBeenCalledWith(sampleDialogs);
+  });
+});

--- a/src/components/dialogs/DialogsList.tsx
+++ b/src/components/dialogs/DialogsList.tsx
@@ -15,17 +15,129 @@
  *
  * Both controls are keyboard-operable and labelled for assistive technology.
  * An empty-view export guard disables the buttons when there is nothing to export.
+ *
+ * Each list item exposes an icon-only "Copy ID" button with a descriptive
+ * aria-label so keyboard and assistive-technology users can copy the dialog ID
+ * without having to select the code element manually. The button uses the
+ * Clipboard API with a documented execCommand fallback and surfaces feedback
+ * through the global toast system.
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useCallback, useState, useMemo } from 'react';
 import {
   type DialogRecord,
   type DialogStatus,
   downloadDialogsCsv,
   downloadDialogsJson,
 } from '@/lib/exportDialogs';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { useToast } from '@/components/toast/toast-provider';
 
 export type { DialogRecord, DialogStatus };
+
+// ---------------------------------------------------------------------------
+// execCommandFallback — documented clipboard fallback for environments where
+// navigator.clipboard is unavailable (e.g. non-HTTPS contexts, older browsers).
+// ---------------------------------------------------------------------------
+
+/**
+ * Falls back to the deprecated `document.execCommand('copy')` API when the
+ * Clipboard API is not available. Creates a temporary off-screen textarea,
+ * selects its value, and invokes execCommand. The textarea is always removed
+ * from the DOM regardless of success or failure.
+ *
+ * @param text - The string to copy to the clipboard.
+ * @returns `true` if the execCommand succeeded; `false` otherwise.
+ */
+export function execCommandFallback(text: string): boolean {
+  if (typeof document === 'undefined') return false;
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.left = '-9999px';
+  textarea.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  let success = false;
+  try {
+    success = document.execCommand('copy');
+  } catch {
+    // execCommand not supported — success remains false
+  } finally {
+    document.body.removeChild(textarea);
+  }
+  return success;
+}
+
+// ---------------------------------------------------------------------------
+// CopyIdButton — icon-only button with aria-label for each dialog ID
+// ---------------------------------------------------------------------------
+
+interface CopyIdButtonProps {
+  dialogId: string;
+}
+
+function CopyIdButton({ dialogId }: CopyIdButtonProps) {
+  const { showSuccess, showError } = useToast();
+
+  const { copied, copy } = useCopyToClipboard({
+    onSuccess: () => {
+      showSuccess({ title: `Copied "${dialogId}" to clipboard.` });
+    },
+    onError: () => {
+      // Documented fallback: try execCommand when Clipboard API is unavailable
+      const success = execCommandFallback(dialogId);
+      if (success) {
+        showSuccess({ title: `Copied "${dialogId}" to clipboard.` });
+      } else {
+        showError({ title: `Failed to copy "${dialogId}". Please copy it manually.` });
+      }
+    },
+  });
+
+  const handleClick = useCallback(() => {
+    copy(dialogId);
+  }, [copy, dialogId]);
+
+  return (
+    <button
+      type="button"
+      aria-label={`Copy dialog ID ${dialogId} to clipboard`}
+      aria-pressed={copied}
+      data-testid={`copy-dialog-id-btn-${dialogId}`}
+      title="Copy ID to clipboard"
+      onClick={handleClick}
+      className={[
+        'inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500',
+        copied
+          ? 'bg-green-50 border-green-400 text-green-700'
+          : 'bg-white border-gray-300 text-gray-500 hover:bg-gray-50',
+      ].join(' ')}
+    >
+      {copied ? (
+        <>
+          <svg aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Copied
+        </>
+      ) : (
+        <>
+          <svg aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <rect x="1" y="3" width="7" height="8" rx="1" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M4 1h6a1 1 0 0 1 1 1v8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+          Copy ID
+        </>
+      )}
+    </button>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Props
@@ -111,6 +223,7 @@ export const DialogsList = ({
             key={status}
             type="button"
             aria-pressed={filter === status}
+            aria-label={`Filter dialogs by ${status} status`}
             onClick={() => setFilter(status)}
             className={[
               'px-3 py-1 rounded text-sm border',
@@ -200,12 +313,15 @@ export const DialogsList = ({
                 >
                   {d.status}
                 </span>
-                <code
-                  data-testid={`dialog-id-${d.id}`}
-                  className="text-xs text-gray-400 font-mono"
-                >
-                  {d.id}
-                </code>
+                <div className="flex items-center gap-1.5">
+                  <code
+                    data-testid={`dialog-id-${d.id}`}
+                    className="text-xs text-gray-400 font-mono"
+                  >
+                    {d.id}
+                  </code>
+                  <CopyIdButton dialogId={d.id} />
+                </div>
               </div>
             </li>
           ))}


### PR DESCRIPTION
- Add aria-label to all filter buttons in DialogsList (was: text-only, now: text + descriptive aria-label referencing status)
- Add CopyIdButton icon-button with aria-label, aria-pressed, and data-testid to each dialog list item so the ID is keyboard-copyable
- Add execCommandFallback for environments without Clipboard API
- Show success/error toasts via useToast on copy outcome
- Add 31 tests in DialogsListCopyId.test.tsx covering: accessible names on all buttons, copy success/fallback/error paths, keyboard operability, and regression checks for export controls


## Description

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

closes #848 
