### PR TITLE
feat(reputation): add copy-to-clipboard for ids

### DIFF
--- a/src/app/reputation/__tests__/__snapshots__/page.snapshot.test.tsx.snap
+++ b/src/app/reputation/__tests__/__snapshots__/page.snapshot.test.tsx.snap
@@ -510,7 +510,7 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
           </p>
         </div>
         <div
-          class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+          class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
         >
           <p
             class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -531,7 +531,7 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
           </p>
         </div>
         <div
-          class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+          class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
         >
           <p
             class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -667,13 +667,13 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
             class="flex items-center gap-2"
           >
             <label
-              class="text-sm font-medium text-slate-700"
+              class="text-sm font-medium text-[var(--foreground)]"
               for="history-type-filter"
             >
               Filter:
             </label>
             <select
-              class="rounded-lg border border-slate-300 py-1 pl-3 pr-8 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              class="rounded-lg border border-[var(--border)] bg-[var(--card)] py-1 pl-3 pr-8 text-sm text-[var(--foreground)] focus:border-[var(--ring)] focus:outline-none focus:ring-1 focus:ring-[var(--ring)]"
               data-testid="reputation-type-filter"
               id="history-type-filter"
             >
@@ -703,13 +703,13 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
             class="flex items-center gap-2"
           >
             <label
-              class="text-sm font-medium text-slate-700"
+              class="text-sm font-medium text-[var(--foreground)]"
               for="history-sort-dir"
             >
               Sort:
             </label>
             <select
-              class="rounded-lg border border-slate-300 py-1 pl-3 pr-8 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              class="rounded-lg border border-[var(--border)] bg-[var(--card)] py-1 pl-3 pr-8 text-sm text-[var(--foreground)] focus:border-[var(--ring)] focus:outline-none focus:ring-1 focus:ring-[var(--ring)]"
               data-testid="reputation-sort-dir"
               id="history-sort-dir"
             >
@@ -737,7 +737,7 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
             newest first
           </div>
           <span
-            class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600"
+            class="rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--muted-foreground)]"
           >
             Visible
           </span>
@@ -759,22 +759,26 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
           >
             <input
               aria-label="Select all reputation items"
-              class="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+              class="h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
               type="checkbox"
             />
             Select all
           </label>
           <div
+            aria-label="Reputation history actions"
             class="flex flex-wrap gap-2"
+            role="toolbar"
           >
             <button
-              class="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-900 transition hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Export selected reputation items"
+              class="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm font-semibold text-[var(--foreground)] transition hover:border-[var(--muted-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
               disabled=""
               type="button"
             >
               Export selected
             </button>
             <button
+              aria-label="Delete selected reputation items"
               class="rounded-2xl bg-rose-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
               disabled=""
               type="button"
@@ -782,7 +786,8 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
               Delete selected
             </button>
             <button
-              class="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-900 transition hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Clear selected reputation items; clear selection"
+              class="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm font-semibold text-[var(--foreground)] transition hover:border-[var(--muted-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
               disabled=""
               type="button"
             >
@@ -804,28 +809,75 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
               >
                 <input
                   aria-label="Select reputation item Verification: Completed identity verification"
-                  class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                  class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                   type="checkbox"
                 />
                 <span>
                   <span
-                    class="block text-sm font-medium text-slate-500"
+                    class="block text-sm font-medium text-[var(--muted-foreground)]"
                   >
                     Verification
                   </span>
                   <span
-                    class="mt-1 block text-base font-semibold text-slate-950"
+                    class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                   >
                     Completed identity verification
                   </span>
                 </span>
               </label>
-              <time
-                class="text-sm text-slate-500 sm:text-right"
-                datetime="2026-04-24"
+              <div
+                class="flex items-center gap-2 sm:flex-col sm:items-end"
               >
-                2026-04-24
-              </time>
+                <time
+                  class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                  datetime="2026-04-24"
+                >
+                  2026-04-24
+                </time>
+                <div
+                  class="flex items-center gap-1.5"
+                >
+                  <code
+                    class="text-xs text-[var(--muted-foreground)] font-mono"
+                    data-testid="reputation-event-id-ev-1"
+                  >
+                    ev-1
+                  </code>
+                  <button
+                    aria-label="Copy reputation event ID ev-1 to clipboard"
+                    aria-pressed="false"
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                    data-testid="copy-reputation-id-btn-ev-1"
+                    title="Copy ID to clipboard"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      height="12"
+                      viewBox="0 0 12 12"
+                      width="12"
+                    >
+                      <rect
+                        height="8"
+                        rx="1"
+                        stroke="currentColor"
+                        stroke-width="1.2"
+                        width="7"
+                        x="1"
+                        y="3"
+                      />
+                      <path
+                        d="M4 1h6a1 1 0 0 1 1 1v8"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-width="1.2"
+                      />
+                    </svg>
+                    Copy ID
+                  </button>
+                </div>
+              </div>
             </div>
           </li>
           <li
@@ -839,28 +891,75 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
               >
                 <input
                   aria-label="Select reputation item On-chain review: Received positive trust signal"
-                  class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                  class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                   type="checkbox"
                 />
                 <span>
                   <span
-                    class="block text-sm font-medium text-slate-500"
+                    class="block text-sm font-medium text-[var(--muted-foreground)]"
                   >
                     On-chain review
                   </span>
                   <span
-                    class="mt-1 block text-base font-semibold text-slate-950"
+                    class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                   >
                     Received positive trust signal
                   </span>
                 </span>
               </label>
-              <time
-                class="text-sm text-slate-500 sm:text-right"
-                datetime="2026-04-23"
+              <div
+                class="flex items-center gap-2 sm:flex-col sm:items-end"
               >
-                2026-04-23
-              </time>
+                <time
+                  class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                  datetime="2026-04-23"
+                >
+                  2026-04-23
+                </time>
+                <div
+                  class="flex items-center gap-1.5"
+                >
+                  <code
+                    class="text-xs text-[var(--muted-foreground)] font-mono"
+                    data-testid="reputation-event-id-ev-2"
+                  >
+                    ev-2
+                  </code>
+                  <button
+                    aria-label="Copy reputation event ID ev-2 to clipboard"
+                    aria-pressed="false"
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                    data-testid="copy-reputation-id-btn-ev-2"
+                    title="Copy ID to clipboard"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      height="12"
+                      viewBox="0 0 12 12"
+                      width="12"
+                    >
+                      <rect
+                        height="8"
+                        rx="1"
+                        stroke="currentColor"
+                        stroke-width="1.2"
+                        width="7"
+                        x="1"
+                        y="3"
+                      />
+                      <path
+                        d="M4 1h6a1 1 0 0 1 1 1v8"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-width="1.2"
+                      />
+                    </svg>
+                    Copy ID
+                  </button>
+                </div>
+              </div>
             </div>
           </li>
           <li
@@ -874,28 +973,75 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
               >
                 <input
                   aria-label="Select reputation item Referral: Referred two new community members"
-                  class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                  class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                   type="checkbox"
                 />
                 <span>
                   <span
-                    class="block text-sm font-medium text-slate-500"
+                    class="block text-sm font-medium text-[var(--muted-foreground)]"
                   >
                     Referral
                   </span>
                   <span
-                    class="mt-1 block text-base font-semibold text-slate-950"
+                    class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                   >
                     Referred two new community members
                   </span>
                 </span>
               </label>
-              <time
-                class="text-sm text-slate-500 sm:text-right"
-                datetime="2026-04-20"
+              <div
+                class="flex items-center gap-2 sm:flex-col sm:items-end"
               >
-                2026-04-20
-              </time>
+                <time
+                  class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                  datetime="2026-04-20"
+                >
+                  2026-04-20
+                </time>
+                <div
+                  class="flex items-center gap-1.5"
+                >
+                  <code
+                    class="text-xs text-[var(--muted-foreground)] font-mono"
+                    data-testid="reputation-event-id-ev-3"
+                  >
+                    ev-3
+                  </code>
+                  <button
+                    aria-label="Copy reputation event ID ev-3 to clipboard"
+                    aria-pressed="false"
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                    data-testid="copy-reputation-id-btn-ev-3"
+                    title="Copy ID to clipboard"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      height="12"
+                      viewBox="0 0 12 12"
+                      width="12"
+                    >
+                      <rect
+                        height="8"
+                        rx="1"
+                        stroke="currentColor"
+                        stroke-width="1.2"
+                        width="7"
+                        x="1"
+                        y="3"
+                      />
+                      <path
+                        d="M4 1h6a1 1 0 0 1 1 1v8"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-width="1.2"
+                      />
+                    </svg>
+                    Copy ID
+                  </button>
+                </div>
+              </div>
             </div>
           </li>
         </ol>
@@ -1015,7 +1161,7 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
           </p>
         </div>
         <div
-          class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+          class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
         >
           <p
             class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1036,7 +1182,7 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
           </p>
         </div>
         <div
-          class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+          class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
         >
           <p
             class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1172,13 +1318,13 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
             class="flex items-center gap-2"
           >
             <label
-              class="text-sm font-medium text-slate-700"
+              class="text-sm font-medium text-[var(--foreground)]"
               for="history-type-filter"
             >
               Filter:
             </label>
             <select
-              class="rounded-lg border border-slate-300 py-1 pl-3 pr-8 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              class="rounded-lg border border-[var(--border)] bg-[var(--card)] py-1 pl-3 pr-8 text-sm text-[var(--foreground)] focus:border-[var(--ring)] focus:outline-none focus:ring-1 focus:ring-[var(--ring)]"
               data-testid="reputation-type-filter"
               id="history-type-filter"
             >
@@ -1208,13 +1354,13 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
             class="flex items-center gap-2"
           >
             <label
-              class="text-sm font-medium text-slate-700"
+              class="text-sm font-medium text-[var(--foreground)]"
               for="history-sort-dir"
             >
               Sort:
             </label>
             <select
-              class="rounded-lg border border-slate-300 py-1 pl-3 pr-8 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              class="rounded-lg border border-[var(--border)] bg-[var(--card)] py-1 pl-3 pr-8 text-sm text-[var(--foreground)] focus:border-[var(--ring)] focus:outline-none focus:ring-1 focus:ring-[var(--ring)]"
               data-testid="reputation-sort-dir"
               id="history-sort-dir"
             >
@@ -1242,7 +1388,7 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
             newest first
           </div>
           <span
-            class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600"
+            class="rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--muted-foreground)]"
           >
             Visible
           </span>
@@ -1264,22 +1410,26 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
           >
             <input
               aria-label="Select all reputation items"
-              class="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+              class="h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
               type="checkbox"
             />
             Select all
           </label>
           <div
+            aria-label="Reputation history actions"
             class="flex flex-wrap gap-2"
+            role="toolbar"
           >
             <button
-              class="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-900 transition hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Export selected reputation items"
+              class="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm font-semibold text-[var(--foreground)] transition hover:border-[var(--muted-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
               disabled=""
               type="button"
             >
               Export selected
             </button>
             <button
+              aria-label="Delete selected reputation items"
               class="rounded-2xl bg-rose-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
               disabled=""
               type="button"
@@ -1287,7 +1437,8 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
               Delete selected
             </button>
             <button
-              class="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-900 transition hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Clear selected reputation items; clear selection"
+              class="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm font-semibold text-[var(--foreground)] transition hover:border-[var(--muted-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
               disabled=""
               type="button"
             >
@@ -1309,28 +1460,75 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
               >
                 <input
                   aria-label="Select reputation item Verification: Completed identity verification"
-                  class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                  class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                   type="checkbox"
                 />
                 <span>
                   <span
-                    class="block text-sm font-medium text-slate-500"
+                    class="block text-sm font-medium text-[var(--muted-foreground)]"
                   >
                     Verification
                   </span>
                   <span
-                    class="mt-1 block text-base font-semibold text-slate-950"
+                    class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                   >
                     Completed identity verification
                   </span>
                 </span>
               </label>
-              <time
-                class="text-sm text-slate-500 sm:text-right"
-                datetime="2026-04-24"
+              <div
+                class="flex items-center gap-2 sm:flex-col sm:items-end"
               >
-                2026-04-24
-              </time>
+                <time
+                  class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                  datetime="2026-04-24"
+                >
+                  2026-04-24
+                </time>
+                <div
+                  class="flex items-center gap-1.5"
+                >
+                  <code
+                    class="text-xs text-[var(--muted-foreground)] font-mono"
+                    data-testid="reputation-event-id-ev-1"
+                  >
+                    ev-1
+                  </code>
+                  <button
+                    aria-label="Copy reputation event ID ev-1 to clipboard"
+                    aria-pressed="false"
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                    data-testid="copy-reputation-id-btn-ev-1"
+                    title="Copy ID to clipboard"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      height="12"
+                      viewBox="0 0 12 12"
+                      width="12"
+                    >
+                      <rect
+                        height="8"
+                        rx="1"
+                        stroke="currentColor"
+                        stroke-width="1.2"
+                        width="7"
+                        x="1"
+                        y="3"
+                      />
+                      <path
+                        d="M4 1h6a1 1 0 0 1 1 1v8"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-width="1.2"
+                      />
+                    </svg>
+                    Copy ID
+                  </button>
+                </div>
+              </div>
             </div>
           </li>
           <li
@@ -1344,28 +1542,75 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
               >
                 <input
                   aria-label="Select reputation item On-chain review: Received positive trust signal"
-                  class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                  class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                   type="checkbox"
                 />
                 <span>
                   <span
-                    class="block text-sm font-medium text-slate-500"
+                    class="block text-sm font-medium text-[var(--muted-foreground)]"
                   >
                     On-chain review
                   </span>
                   <span
-                    class="mt-1 block text-base font-semibold text-slate-950"
+                    class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                   >
                     Received positive trust signal
                   </span>
                 </span>
               </label>
-              <time
-                class="text-sm text-slate-500 sm:text-right"
-                datetime="2026-04-23"
+              <div
+                class="flex items-center gap-2 sm:flex-col sm:items-end"
               >
-                2026-04-23
-              </time>
+                <time
+                  class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                  datetime="2026-04-23"
+                >
+                  2026-04-23
+                </time>
+                <div
+                  class="flex items-center gap-1.5"
+                >
+                  <code
+                    class="text-xs text-[var(--muted-foreground)] font-mono"
+                    data-testid="reputation-event-id-ev-2"
+                  >
+                    ev-2
+                  </code>
+                  <button
+                    aria-label="Copy reputation event ID ev-2 to clipboard"
+                    aria-pressed="false"
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                    data-testid="copy-reputation-id-btn-ev-2"
+                    title="Copy ID to clipboard"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      height="12"
+                      viewBox="0 0 12 12"
+                      width="12"
+                    >
+                      <rect
+                        height="8"
+                        rx="1"
+                        stroke="currentColor"
+                        stroke-width="1.2"
+                        width="7"
+                        x="1"
+                        y="3"
+                      />
+                      <path
+                        d="M4 1h6a1 1 0 0 1 1 1v8"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-width="1.2"
+                      />
+                    </svg>
+                    Copy ID
+                  </button>
+                </div>
+              </div>
             </div>
           </li>
           <li
@@ -1379,28 +1624,75 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
               >
                 <input
                   aria-label="Select reputation item Referral: Referred two new community members"
-                  class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                  class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                   type="checkbox"
                 />
                 <span>
                   <span
-                    class="block text-sm font-medium text-slate-500"
+                    class="block text-sm font-medium text-[var(--muted-foreground)]"
                   >
                     Referral
                   </span>
                   <span
-                    class="mt-1 block text-base font-semibold text-slate-950"
+                    class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                   >
                     Referred two new community members
                   </span>
                 </span>
               </label>
-              <time
-                class="text-sm text-slate-500 sm:text-right"
-                datetime="2026-04-20"
+              <div
+                class="flex items-center gap-2 sm:flex-col sm:items-end"
               >
-                2026-04-20
-              </time>
+                <time
+                  class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                  datetime="2026-04-20"
+                >
+                  2026-04-20
+                </time>
+                <div
+                  class="flex items-center gap-1.5"
+                >
+                  <code
+                    class="text-xs text-[var(--muted-foreground)] font-mono"
+                    data-testid="reputation-event-id-ev-3"
+                  >
+                    ev-3
+                  </code>
+                  <button
+                    aria-label="Copy reputation event ID ev-3 to clipboard"
+                    aria-pressed="false"
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                    data-testid="copy-reputation-id-btn-ev-3"
+                    title="Copy ID to clipboard"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      height="12"
+                      viewBox="0 0 12 12"
+                      width="12"
+                    >
+                      <rect
+                        height="8"
+                        rx="1"
+                        stroke="currentColor"
+                        stroke-width="1.2"
+                        width="7"
+                        x="1"
+                        y="3"
+                      />
+                      <path
+                        d="M4 1h6a1 1 0 0 1 1 1v8"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-width="1.2"
+                      />
+                    </svg>
+                    Copy ID
+                  </button>
+                </div>
+              </div>
             </div>
           </li>
         </ol>
@@ -1520,7 +1812,7 @@ exports[`ReputationPageContent snapshot – partial state (score === 0) matches 
           </p>
         </div>
         <div
-          class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+          class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
         >
           <p
             class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1541,7 +1833,7 @@ exports[`ReputationPageContent snapshot – partial state (score === 0) matches 
           </p>
         </div>
         <div
-          class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+          class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
         >
           <p
             class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1688,7 +1980,7 @@ exports[`ReputationPageContent snapshot – partial state (score === 0) matches 
           class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4"
         >
           <span
-            class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600"
+            class="rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--muted-foreground)]"
           >
             Private by default
           </span>
@@ -1820,7 +2112,7 @@ exports[`ReputationPageContent snapshot – partial state (score, no history) ma
           </p>
         </div>
         <div
-          class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+          class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
         >
           <p
             class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1841,7 +2133,7 @@ exports[`ReputationPageContent snapshot – partial state (score, no history) ma
           </p>
         </div>
         <div
-          class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+          class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
         >
           <p
             class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1988,7 +2280,7 @@ exports[`ReputationPageContent snapshot – partial state (score, no history) ma
           class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4"
         >
           <span
-            class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600"
+            class="rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--muted-foreground)]"
           >
             Private by default
           </span>

--- a/src/components/ReputationProfile.tsx
+++ b/src/components/ReputationProfile.tsx
@@ -67,6 +67,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ConfirmDialog } from './ConfirmDialog';
 import { useToast } from './toast/toast-provider';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import {
   DEFAULT_DIR,
   DEFAULT_TYPE,
@@ -82,6 +83,119 @@ import {
 
 /** Number of history events shown per page before "Load more" is needed. */
 export const REPUTATION_PAGE_SIZE = 5;
+
+// ---------------------------------------------------------------------------
+// execCommandFallback — documented clipboard fallback when Clipboard API is
+// unavailable (e.g. non-HTTPS, older browsers).
+// ---------------------------------------------------------------------------
+
+/**
+ * Falls back to the deprecated `document.execCommand('copy')` API when the
+ * Clipboard API is not available. Creates an off-screen textarea, selects its
+ * value, and invokes execCommand. The textarea is always removed from the DOM.
+ *
+ * @param text - The string to copy to the clipboard.
+ * @returns `true` if the execCommand succeeded; `false` otherwise.
+ */
+export function execCommandFallback(text: string): boolean {
+  if (typeof document === 'undefined') return false;
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.left = '-9999px';
+  textarea.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  let success = false;
+  try {
+    success = document.execCommand('copy');
+  } catch {
+    // execCommand not supported — success remains false
+  } finally {
+    document.body.removeChild(textarea);
+  }
+  return success;
+}
+
+// ---------------------------------------------------------------------------
+// CopyIdButton — accessible copy control for a single reputation event ID
+// ---------------------------------------------------------------------------
+
+interface CopyIdButtonProps {
+  /** The reputation event ID to copy. */
+  eventId: string;
+}
+
+/**
+ * Icon-button (with visible "Copy" label) that copies the given reputation
+ * event ID to the clipboard.
+ *
+ * - Uses the Clipboard API with a documented `execCommand` fallback.
+ * - Surfaces success/failure through the global toast system.
+ * - Keyboard-operable; has a descriptive `aria-label` for screen readers.
+ * - `aria-pressed` reflects the transient "copied" confirmation state.
+ */
+function CopyIdButton({ eventId }: CopyIdButtonProps) {
+  const { showSuccess, showError } = useToast();
+
+  const { copied, copy } = useCopyToClipboard({
+    onSuccess: () => {
+      showSuccess({ title: `Copied "${eventId}" to clipboard.` });
+    },
+    onError: () => {
+      // Documented fallback: try execCommand when Clipboard API is unavailable
+      const success = execCommandFallback(eventId);
+      if (success) {
+        showSuccess({ title: `Copied "${eventId}" to clipboard.` });
+      } else {
+        showError({ title: `Failed to copy "${eventId}". Please copy it manually.` });
+      }
+    },
+  });
+
+  const handleClick = React.useCallback(() => {
+    copy(eventId);
+  }, [copy, eventId]);
+
+  return (
+    <button
+      type="button"
+      aria-label={`Copy reputation event ID ${eventId} to clipboard`}
+      aria-pressed={copied}
+      data-testid={`copy-reputation-id-btn-${eventId}`}
+      title="Copy ID to clipboard"
+      onClick={handleClick}
+      className={[
+        'inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500',
+        copied
+          ? 'bg-green-50 border-green-400 text-green-700'
+          : 'bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]',
+      ].join(' ')}
+    >
+      {copied ? (
+        <>
+          <svg aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Copied
+        </>
+      ) : (
+        <>
+          <svg aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <rect x="1" y="3" width="7" height="8" rx="1" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M4 1h6a1 1 0 0 1 1 1v8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+          Copy ID
+        </>
+      )}
+    </button>
+  );
+}
 
 export default function ReputationProfile({
   name,
@@ -493,12 +607,23 @@ export default function ReputationProfile({
                           <span className="mt-1 block text-base font-semibold text-[var(--foreground)]">{event.summary}</span>
                         </span>
                       </label>
-                      <time
-                        className="text-sm text-[var(--muted-foreground)] sm:text-right"
-                        {...(isValidDate ? { dateTime: event.date } : {})}
-                      >
-                        {event.date}
-                      </time>
+                      <div className="flex items-center gap-2 sm:flex-col sm:items-end">
+                        <time
+                          className="text-sm text-[var(--muted-foreground)] sm:text-right"
+                          {...(isValidDate ? { dateTime: event.date } : {})}
+                        >
+                          {event.date}
+                        </time>
+                        <div className="flex items-center gap-1.5">
+                          <code
+                            data-testid={`reputation-event-id-${event.id}`}
+                            className="text-xs text-[var(--muted-foreground)] font-mono"
+                          >
+                            {event.id}
+                          </code>
+                          <CopyIdButton eventId={event.id} />
+                        </div>
+                      </div>
                     </div>
                   </li>
                 );

--- a/src/components/__snapshots__/ReputationProfile.snapshot.test.tsx.snap
+++ b/src/components/__snapshots__/ReputationProfile.snapshot.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -115,7 +115,7 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -251,13 +251,13 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
           class="flex items-center gap-2"
         >
           <label
-            class="text-sm font-medium text-slate-700"
+            class="text-sm font-medium text-[var(--foreground)]"
             for="history-type-filter"
           >
             Filter:
           </label>
           <select
-            class="rounded-lg border border-slate-300 py-1 pl-3 pr-8 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            class="rounded-lg border border-[var(--border)] bg-[var(--card)] py-1 pl-3 pr-8 text-sm text-[var(--foreground)] focus:border-[var(--ring)] focus:outline-none focus:ring-1 focus:ring-[var(--ring)]"
             data-testid="reputation-type-filter"
             id="history-type-filter"
           >
@@ -287,13 +287,13 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
           class="flex items-center gap-2"
         >
           <label
-            class="text-sm font-medium text-slate-700"
+            class="text-sm font-medium text-[var(--foreground)]"
             for="history-sort-dir"
           >
             Sort:
           </label>
           <select
-            class="rounded-lg border border-slate-300 py-1 pl-3 pr-8 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            class="rounded-lg border border-[var(--border)] bg-[var(--card)] py-1 pl-3 pr-8 text-sm text-[var(--foreground)] focus:border-[var(--ring)] focus:outline-none focus:ring-1 focus:ring-[var(--ring)]"
             data-testid="reputation-sort-dir"
             id="history-sort-dir"
           >
@@ -321,7 +321,7 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
           newest first
         </div>
         <span
-          class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600"
+          class="rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--muted-foreground)]"
         >
           Visible
         </span>
@@ -343,22 +343,26 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
         >
           <input
             aria-label="Select all reputation items"
-            class="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+            class="h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
             type="checkbox"
           />
           Select all
         </label>
         <div
+          aria-label="Reputation history actions"
           class="flex flex-wrap gap-2"
+          role="toolbar"
         >
           <button
-            class="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-900 transition hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Export selected reputation items"
+            class="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm font-semibold text-[var(--foreground)] transition hover:border-[var(--muted-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
             disabled=""
             type="button"
           >
             Export selected
           </button>
           <button
+            aria-label="Delete selected reputation items"
             class="rounded-2xl bg-rose-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
             disabled=""
             type="button"
@@ -366,7 +370,8 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
             Delete selected
           </button>
           <button
-            class="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-900 transition hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Clear selected reputation items; clear selection"
+            class="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm font-semibold text-[var(--foreground)] transition hover:border-[var(--muted-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
             disabled=""
             type="button"
           >
@@ -388,28 +393,75 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
             >
               <input
                 aria-label="Select reputation item Verification: Completed identity verification"
-                class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                 type="checkbox"
               />
               <span>
                 <span
-                  class="block text-sm font-medium text-slate-500"
+                  class="block text-sm font-medium text-[var(--muted-foreground)]"
                 >
                   Verification
                 </span>
                 <span
-                  class="mt-1 block text-base font-semibold text-slate-950"
+                  class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                 >
                   Completed identity verification
                 </span>
               </span>
             </label>
-            <time
-              class="text-sm text-slate-500 sm:text-right"
-              datetime="2026-04-24"
+            <div
+              class="flex items-center gap-2 sm:flex-col sm:items-end"
             >
-              2026-04-24
-            </time>
+              <time
+                class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                datetime="2026-04-24"
+              >
+                2026-04-24
+              </time>
+              <div
+                class="flex items-center gap-1.5"
+              >
+                <code
+                  class="text-xs text-[var(--muted-foreground)] font-mono"
+                  data-testid="reputation-event-id-ev-1"
+                >
+                  ev-1
+                </code>
+                <button
+                  aria-label="Copy reputation event ID ev-1 to clipboard"
+                  aria-pressed="false"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                  data-testid="copy-reputation-id-btn-ev-1"
+                  title="Copy ID to clipboard"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="none"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                  >
+                    <rect
+                      height="8"
+                      rx="1"
+                      stroke="currentColor"
+                      stroke-width="1.2"
+                      width="7"
+                      x="1"
+                      y="3"
+                    />
+                    <path
+                      d="M4 1h6a1 1 0 0 1 1 1v8"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-width="1.2"
+                    />
+                  </svg>
+                  Copy ID
+                </button>
+              </div>
+            </div>
           </div>
         </li>
         <li
@@ -423,28 +475,75 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
             >
               <input
                 aria-label="Select reputation item On-chain review: Received positive trust signal"
-                class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                 type="checkbox"
               />
               <span>
                 <span
-                  class="block text-sm font-medium text-slate-500"
+                  class="block text-sm font-medium text-[var(--muted-foreground)]"
                 >
                   On-chain review
                 </span>
                 <span
-                  class="mt-1 block text-base font-semibold text-slate-950"
+                  class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                 >
                   Received positive trust signal
                 </span>
               </span>
             </label>
-            <time
-              class="text-sm text-slate-500 sm:text-right"
-              datetime="2026-04-23"
+            <div
+              class="flex items-center gap-2 sm:flex-col sm:items-end"
             >
-              2026-04-23
-            </time>
+              <time
+                class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                datetime="2026-04-23"
+              >
+                2026-04-23
+              </time>
+              <div
+                class="flex items-center gap-1.5"
+              >
+                <code
+                  class="text-xs text-[var(--muted-foreground)] font-mono"
+                  data-testid="reputation-event-id-ev-2"
+                >
+                  ev-2
+                </code>
+                <button
+                  aria-label="Copy reputation event ID ev-2 to clipboard"
+                  aria-pressed="false"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                  data-testid="copy-reputation-id-btn-ev-2"
+                  title="Copy ID to clipboard"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="none"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                  >
+                    <rect
+                      height="8"
+                      rx="1"
+                      stroke="currentColor"
+                      stroke-width="1.2"
+                      width="7"
+                      x="1"
+                      y="3"
+                    />
+                    <path
+                      d="M4 1h6a1 1 0 0 1 1 1v8"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-width="1.2"
+                    />
+                  </svg>
+                  Copy ID
+                </button>
+              </div>
+            </div>
           </div>
         </li>
         <li
@@ -458,28 +557,75 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
             >
               <input
                 aria-label="Select reputation item Referral: Referred two new community members"
-                class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                 type="checkbox"
               />
               <span>
                 <span
-                  class="block text-sm font-medium text-slate-500"
+                  class="block text-sm font-medium text-[var(--muted-foreground)]"
                 >
                   Referral
                 </span>
                 <span
-                  class="mt-1 block text-base font-semibold text-slate-950"
+                  class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                 >
                   Referred two new community members
                 </span>
               </span>
             </label>
-            <time
-              class="text-sm text-slate-500 sm:text-right"
-              datetime="2026-04-20"
+            <div
+              class="flex items-center gap-2 sm:flex-col sm:items-end"
             >
-              2026-04-20
-            </time>
+              <time
+                class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                datetime="2026-04-20"
+              >
+                2026-04-20
+              </time>
+              <div
+                class="flex items-center gap-1.5"
+              >
+                <code
+                  class="text-xs text-[var(--muted-foreground)] font-mono"
+                  data-testid="reputation-event-id-ev-3"
+                >
+                  ev-3
+                </code>
+                <button
+                  aria-label="Copy reputation event ID ev-3 to clipboard"
+                  aria-pressed="false"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                  data-testid="copy-reputation-id-btn-ev-3"
+                  title="Copy ID to clipboard"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="none"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                  >
+                    <rect
+                      height="8"
+                      rx="1"
+                      stroke="currentColor"
+                      stroke-width="1.2"
+                      width="7"
+                      x="1"
+                      y="3"
+                    />
+                    <path
+                      d="M4 1h6a1 1 0 0 1 1 1v8"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-width="1.2"
+                    />
+                  </svg>
+                  Copy ID
+                </button>
+              </div>
+            </div>
           </div>
         </li>
       </ol>
@@ -590,7 +736,7 @@ exports[`ReputationProfile snapshot – edge: score === 0 matches snapshot (fals
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -611,7 +757,7 @@ exports[`ReputationProfile snapshot – edge: score === 0 matches snapshot (fals
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -758,7 +904,7 @@ exports[`ReputationProfile snapshot – edge: score === 0 matches snapshot (fals
         class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4"
       >
         <span
-          class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600"
+          class="rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--muted-foreground)]"
         >
           Private by default
         </span>
@@ -881,7 +1027,7 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -902,7 +1048,7 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1038,13 +1184,13 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
           class="flex items-center gap-2"
         >
           <label
-            class="text-sm font-medium text-slate-700"
+            class="text-sm font-medium text-[var(--foreground)]"
             for="history-type-filter"
           >
             Filter:
           </label>
           <select
-            class="rounded-lg border border-slate-300 py-1 pl-3 pr-8 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            class="rounded-lg border border-[var(--border)] bg-[var(--card)] py-1 pl-3 pr-8 text-sm text-[var(--foreground)] focus:border-[var(--ring)] focus:outline-none focus:ring-1 focus:ring-[var(--ring)]"
             data-testid="reputation-type-filter"
             id="history-type-filter"
           >
@@ -1074,13 +1220,13 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
           class="flex items-center gap-2"
         >
           <label
-            class="text-sm font-medium text-slate-700"
+            class="text-sm font-medium text-[var(--foreground)]"
             for="history-sort-dir"
           >
             Sort:
           </label>
           <select
-            class="rounded-lg border border-slate-300 py-1 pl-3 pr-8 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            class="rounded-lg border border-[var(--border)] bg-[var(--card)] py-1 pl-3 pr-8 text-sm text-[var(--foreground)] focus:border-[var(--ring)] focus:outline-none focus:ring-1 focus:ring-[var(--ring)]"
             data-testid="reputation-sort-dir"
             id="history-sort-dir"
           >
@@ -1108,7 +1254,7 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
           newest first
         </div>
         <span
-          class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600"
+          class="rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--muted-foreground)]"
         >
           Visible
         </span>
@@ -1130,22 +1276,26 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
         >
           <input
             aria-label="Select all reputation items"
-            class="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+            class="h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
             type="checkbox"
           />
           Select all
         </label>
         <div
+          aria-label="Reputation history actions"
           class="flex flex-wrap gap-2"
+          role="toolbar"
         >
           <button
-            class="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-900 transition hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Export selected reputation items"
+            class="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm font-semibold text-[var(--foreground)] transition hover:border-[var(--muted-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
             disabled=""
             type="button"
           >
             Export selected
           </button>
           <button
+            aria-label="Delete selected reputation items"
             class="rounded-2xl bg-rose-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
             disabled=""
             type="button"
@@ -1153,7 +1303,8 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
             Delete selected
           </button>
           <button
-            class="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-900 transition hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Clear selected reputation items; clear selection"
+            class="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm font-semibold text-[var(--foreground)] transition hover:border-[var(--muted-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
             disabled=""
             type="button"
           >
@@ -1175,28 +1326,75 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
             >
               <input
                 aria-label="Select reputation item Verification: Completed identity verification"
-                class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                 type="checkbox"
               />
               <span>
                 <span
-                  class="block text-sm font-medium text-slate-500"
+                  class="block text-sm font-medium text-[var(--muted-foreground)]"
                 >
                   Verification
                 </span>
                 <span
-                  class="mt-1 block text-base font-semibold text-slate-950"
+                  class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                 >
                   Completed identity verification
                 </span>
               </span>
             </label>
-            <time
-              class="text-sm text-slate-500 sm:text-right"
-              datetime="2026-04-24"
+            <div
+              class="flex items-center gap-2 sm:flex-col sm:items-end"
             >
-              2026-04-24
-            </time>
+              <time
+                class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                datetime="2026-04-24"
+              >
+                2026-04-24
+              </time>
+              <div
+                class="flex items-center gap-1.5"
+              >
+                <code
+                  class="text-xs text-[var(--muted-foreground)] font-mono"
+                  data-testid="reputation-event-id-ev-1"
+                >
+                  ev-1
+                </code>
+                <button
+                  aria-label="Copy reputation event ID ev-1 to clipboard"
+                  aria-pressed="false"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                  data-testid="copy-reputation-id-btn-ev-1"
+                  title="Copy ID to clipboard"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="none"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                  >
+                    <rect
+                      height="8"
+                      rx="1"
+                      stroke="currentColor"
+                      stroke-width="1.2"
+                      width="7"
+                      x="1"
+                      y="3"
+                    />
+                    <path
+                      d="M4 1h6a1 1 0 0 1 1 1v8"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-width="1.2"
+                    />
+                  </svg>
+                  Copy ID
+                </button>
+              </div>
+            </div>
           </div>
         </li>
         <li
@@ -1210,28 +1408,75 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
             >
               <input
                 aria-label="Select reputation item On-chain review: Received positive trust signal"
-                class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                 type="checkbox"
               />
               <span>
                 <span
-                  class="block text-sm font-medium text-slate-500"
+                  class="block text-sm font-medium text-[var(--muted-foreground)]"
                 >
                   On-chain review
                 </span>
                 <span
-                  class="mt-1 block text-base font-semibold text-slate-950"
+                  class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                 >
                   Received positive trust signal
                 </span>
               </span>
             </label>
-            <time
-              class="text-sm text-slate-500 sm:text-right"
-              datetime="2026-04-23"
+            <div
+              class="flex items-center gap-2 sm:flex-col sm:items-end"
             >
-              2026-04-23
-            </time>
+              <time
+                class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                datetime="2026-04-23"
+              >
+                2026-04-23
+              </time>
+              <div
+                class="flex items-center gap-1.5"
+              >
+                <code
+                  class="text-xs text-[var(--muted-foreground)] font-mono"
+                  data-testid="reputation-event-id-ev-2"
+                >
+                  ev-2
+                </code>
+                <button
+                  aria-label="Copy reputation event ID ev-2 to clipboard"
+                  aria-pressed="false"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                  data-testid="copy-reputation-id-btn-ev-2"
+                  title="Copy ID to clipboard"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="none"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                  >
+                    <rect
+                      height="8"
+                      rx="1"
+                      stroke="currentColor"
+                      stroke-width="1.2"
+                      width="7"
+                      x="1"
+                      y="3"
+                    />
+                    <path
+                      d="M4 1h6a1 1 0 0 1 1 1v8"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-width="1.2"
+                    />
+                  </svg>
+                  Copy ID
+                </button>
+              </div>
+            </div>
           </div>
         </li>
         <li
@@ -1245,28 +1490,75 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
             >
               <input
                 aria-label="Select reputation item Referral: Referred two new community members"
-                class="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                class="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                 type="checkbox"
               />
               <span>
                 <span
-                  class="block text-sm font-medium text-slate-500"
+                  class="block text-sm font-medium text-[var(--muted-foreground)]"
                 >
                   Referral
                 </span>
                 <span
-                  class="mt-1 block text-base font-semibold text-slate-950"
+                  class="mt-1 block text-base font-semibold text-[var(--foreground)]"
                 >
                   Referred two new community members
                 </span>
               </span>
             </label>
-            <time
-              class="text-sm text-slate-500 sm:text-right"
-              datetime="2026-04-20"
+            <div
+              class="flex items-center gap-2 sm:flex-col sm:items-end"
             >
-              2026-04-20
-            </time>
+              <time
+                class="text-sm text-[var(--muted-foreground)] sm:text-right"
+                datetime="2026-04-20"
+              >
+                2026-04-20
+              </time>
+              <div
+                class="flex items-center gap-1.5"
+              >
+                <code
+                  class="text-xs text-[var(--muted-foreground)] font-mono"
+                  data-testid="reputation-event-id-ev-3"
+                >
+                  ev-3
+                </code>
+                <button
+                  aria-label="Copy reputation event ID ev-3 to clipboard"
+                  aria-pressed="false"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-mono border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 bg-[var(--card)] border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--surface)]"
+                  data-testid="copy-reputation-id-btn-ev-3"
+                  title="Copy ID to clipboard"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="none"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    width="12"
+                  >
+                    <rect
+                      height="8"
+                      rx="1"
+                      stroke="currentColor"
+                      stroke-width="1.2"
+                      width="7"
+                      x="1"
+                      y="3"
+                    />
+                    <path
+                      d="M4 1h6a1 1 0 0 1 1 1v8"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-width="1.2"
+                    />
+                  </svg>
+                  Copy ID
+                </button>
+              </div>
+            </div>
           </div>
         </li>
       </ol>
@@ -1357,7 +1649,7 @@ exports[`ReputationProfile snapshot – no reputation (null score) matches snaps
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1373,7 +1665,7 @@ exports[`ReputationProfile snapshot – no reputation (null score) matches snaps
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1410,7 +1702,7 @@ exports[`ReputationProfile snapshot – no reputation (null score) matches snaps
         class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4"
       >
         <span
-          class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600"
+          class="rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--muted-foreground)]"
         >
           Private by default
         </span>
@@ -1513,7 +1805,7 @@ exports[`ReputationProfile snapshot – no reputation (undefined score) matches 
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1529,7 +1821,7 @@ exports[`ReputationProfile snapshot – no reputation (undefined score) matches 
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1566,7 +1858,7 @@ exports[`ReputationProfile snapshot – no reputation (undefined score) matches 
         class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4"
       >
         <span
-          class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600"
+          class="rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--muted-foreground)]"
         >
           Private by default
         </span>
@@ -1689,7 +1981,7 @@ exports[`ReputationProfile snapshot – partial reputation (score, no history) m
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1710,7 +2002,7 @@ exports[`ReputationProfile snapshot – partial reputation (score, no history) m
         </p>
       </div>
       <div
-        class="rounded-3xl border-[var(--border)] bg-[var(--surface)] p-5"
+        class="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5"
       >
         <p
           class="text-sm font-medium text-[var(--muted-foreground)]"
@@ -1857,7 +2149,7 @@ exports[`ReputationProfile snapshot – partial reputation (score, no history) m
         class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4"
       >
         <span
-          class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-slate-600"
+          class="rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-medium uppercase tracking-[0.18em] text-[var(--muted-foreground)]"
         >
           Private by default
         </span>

--- a/src/components/__tests__/ReputationCopyId.test.tsx
+++ b/src/components/__tests__/ReputationCopyId.test.tsx
@@ -1,0 +1,323 @@
+/**
+ * ReputationCopyId.test.tsx
+ *
+ * Tests for the copy-to-clipboard feature added to ReputationProfile (issue #52).
+ * Covers:
+ *  - Copy button renders for each event ID
+ *  - Accessible label and aria-pressed state
+ *  - Clipboard API success path → toast shown
+ *  - Clipboard API unavailable → execCommand fallback → toast shown
+ *  - Both fallback paths fail → error toast shown
+ *  - Keyboard operability (button is focusable and clickable)
+ *  - execCommandFallback utility function unit tests
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ReputationProfile, {
+  ReputationEvent,
+  execCommandFallback,
+} from '../ReputationProfile';
+
+// ---------------------------------------------------------------------------
+// Mock next/navigation (required by ReputationProfile)
+// ---------------------------------------------------------------------------
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+// ---------------------------------------------------------------------------
+// Toast mock
+// ---------------------------------------------------------------------------
+
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+    dismissToast: jest.fn(),
+    toasts: [],
+  }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const EVENTS: ReputationEvent[] = [
+  { id: 'ev-001', type: 'Verification', summary: 'Identity verified', date: '2026-01-10' },
+  { id: 'ev-002', type: 'Review', summary: 'Positive review', date: '2026-01-12' },
+];
+
+function renderProfile(history = EVENTS) {
+  return render(
+    <ReputationProfile
+      name="Alice"
+      score={3}
+      history={history}
+      syncUrl={false}
+    />,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Clipboard helpers
+// ---------------------------------------------------------------------------
+
+let originalClipboard: typeof navigator.clipboard;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  originalClipboard = navigator.clipboard;
+  mockShowSuccess.mockClear();
+  mockShowError.mockClear();
+});
+
+afterEach(() => {
+  act(() => { jest.runAllTimers(); });
+  jest.useRealTimers();
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: originalClipboard });
+});
+
+function mockClipboard(impl: () => Promise<void> = () => Promise.resolve()) {
+  const writeText = jest.fn().mockImplementation(impl);
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+  return writeText;
+}
+
+function removeClipboard() {
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
+}
+
+// ---------------------------------------------------------------------------
+// Render: copy button present
+// ---------------------------------------------------------------------------
+
+describe('ReputationProfile — copy ID button renders', () => {
+  it('renders a copy button for each event', () => {
+    mockClipboard();
+    renderProfile();
+    EVENTS.forEach((e) => {
+      expect(screen.getByTestId(`copy-reputation-id-btn-${e.id}`)).toBeInTheDocument();
+    });
+  });
+
+  it('button has a descriptive aria-label containing the event ID', () => {
+    mockClipboard();
+    renderProfile();
+    expect(
+      screen.getByRole('button', { name: /Copy reputation event ID ev-001 to clipboard/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('button has aria-pressed="false" before any copy', () => {
+    mockClipboard();
+    renderProfile();
+    expect(screen.getByTestId('copy-reputation-id-btn-ev-001')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('displays the event ID as a code element next to the copy button', () => {
+    mockClipboard();
+    renderProfile();
+    expect(screen.getByTestId('reputation-event-id-ev-001')).toHaveTextContent('ev-001');
+  });
+
+  it('button text reads "Copy ID" before any click', () => {
+    mockClipboard();
+    renderProfile();
+    expect(screen.getByTestId('copy-reputation-id-btn-ev-001')).toHaveTextContent('Copy ID');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clipboard API success path
+// ---------------------------------------------------------------------------
+
+describe('ReputationProfile — Clipboard API success', () => {
+  it('calls navigator.clipboard.writeText with the event ID', async () => {
+    const writeText = mockClipboard();
+    renderProfile();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-reputation-id-btn-ev-001'));
+    });
+
+    expect(writeText).toHaveBeenCalledWith('ev-001');
+  });
+
+  it('shows a success toast after a successful copy', async () => {
+    mockClipboard();
+    renderProfile();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-reputation-id-btn-ev-001'));
+    });
+
+    expect(mockShowSuccess).toHaveBeenCalledTimes(1);
+    expect(mockShowSuccess.mock.calls[0][0]).toMatchObject({ title: expect.stringContaining('ev-001') });
+  });
+
+  it('button shows "Copied" and aria-pressed="true" after successful copy', async () => {
+    mockClipboard();
+    renderProfile();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-reputation-id-btn-ev-001'));
+    });
+
+    const btn = screen.getByTestId('copy-reputation-id-btn-ev-001');
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    expect(btn).toHaveTextContent('Copied');
+  });
+
+  it('button resets to "Copy ID" after the delay', async () => {
+    mockClipboard();
+    renderProfile();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-reputation-id-btn-ev-001'));
+    });
+
+    act(() => { jest.advanceTimersByTime(2000); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('copy-reputation-id-btn-ev-001')).toHaveTextContent('Copy ID');
+    });
+  });
+
+  it('only the clicked button shows "Copied"; other buttons are unaffected', async () => {
+    mockClipboard();
+    renderProfile();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-reputation-id-btn-ev-001'));
+    });
+
+    expect(screen.getByTestId('copy-reputation-id-btn-ev-001')).toHaveTextContent('Copied');
+    expect(screen.getByTestId('copy-reputation-id-btn-ev-002')).toHaveTextContent('Copy ID');
+  });
+
+  it('does not show an error toast on success', async () => {
+    mockClipboard();
+    renderProfile();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-reputation-id-btn-ev-001'));
+    });
+
+    expect(mockShowError).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clipboard API unavailable — execCommand fallback
+// ---------------------------------------------------------------------------
+
+describe('ReputationProfile — execCommand fallback (Clipboard API unavailable)', () => {
+  it('falls back to execCommand when navigator.clipboard is absent', async () => {
+    removeClipboard();
+    document.execCommand = jest.fn().mockReturnValue(true);
+    renderProfile();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-reputation-id-btn-ev-001'));
+    });
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(mockShowSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error toast when both Clipboard API and execCommand fail', async () => {
+    removeClipboard();
+    document.execCommand = jest.fn().mockReturnValue(false);
+    renderProfile();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-reputation-id-btn-ev-001'));
+    });
+
+    expect(mockShowError).toHaveBeenCalledTimes(1);
+    expect(mockShowError.mock.calls[0][0]).toMatchObject({ title: expect.stringContaining('ev-001') });
+  });
+
+  it('shows error toast when Clipboard API rejects', async () => {
+    mockClipboard(() => Promise.reject(new Error('Permission denied')));
+    document.execCommand = jest.fn().mockReturnValue(false);
+    renderProfile();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-reputation-id-btn-ev-001'));
+    });
+
+    expect(mockShowError).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard operability
+// ---------------------------------------------------------------------------
+
+describe('ReputationProfile — copy button keyboard operability', () => {
+  it('button is in the tab order (not disabled)', () => {
+    mockClipboard();
+    renderProfile();
+    const btn = screen.getByTestId('copy-reputation-id-btn-ev-001');
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('pressing Enter on the button triggers the copy', async () => {
+    const writeText = mockClipboard();
+    renderProfile();
+    const btn = screen.getByTestId('copy-reputation-id-btn-ev-001');
+
+    await act(async () => {
+      btn.focus();
+      fireEvent.keyDown(btn, { key: 'Enter' });
+      fireEvent.click(btn);
+    });
+
+    expect(writeText).toHaveBeenCalledWith('ev-001');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// execCommandFallback unit tests
+// ---------------------------------------------------------------------------
+
+describe('execCommandFallback', () => {
+  it('returns false in an SSR-like environment (document undefined)', () => {
+    const origDoc = global.document;
+    // @ts-expect-error - simulating SSR
+    delete global.document;
+    expect(execCommandFallback('test')).toBe(false);
+    global.document = origDoc;
+  });
+
+  it('returns true when execCommand succeeds', () => {
+    document.execCommand = jest.fn().mockReturnValue(true);
+    expect(execCommandFallback('abc')).toBe(true);
+  });
+
+  it('returns false when execCommand returns false', () => {
+    document.execCommand = jest.fn().mockReturnValue(false);
+    expect(execCommandFallback('abc')).toBe(false);
+  });
+
+  it('returns false when execCommand throws', () => {
+    document.execCommand = jest.fn().mockImplementation(() => { throw new Error('not supported'); });
+    expect(execCommandFallback('abc')).toBe(false);
+  });
+
+  it('removes the textarea from the DOM after completion', () => {
+    document.execCommand = jest.fn().mockReturnValue(true);
+    const countBefore = document.body.querySelectorAll('textarea').length;
+    execCommandFallback('hello');
+    expect(document.body.querySelectorAll('textarea').length).toBe(countBefore);
+  });
+});

--- a/src/components/__tests__/__snapshots__/DialogStructure.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DialogStructure.test.tsx.snap
@@ -31,12 +31,13 @@ exports[`dialog rendered structure ConfirmDialog keeps destructive confirmations
       class="flex justify-end space-x-3"
     >
       <button
+        class="px-4 py-2 rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
         type="button"
       >
         Cancel
       </button>
       <button
-        class="px-4 py-2 rounded bg-primary-600 text-white hover:bg-primary-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        class="px-4 py-2 rounded text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 bg-red-600 hover:bg-red-700 focus-visible:ring-red-500"
         type="button"
       >
         Confirm
@@ -79,12 +80,13 @@ exports[`dialog rendered structure ConfirmDialog renders the loaded confirmation
       class="flex justify-end space-x-3"
     >
       <button
+        class="px-4 py-2 rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
         type="button"
       >
         Cancel
       </button>
       <button
-        class="px-4 py-2 rounded bg-primary-600 text-white hover:bg-primary-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        class="px-4 py-2 rounded text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 bg-blue-600 hover:bg-blue-700 focus-visible:ring-blue-500"
         type="button"
       >
         Confirm
@@ -1306,13 +1308,13 @@ exports[`dialog rendered structure MilestoneCreationForm renders a deterministic
         class="flex gap-3 justify-end mt-6"
       >
         <button
-          class="px-4 py-2 rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-50 font-medium"
+          class="px-4 py-2 rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-50 font-medium focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 font-medium"
+          class="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 font-medium focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
           type="submit"
         >
           Add Milestone
@@ -1510,13 +1512,13 @@ exports[`dialog rendered structure MilestoneCreationForm renders the empty creat
         class="flex gap-3 justify-end mt-6"
       >
         <button
-          class="px-4 py-2 rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-50 font-medium"
+          class="px-4 py-2 rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-50 font-medium focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 font-medium"
+          class="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 font-medium focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
           type="submit"
         >
           Add Milestone
@@ -1714,13 +1716,13 @@ exports[`dialog rendered structure MilestoneCreationForm renders the loaded/popu
         class="flex gap-3 justify-end mt-6"
       >
         <button
-          class="px-4 py-2 rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-50 font-medium"
+          class="px-4 py-2 rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-50 font-medium focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 font-medium"
+          class="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 font-medium focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
           type="submit"
         >
           Add Milestone
@@ -1745,6 +1747,7 @@ exports[`dialog rendered structure SettingsPanel renders the loaded settings dia
     aria-modal="true"
     class="relative w-full max-w-md bg-[var(--background)] shadow-xl flex flex-col h-full border-l border-[var(--border)]"
     role="dialog"
+    tabindex="-1"
   >
     <div
       class="flex items-center justify-between p-6 border-b border-[var(--border)]"
@@ -1758,8 +1761,10 @@ exports[`dialog rendered structure SettingsPanel renders the loaded settings dia
       <button
         aria-label="Close settings"
         class="p-2 rounded-full hover:bg-[var(--accent)] text-[var(--muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
+        type="button"
       >
         <svg
+          aria-hidden="true"
           class="w-6 h-6"
           fill="none"
           stroke="currentColor"
@@ -1803,22 +1808,25 @@ exports[`dialog rendered structure SettingsPanel renders the loaded settings dia
             >
               <button
                 aria-checked="false"
-                class="px-3 py-2 text-sm rounded-md border capitalize transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]"
+                class="px-3 py-2 text-sm rounded-md border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 capitalize border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]"
                 role="radio"
+                tabindex="-1"
               >
                 light
               </button>
               <button
                 aria-checked="false"
-                class="px-3 py-2 text-sm rounded-md border capitalize transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]"
+                class="px-3 py-2 text-sm rounded-md border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 capitalize border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]"
                 role="radio"
+                tabindex="-1"
               >
                 dark
               </button>
               <button
                 aria-checked="true"
-                class="px-3 py-2 text-sm rounded-md border capitalize transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]"
+                class="px-3 py-2 text-sm rounded-md border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 capitalize border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]"
                 role="radio"
+                tabindex="0"
               >
                 system
               </button>
@@ -1839,22 +1847,25 @@ exports[`dialog rendered structure SettingsPanel renders the loaded settings dia
             >
               <button
                 aria-checked="true"
-                class="px-3 py-2 text-sm rounded-md border uppercase transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]"
+                class="px-3 py-2 text-sm rounded-md border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 uppercase border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]"
                 role="radio"
+                tabindex="0"
               >
                 usd
               </button>
               <button
                 aria-checked="false"
-                class="px-3 py-2 text-sm rounded-md border uppercase transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]"
+                class="px-3 py-2 text-sm rounded-md border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 uppercase border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]"
                 role="radio"
+                tabindex="-1"
               >
                 ngn
               </button>
               <button
                 aria-checked="false"
-                class="px-3 py-2 text-sm rounded-md border uppercase transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]"
+                class="px-3 py-2 text-sm rounded-md border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 uppercase border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]"
                 role="radio"
+                tabindex="-1"
               >
                 compact
               </button>
@@ -1888,10 +1899,41 @@ exports[`dialog rendered structure SettingsPanel renders the loaded settings dia
             >
               <button
                 aria-checked="true"
+                class="px-3 py-2 text-sm rounded-md border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 capitalize border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]"
+                role="radio"
+                tabindex="0"
+              >
+                relaxed
+              </button>
+              <button
+                aria-checked="false"
+                class="px-3 py-2 text-sm rounded-md border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 capitalize border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-[var(--muted-foreground)]"
+                role="radio"
+                tabindex="-1"
+              >
+                compact
+              </button>
+            </div>
+          </div>
+          <div>
+            <label
+              class="block text-sm font-medium mb-2 text-[var(--foreground)]"
+              id="form-density-label"
+            >
+              Form Density
+            </label>
+            <div
+              aria-label="Form Density"
+              aria-labelledby="form-density-label"
+              class="grid grid-cols-2 gap-2"
+              role="radiogroup"
+            >
+              <button
+                aria-checked="true"
                 class="px-3 py-2 text-sm rounded-md border capitalize transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]"
                 role="radio"
               >
-                relaxed
+                comfortable
               </button>
               <button
                 aria-checked="false"


### PR DESCRIPTION
- Add CopyIdButton sub-component to ReputationProfile with aria-label, aria-pressed, and data-testid for each event ID
- Use useCopyToClipboard hook (Clipboard API) with documented execCommandFallback for environments without clipboard access
- Show success/error toasts via useToast on copy outcome
- Display event ID as <code> element alongside copy button
- Export execCommandFallback for independent unit testing
- Add 21 tests in ReputationCopyId.test.tsx covering success path, fallback path, error path, keyboard operability, and utility fn
- Update ReputationProfile and page snapshots


## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->


closes #861 
