### PR TITLE
a11y(contracts): add modal focus trap

### DIFF
--- a/src/components/contracts/CreateContractForm.tsx
+++ b/src/components/contracts/CreateContractForm.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { FormField } from '@/components/FormField';
 import { ErrorSummary } from '@/components/ErrorSummary';
 import { WalletAddressInput } from '@/components/WalletAddressInput';
+import { useDialogFocusTrap } from '@/hooks/useDialogFocusTrap';
 import { useToast } from '@/components/toast/toast-provider';
 import { saveContract } from '@/lib/repository';
 import { normalizeStellarAddress } from '@/lib/stellarAddress';
@@ -33,10 +34,15 @@ export interface CreateContractFormProps {
 const CURRENCY_OPTIONS = ['USD', 'XLM', 'EUR', 'GBP'] as const;
 
 /**
- * `CreateContractForm` — an accessible, validated inline form for creating
+ * `CreateContractForm` — an accessible, validated modal form for creating
  * a new TalentTrust escrow contract.
  *
  * Accessibility contract:
+ * - It renders as a `role="dialog"` / `aria-modal="true"` overlay.
+ * - Focus is trapped inside the dialog and cycles through all focusable
+ *   elements via Tab / Shift+Tab.
+ * - Pressing Escape calls `onCancel`.
+ * - On close, focus returns to the trigger element that opened the form.
  * - The form is labelled by a visible `<h2>` via `aria-labelledby`.
  * - Every field is wrapped in `FormField`, which wires `<label>`,
  *   `aria-invalid`, and `aria-describedby` automatically.
@@ -47,7 +53,17 @@ const CURRENCY_OPTIONS = ['USD', 'XLM', 'EUR', 'GBP'] as const;
  *   no `alert()` is used.
  */
 const CreateContractForm: React.FC<CreateContractFormProps> = ({ onSuccess, onCancel }) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const contractNameRef = useRef<HTMLInputElement>(null);
   const { showSuccess } = useToast();
+
+  useDialogFocusTrap({
+    isOpen: true,
+    dialogRef,
+    initialFocusRef: contractNameRef,
+    onEscape: onCancel,
+    restoreFocus: true,
+  });
 
   const [contractName, setContractName] = useState('');
   const [freelancerAddress, setFreelancerAddress] = useState('');
@@ -117,109 +133,120 @@ const CreateContractForm: React.FC<CreateContractFormProps> = ({ onSuccess, onCa
     'w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition';
 
   return (
-    <section
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden bg-black/50 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
       aria-labelledby="create-contract-heading"
-      className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+      onClick={onCancel}
     >
-      <h2
-        id="create-contract-heading"
-        className="text-xl font-semibold text-slate-900 mb-6"
+      {/* Stop click propagation so clicking inside the form does not dismiss */}
+      <div
+        className="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-3xl border border-slate-200 bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
       >
-        Create a new contract
-      </h2>
-
-      <ErrorSummary errors={errors} />
-
-      <form onSubmit={handleSubmit} noValidate>
-        <FormField
-          id="contractName"
-          label="Contract name"
-          error={errors.find((e) => e.fieldId === 'contractName')?.message}
-          required
+        <h2
+          id="create-contract-heading"
+          className="text-xl font-semibold text-slate-900 mb-6"
         >
-          <input
-            type="text"
-            value={contractName}
-            onChange={(e) => {
-              setContractName(e.target.value);
-              setErrors((prev) => prev.filter((err) => err.fieldId !== 'contractName'));
-            }}
-            placeholder="e.g. Website Redesign"
-            autoComplete="off"
-            className={inputClass}
+          Create a new contract
+        </h2>
+
+        <ErrorSummary errors={errors} />
+
+        <form onSubmit={handleSubmit} noValidate>
+          <FormField
+            id="contractName"
+            label="Contract name"
+            error={errors.find((e) => e.fieldId === 'contractName')?.message}
+            required
+          >
+            <input
+              ref={contractNameRef}
+              type="text"
+              value={contractName}
+              onChange={(e) => {
+                setContractName(e.target.value);
+                setErrors((prev) => prev.filter((err) => err.fieldId !== 'contractName'));
+              }}
+              placeholder="e.g. Website Redesign"
+              autoComplete="off"
+              className={inputClass}
+            />
+          </FormField>
+
+          <WalletAddressInput
+            id="freelancerAddress"
+            label="Freelancer Stellar address"
+            helperText="Must be a valid Stellar public key starting with G"
+            value={freelancerAddress}
+            onChange={setFreelancerAddress}
+            error={errors.find((e) => e.fieldId === 'freelancerAddress')?.message}
+            required
+            onValidation={handleWalletValidation}
           />
-        </FormField>
 
-        <WalletAddressInput
-          id="freelancerAddress"
-          label="Freelancer Stellar address"
-          helperText="Must be a valid Stellar public key starting with G"
-          value={freelancerAddress}
-          onChange={setFreelancerAddress}
-          error={errors.find((e) => e.fieldId === 'freelancerAddress')?.message}
-          required
-          onValidation={handleWalletValidation}
-        />
-
-        <FormField
-          id="totalValue"
-          label="Total value"
-          error={errors.find((e) => e.fieldId === 'totalValue')?.message}
-          required
-        >
-          <input
-            type="number"
-            value={totalValue}
-            onChange={(e) => {
-              setTotalValue(e.target.value);
-              setErrors((prev) => prev.filter((err) => err.fieldId !== 'totalValue'));
-            }}
-            placeholder="0.00"
-            min="0.01"
-            step="any"
-            className={inputClass}
-          />
-        </FormField>
-
-        <FormField
-          id="currency"
-          label="Currency"
-          error={errors.find((e) => e.fieldId === 'currency')?.message}
-          required
-        >
-          <select
-            value={currency}
-            onChange={(e) => {
-              setCurrency(e.target.value);
-              setErrors((prev) => prev.filter((err) => err.fieldId !== 'currency'));
-            }}
-            className={inputClass}
+          <FormField
+            id="totalValue"
+            label="Total value"
+            error={errors.find((e) => e.fieldId === 'totalValue')?.message}
+            required
           >
-            {CURRENCY_OPTIONS.map((c) => (
-              <option key={c} value={c}>
-                {c}
-              </option>
-            ))}
-          </select>
-        </FormField>
+            <input
+              type="number"
+              value={totalValue}
+              onChange={(e) => {
+                setTotalValue(e.target.value);
+                setErrors((prev) => prev.filter((err) => err.fieldId !== 'totalValue'));
+              }}
+              placeholder="0.00"
+              min="0.01"
+              step="any"
+              className={inputClass}
+            />
+          </FormField>
 
-        <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-          <button
-            type="submit"
-            className="rounded-2xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          <FormField
+            id="currency"
+            label="Currency"
+            error={errors.find((e) => e.fieldId === 'currency')?.message}
+            required
           >
-            Create Contract
-          </button>
-          <button
-            type="button"
-            onClick={onCancel}
-            className="rounded-2xl border border-slate-300 bg-white px-6 py-2.5 text-sm font-semibold text-slate-900 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-          >
-            Cancel
-          </button>
-        </div>
-      </form>
-    </section>
+            <select
+              value={currency}
+              onChange={(e) => {
+                setCurrency(e.target.value);
+                setErrors((prev) => prev.filter((err) => err.fieldId !== 'currency'));
+              }}
+              className={inputClass}
+            >
+              {CURRENCY_OPTIONS.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </FormField>
+
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+            <button
+              type="submit"
+              className="rounded-2xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+            >
+              Create Contract
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-2xl border border-slate-300 bg-white px-6 py-2.5 text-sm font-semibold text-slate-900 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/contracts/__tests__/CreateContractForm.test.tsx
+++ b/src/components/contracts/__tests__/CreateContractForm.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import CreateContractForm from '../CreateContractForm';
 
@@ -41,6 +42,44 @@ function renderForm() {
 }
 
 // ---------------------------------------------------------------------------
+// Test harness for focus-management tests
+// ---------------------------------------------------------------------------
+
+function createFocusTestHarness() {
+  const dialogOnCancel = jest.fn();
+  const dialogOnSuccess = jest.fn();
+
+  function Harness() {
+    const [isOpen, setIsOpen] = React.useState(false);
+
+    return (
+      <>
+        <button type="button" onClick={() => setIsOpen(true)}>
+          Open contract form
+        </button>
+        <button type="button" onClick={() => setIsOpen(false)}>
+          External close
+        </button>
+        {isOpen && (
+          <CreateContractForm
+            onSuccess={(contract) => {
+              dialogOnSuccess(contract);
+              setIsOpen(false);
+            }}
+            onCancel={() => {
+              dialogOnCancel();
+              setIsOpen(false);
+            }}
+          />
+        )}
+      </>
+    );
+  }
+
+  return { Harness, dialogOnCancel, dialogOnSuccess };
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -58,6 +97,14 @@ describe('CreateContractForm', () => {
     expect(screen.getByLabelText(/currency/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /create contract/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it('renders as a modal dialog with correct ARIA attributes', () => {
+    renderForm();
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'create-contract-heading');
   });
 
   it('matches the empty-state form structure', () => {
@@ -395,5 +442,131 @@ describe('CreateContractForm', () => {
     expect(screen.queryByText('Contract name is required')).not.toBeInTheDocument();
     expect(screen.queryByText('Freelancer address is required')).not.toBeInTheDocument();
     expect(screen.queryByText('Total value must be a positive number')).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Focus management
+  // ---------------------------------------------------------------------------
+
+  describe('focus management', () => {
+    it('sets initial focus to the contract name field when opened', async () => {
+      const user = userEvent.setup();
+      const { Harness } = createFocusTestHarness();
+      render(<Harness />);
+
+      await user.click(screen.getByRole('button', { name: 'Open contract form' }));
+
+      expect(screen.getByLabelText(/contract name/i)).toHaveFocus();
+    });
+
+    it('invokes onCancel when Escape is pressed', async () => {
+      const user = userEvent.setup();
+      const { Harness, dialogOnCancel } = createFocusTestHarness();
+      render(<Harness />);
+
+      await user.click(screen.getByRole('button', { name: 'Open contract form' }));
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+
+      expect(dialogOnCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('traps Tab focus within the dialog while open', async () => {
+      const user = userEvent.setup();
+      const { Harness } = createFocusTestHarness();
+      render(<Harness />);
+
+      await user.click(screen.getByRole('button', { name: 'Open contract form' }));
+      const dialog = screen.getByRole('dialog');
+
+      // First get all focusable elements inside the dialog
+      const focusable = dialog.querySelectorAll(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      const focusableArray = Array.from(focusable) as HTMLElement[];
+      expect(focusableArray.length).toBeGreaterThan(0);
+
+      const firstFocusable = focusableArray[0];
+      const lastFocusable = focusableArray[focusableArray.length - 1];
+
+      // Focus the last element, then Tab — should wrap to the first
+      lastFocusable.focus();
+      await user.tab();
+
+      expect(firstFocusable).toHaveFocus();
+    });
+
+    it('cycles Shift+Tab from the first control back to the last control', async () => {
+      const user = userEvent.setup();
+      const { Harness } = createFocusTestHarness();
+      render(<Harness />);
+
+      await user.click(screen.getByRole('button', { name: 'Open contract form' }));
+      const dialog = screen.getByRole('dialog');
+      const contractNameInput = screen.getByLabelText(/contract name/i);
+
+      contractNameInput.focus();
+      await user.tab({ shift: true });
+
+      const focusable = dialog.querySelectorAll(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      const focusableArray = Array.from(focusable);
+      const lastFocusable = focusableArray[focusableArray.length - 1];
+
+      expect(lastFocusable).toHaveFocus();
+    });
+
+    it('restores focus to the trigger after closing with Escape', async () => {
+      const user = userEvent.setup();
+      const { Harness, dialogOnCancel } = createFocusTestHarness();
+      render(<Harness />);
+
+      const trigger = screen.getByRole('button', { name: 'Open contract form' });
+      await user.click(trigger);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+
+      expect(dialogOnCancel).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+
+    it('restores focus to the trigger after cancel button closes the dialog', async () => {
+      const user = userEvent.setup();
+      const { Harness } = createFocusTestHarness();
+      render(<Harness />);
+
+      const trigger = screen.getByRole('button', { name: 'Open contract form' });
+      await user.click(trigger);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+
+    it('restores focus to the trigger after successful submission', async () => {
+      const user = userEvent.setup();
+      const { Harness, dialogOnSuccess } = createFocusTestHarness();
+      render(<Harness />);
+
+      const trigger = screen.getByRole('button', { name: 'Open contract form' });
+      await user.click(trigger);
+
+      // Fill valid form data
+      await user.type(screen.getByLabelText(/contract name/i), 'Test Contract');
+      await user.type(screen.getByLabelText(/freelancer stellar address/i), VALID_ADDRESS);
+      await user.type(screen.getByLabelText(/total value/i), '1000');
+
+      await user.click(screen.getByRole('button', { name: /create contract/i }));
+
+      expect(dialogOnSuccess).toHaveBeenCalled();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
   });
 });

--- a/src/components/contracts/__tests__/__snapshots__/CreateContractForm.test.tsx.snap
+++ b/src/components/contracts/__tests__/__snapshots__/CreateContractForm.test.tsx.snap
@@ -1,563 +1,581 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CreateContractForm matches the empty-state form structure 1`] = `
-<section
+<div
   aria-labelledby="create-contract-heading"
-  class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+  aria-modal="true"
+  class="fixed inset-0 z-50 flex items-center justify-center overflow-hidden bg-black/50 backdrop-blur-sm"
+  role="dialog"
 >
-  <h2
-    class="text-xl font-semibold text-slate-900 mb-6"
-    id="create-contract-heading"
+  <div
+    class="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-3xl border border-slate-200 bg-white p-6 shadow-xl"
   >
-    Create a new contract
-  </h2>
-  <form
-    novalidate=""
-  >
-    <div
-      class="mb-4 w-full"
+    <h2
+      class="text-xl font-semibold text-slate-900 mb-6"
+      id="create-contract-heading"
     >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="contractName"
-      >
-        Contract name
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
-        >
-          *
-        </span>
-      </label>
-      <input
-        aria-invalid="false"
-        aria-required="true"
-        autocomplete="off"
-        class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
-        id="contractName"
-        placeholder="e.g. Website Redesign"
-        type="text"
-        value=""
-      />
-    </div>
-    <div
-      class="mb-4 w-full"
+      Create a new contract
+    </h2>
+    <form
+      novalidate=""
     >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="freelancerAddress"
+      <div
+        class="mb-4 w-full"
       >
-        Freelancer Stellar address
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="contractName"
         >
-          *
-        </span>
-      </label>
-      <input
-        aria-describedby="freelancerAddress-helper"
-        aria-invalid="false"
-        aria-required="true"
-        autocapitalize="off"
-        autocomplete="off"
-        class="w-full rounded-2xl border px-4 py-2.5 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
-        id="freelancerAddress"
-        maxlength="56"
-        placeholder="GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-        spellcheck="false"
-        type="text"
-        value=""
-      />
-      <p
-        class="mt-1 text-sm text-gray-500"
-        id="freelancerAddress-helper"
+          Contract name
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <input
+          aria-invalid="false"
+          aria-required="true"
+          autocomplete="off"
+          class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
+          id="contractName"
+          placeholder="e.g. Website Redesign"
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        class="mb-4 w-full"
       >
-        Must be a valid Stellar public key starting with G
-      </p>
-    </div>
-    <div
-      class="mb-4 w-full"
-    >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="totalValue"
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="freelancerAddress"
+        >
+          Freelancer Stellar address
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <input
+          aria-describedby="freelancerAddress-helper"
+          aria-invalid="false"
+          aria-required="true"
+          autocapitalize="off"
+          autocomplete="off"
+          class="w-full rounded-2xl border px-4 py-2.5 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
+          id="freelancerAddress"
+          maxlength="56"
+          placeholder="GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+          spellcheck="false"
+          type="text"
+          value=""
+        />
+        <p
+          class="mt-1 text-sm text-gray-500"
+          id="freelancerAddress-helper"
+        >
+          Must be a valid Stellar public key starting with G
+        </p>
+      </div>
+      <div
+        class="mb-4 w-full"
       >
-        Total value
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="totalValue"
         >
-          *
-        </span>
-      </label>
-      <input
-        aria-invalid="false"
-        aria-required="true"
-        class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
-        id="totalValue"
-        min="0.01"
-        placeholder="0.00"
-        step="any"
-        type="number"
-        value=""
-      />
-    </div>
-    <div
-      class="mb-4 w-full"
-    >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="currency"
+          Total value
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <input
+          aria-invalid="false"
+          aria-required="true"
+          class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
+          id="totalValue"
+          min="0.01"
+          placeholder="0.00"
+          step="any"
+          type="number"
+          value=""
+        />
+      </div>
+      <div
+        class="mb-4 w-full"
       >
-        Currency
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="currency"
         >
-          *
-        </span>
-      </label>
-      <select
-        aria-invalid="false"
-        aria-required="true"
-        class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
-        id="currency"
+          Currency
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <select
+          aria-invalid="false"
+          aria-required="true"
+          class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
+          id="currency"
+        >
+          <option
+            value="USD"
+          >
+            USD
+          </option>
+          <option
+            value="XLM"
+          >
+            XLM
+          </option>
+          <option
+            value="EUR"
+          >
+            EUR
+          </option>
+          <option
+            value="GBP"
+          >
+            GBP
+          </option>
+        </select>
+      </div>
+      <div
+        class="mt-6 flex flex-col gap-3 sm:flex-row"
       >
-        <option
-          value="USD"
+        <button
+          class="rounded-2xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          type="submit"
         >
-          USD
-        </option>
-        <option
-          value="XLM"
+          Create Contract
+        </button>
+        <button
+          class="rounded-2xl border border-slate-300 bg-white px-6 py-2.5 text-sm font-semibold text-slate-900 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          type="button"
         >
-          XLM
-        </option>
-        <option
-          value="EUR"
-        >
-          EUR
-        </option>
-        <option
-          value="GBP"
-        >
-          GBP
-        </option>
-      </select>
-    </div>
-    <div
-      class="mt-6 flex flex-col gap-3 sm:flex-row"
-    >
-      <button
-        class="rounded-2xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-        type="submit"
-      >
-        Create Contract
-      </button>
-      <button
-        class="rounded-2xl border border-slate-300 bg-white px-6 py-2.5 text-sm font-semibold text-slate-900 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-        type="button"
-      >
-        Cancel
-      </button>
-    </div>
-  </form>
-</section>
+          Cancel
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
 `;
 
 exports[`CreateContractForm matches the error-state form structure after validation failures 1`] = `
-<section
+<div
   aria-labelledby="create-contract-heading"
-  class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+  aria-modal="true"
+  class="fixed inset-0 z-50 flex items-center justify-center overflow-hidden bg-black/50 backdrop-blur-sm"
+  role="dialog"
 >
-  <h2
-    class="text-xl font-semibold text-slate-900 mb-6"
-    id="create-contract-heading"
-  >
-    Create a new contract
-  </h2>
   <div
-    aria-labelledby="error-summary-title"
-    class="p-4 mb-6 border-l-4 border-red-500 bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500"
-    role="alert"
-    tabindex="-1"
+    class="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-3xl border border-slate-200 bg-white p-6 shadow-xl"
   >
     <h2
-      class="text-lg font-bold text-red-800"
-      id="error-summary-title"
+      class="text-xl font-semibold text-slate-900 mb-6"
+      id="create-contract-heading"
     >
-      There is a problem
+      Create a new contract
     </h2>
-    <ul
-      class="mt-2 space-y-1 list-inside text-sm text-red-700"
+    <div
+      aria-labelledby="error-summary-title"
+      class="p-4 mb-6 border-l-4 border-red-500 bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500"
+      role="alert"
+      tabindex="-1"
     >
-      <li>
-        <a
-          class="font-medium underline hover:text-red-900 focus:text-red-900 transition-colors"
-          href="#contractName"
+      <h2
+        class="text-lg font-bold text-red-800"
+        id="error-summary-title"
+      >
+        There is a problem
+      </h2>
+      <ul
+        class="mt-2 space-y-1 list-inside text-sm text-red-700"
+      >
+        <li>
+          <a
+            class="font-medium underline hover:text-red-900 focus:text-red-900 transition-colors"
+            href="#contractName"
+          >
+            Contract name is required
+          </a>
+        </li>
+        <li>
+          <a
+            class="font-medium underline hover:text-red-900 focus:text-red-900 transition-colors"
+            href="#freelancerAddress"
+          >
+            Freelancer address is required
+          </a>
+        </li>
+        <li>
+          <a
+            class="font-medium underline hover:text-red-900 focus:text-red-900 transition-colors"
+            href="#totalValue"
+          >
+            Total value must be a positive number
+          </a>
+        </li>
+      </ul>
+    </div>
+    <form
+      novalidate=""
+    >
+      <div
+        class="mb-4 w-full"
+      >
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="contractName"
+        >
+          Contract name
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <input
+          aria-describedby="contractName-error"
+          aria-invalid="true"
+          aria-required="true"
+          autocomplete="off"
+          class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition border-red-500 focus:ring-red-500 focus:border-red-500"
+          id="contractName"
+          placeholder="e.g. Website Redesign"
+          type="text"
+          value=""
+        />
+        <p
+          class="mt-1 text-sm text-red-600 font-medium"
+          id="contractName-error"
+          role="alert"
         >
           Contract name is required
-        </a>
-      </li>
-      <li>
-        <a
-          class="font-medium underline hover:text-red-900 focus:text-red-900 transition-colors"
-          href="#freelancerAddress"
+        </p>
+      </div>
+      <div
+        class="mb-4 w-full"
+      >
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="freelancerAddress"
+        >
+          Freelancer Stellar address
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <input
+          aria-describedby="freelancerAddress-error freelancerAddress-helper"
+          aria-invalid="true"
+          aria-required="true"
+          autocapitalize="off"
+          autocomplete="off"
+          class="w-full rounded-2xl border px-4 py-2.5 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition border-red-500 focus:ring-red-500 focus:border-red-500"
+          id="freelancerAddress"
+          maxlength="56"
+          placeholder="GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+          spellcheck="false"
+          type="text"
+          value=""
+        />
+        <p
+          class="mt-1 text-sm text-gray-500"
+          id="freelancerAddress-helper"
+        >
+          Must be a valid Stellar public key starting with G
+        </p>
+        <p
+          class="mt-1 text-sm text-red-600 font-medium"
+          id="freelancerAddress-error"
+          role="alert"
         >
           Freelancer address is required
-        </a>
-      </li>
-      <li>
-        <a
-          class="font-medium underline hover:text-red-900 focus:text-red-900 transition-colors"
-          href="#totalValue"
+        </p>
+      </div>
+      <div
+        class="mb-4 w-full"
+      >
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="totalValue"
+        >
+          Total value
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <input
+          aria-describedby="totalValue-error"
+          aria-invalid="true"
+          aria-required="true"
+          class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition border-red-500 focus:ring-red-500 focus:border-red-500"
+          id="totalValue"
+          min="0.01"
+          placeholder="0.00"
+          step="any"
+          type="number"
+          value=""
+        />
+        <p
+          class="mt-1 text-sm text-red-600 font-medium"
+          id="totalValue-error"
+          role="alert"
         >
           Total value must be a positive number
-        </a>
-      </li>
-    </ul>
+        </p>
+      </div>
+      <div
+        class="mb-4 w-full"
+      >
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="currency"
+        >
+          Currency
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <select
+          aria-invalid="false"
+          aria-required="true"
+          class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
+          id="currency"
+        >
+          <option
+            value="USD"
+          >
+            USD
+          </option>
+          <option
+            value="XLM"
+          >
+            XLM
+          </option>
+          <option
+            value="EUR"
+          >
+            EUR
+          </option>
+          <option
+            value="GBP"
+          >
+            GBP
+          </option>
+        </select>
+      </div>
+      <div
+        class="mt-6 flex flex-col gap-3 sm:flex-row"
+      >
+        <button
+          class="rounded-2xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          type="submit"
+        >
+          Create Contract
+        </button>
+        <button
+          class="rounded-2xl border border-slate-300 bg-white px-6 py-2.5 text-sm font-semibold text-slate-900 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          type="button"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
   </div>
-  <form
-    novalidate=""
-  >
-    <div
-      class="mb-4 w-full"
-    >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="contractName"
-      >
-        Contract name
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
-        >
-          *
-        </span>
-      </label>
-      <input
-        aria-describedby="contractName-error"
-        aria-invalid="true"
-        aria-required="true"
-        autocomplete="off"
-        class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition border-red-500 focus:ring-red-500 focus:border-red-500"
-        id="contractName"
-        placeholder="e.g. Website Redesign"
-        type="text"
-        value=""
-      />
-      <p
-        class="mt-1 text-sm text-red-600 font-medium"
-        id="contractName-error"
-        role="alert"
-      >
-        Contract name is required
-      </p>
-    </div>
-    <div
-      class="mb-4 w-full"
-    >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="freelancerAddress"
-      >
-        Freelancer Stellar address
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
-        >
-          *
-        </span>
-      </label>
-      <input
-        aria-describedby="freelancerAddress-error freelancerAddress-helper"
-        aria-invalid="true"
-        aria-required="true"
-        autocapitalize="off"
-        autocomplete="off"
-        class="w-full rounded-2xl border px-4 py-2.5 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition border-red-500 focus:ring-red-500 focus:border-red-500"
-        id="freelancerAddress"
-        maxlength="56"
-        placeholder="GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-        spellcheck="false"
-        type="text"
-        value=""
-      />
-      <p
-        class="mt-1 text-sm text-gray-500"
-        id="freelancerAddress-helper"
-      >
-        Must be a valid Stellar public key starting with G
-      </p>
-      <p
-        class="mt-1 text-sm text-red-600 font-medium"
-        id="freelancerAddress-error"
-        role="alert"
-      >
-        Freelancer address is required
-      </p>
-    </div>
-    <div
-      class="mb-4 w-full"
-    >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="totalValue"
-      >
-        Total value
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
-        >
-          *
-        </span>
-      </label>
-      <input
-        aria-describedby="totalValue-error"
-        aria-invalid="true"
-        aria-required="true"
-        class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition border-red-500 focus:ring-red-500 focus:border-red-500"
-        id="totalValue"
-        min="0.01"
-        placeholder="0.00"
-        step="any"
-        type="number"
-        value=""
-      />
-      <p
-        class="mt-1 text-sm text-red-600 font-medium"
-        id="totalValue-error"
-        role="alert"
-      >
-        Total value must be a positive number
-      </p>
-    </div>
-    <div
-      class="mb-4 w-full"
-    >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="currency"
-      >
-        Currency
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
-        >
-          *
-        </span>
-      </label>
-      <select
-        aria-invalid="false"
-        aria-required="true"
-        class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
-        id="currency"
-      >
-        <option
-          value="USD"
-        >
-          USD
-        </option>
-        <option
-          value="XLM"
-        >
-          XLM
-        </option>
-        <option
-          value="EUR"
-        >
-          EUR
-        </option>
-        <option
-          value="GBP"
-        >
-          GBP
-        </option>
-      </select>
-    </div>
-    <div
-      class="mt-6 flex flex-col gap-3 sm:flex-row"
-    >
-      <button
-        class="rounded-2xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-        type="submit"
-      >
-        Create Contract
-      </button>
-      <button
-        class="rounded-2xl border border-slate-300 bg-white px-6 py-2.5 text-sm font-semibold text-slate-900 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-        type="button"
-      >
-        Cancel
-      </button>
-    </div>
-  </form>
-</section>
+</div>
 `;
 
 exports[`CreateContractForm matches the populated-state form structure 1`] = `
-<section
+<div
   aria-labelledby="create-contract-heading"
-  class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+  aria-modal="true"
+  class="fixed inset-0 z-50 flex items-center justify-center overflow-hidden bg-black/50 backdrop-blur-sm"
+  role="dialog"
 >
-  <h2
-    class="text-xl font-semibold text-slate-900 mb-6"
-    id="create-contract-heading"
+  <div
+    class="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-3xl border border-slate-200 bg-white p-6 shadow-xl"
   >
-    Create a new contract
-  </h2>
-  <form
-    novalidate=""
-  >
-    <div
-      class="mb-4 w-full"
+    <h2
+      class="text-xl font-semibold text-slate-900 mb-6"
+      id="create-contract-heading"
     >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="contractName"
-      >
-        Contract name
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
-        >
-          *
-        </span>
-      </label>
-      <input
-        aria-invalid="false"
-        aria-required="true"
-        autocomplete="off"
-        class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
-        id="contractName"
-        placeholder="e.g. Website Redesign"
-        type="text"
-        value="Design Sprint"
-      />
-    </div>
-    <div
-      class="mb-4 w-full"
+      Create a new contract
+    </h2>
+    <form
+      novalidate=""
     >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="freelancerAddress"
+      <div
+        class="mb-4 w-full"
       >
-        Freelancer Stellar address
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="contractName"
         >
-          *
-        </span>
-      </label>
-      <input
-        aria-describedby="freelancerAddress-helper"
-        aria-invalid="false"
-        aria-required="true"
-        autocapitalize="off"
-        autocomplete="off"
-        class="w-full rounded-2xl border px-4 py-2.5 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
-        id="freelancerAddress"
-        maxlength="56"
-        placeholder="GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-        spellcheck="false"
-        type="text"
-        value="GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
-      />
-      <p
-        class="mt-1 text-sm text-gray-500"
-        id="freelancerAddress-helper"
+          Contract name
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <input
+          aria-invalid="false"
+          aria-required="true"
+          autocomplete="off"
+          class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
+          id="contractName"
+          placeholder="e.g. Website Redesign"
+          type="text"
+          value="Design Sprint"
+        />
+      </div>
+      <div
+        class="mb-4 w-full"
       >
-        Must be a valid Stellar public key starting with G
-      </p>
-    </div>
-    <div
-      class="mb-4 w-full"
-    >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="totalValue"
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="freelancerAddress"
+        >
+          Freelancer Stellar address
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <input
+          aria-describedby="freelancerAddress-helper"
+          aria-invalid="false"
+          aria-required="true"
+          autocapitalize="off"
+          autocomplete="off"
+          class="w-full rounded-2xl border px-4 py-2.5 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
+          id="freelancerAddress"
+          maxlength="56"
+          placeholder="GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+          spellcheck="false"
+          type="text"
+          value="GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+        />
+        <p
+          class="mt-1 text-sm text-gray-500"
+          id="freelancerAddress-helper"
+        >
+          Must be a valid Stellar public key starting with G
+        </p>
+      </div>
+      <div
+        class="mb-4 w-full"
       >
-        Total value
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="totalValue"
         >
-          *
-        </span>
-      </label>
-      <input
-        aria-invalid="false"
-        aria-required="true"
-        class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
-        id="totalValue"
-        min="0.01"
-        placeholder="0.00"
-        step="any"
-        type="number"
-        value="5000"
-      />
-    </div>
-    <div
-      class="mb-4 w-full"
-    >
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="currency"
+          Total value
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <input
+          aria-invalid="false"
+          aria-required="true"
+          class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
+          id="totalValue"
+          min="0.01"
+          placeholder="0.00"
+          step="any"
+          type="number"
+          value="5000"
+        />
+      </div>
+      <div
+        class="mb-4 w-full"
       >
-        Currency
-        <span
-          aria-hidden="true"
-          class="text-red-500 ml-1"
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="currency"
         >
-          *
-        </span>
-      </label>
-      <select
-        aria-invalid="false"
-        aria-required="true"
-        class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
-        id="currency"
+          Currency
+          <span
+            aria-hidden="true"
+            class="text-red-500 ml-1"
+          >
+            *
+          </span>
+        </label>
+        <select
+          aria-invalid="false"
+          aria-required="true"
+          class="w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
+          id="currency"
+        >
+          <option
+            value="USD"
+          >
+            USD
+          </option>
+          <option
+            value="XLM"
+          >
+            XLM
+          </option>
+          <option
+            value="EUR"
+          >
+            EUR
+          </option>
+          <option
+            value="GBP"
+          >
+            GBP
+          </option>
+        </select>
+      </div>
+      <div
+        class="mt-6 flex flex-col gap-3 sm:flex-row"
       >
-        <option
-          value="USD"
+        <button
+          class="rounded-2xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          type="submit"
         >
-          USD
-        </option>
-        <option
-          value="XLM"
+          Create Contract
+        </button>
+        <button
+          class="rounded-2xl border border-slate-300 bg-white px-6 py-2.5 text-sm font-semibold text-slate-900 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          type="button"
         >
-          XLM
-        </option>
-        <option
-          value="EUR"
-        >
-          EUR
-        </option>
-        <option
-          value="GBP"
-        >
-          GBP
-        </option>
-      </select>
-    </div>
-    <div
-      class="mt-6 flex flex-col gap-3 sm:flex-row"
-    >
-      <button
-        class="rounded-2xl bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-        type="submit"
-      >
-        Create Contract
-      </button>
-      <button
-        class="rounded-2xl border border-slate-300 bg-white px-6 py-2.5 text-sm font-semibold text-slate-900 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-        type="button"
-      >
-        Cancel
-      </button>
-    </div>
-  </form>
-</section>
+          Cancel
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
 `;


### PR DESCRIPTION
Closes #875

## Summary
- Converted `CreateContractForm` from an inline section to a modal dialog with `role="dialog"` and `aria-modal="true"` for proper assistive-technology announcement
- Integrated `useDialogFocusTrap` hook to trap Tab/Shift+Tab focus, handle Escape dismissal, and restore focus to the trigger element on close
- Added backdrop click-to-dismiss behavior matching the existing `ConfirmDialog` pattern
- Added 7 focus-management tests covering initial focus, escape handling, Tab/Shift+Tab cycling, and focus restoration for all close paths (Escape, Cancel, successful submission)

## Testing
- All 26 tests in `CreateContractForm.test.tsx` pass (3 updated snapshots, 7 new focus-management tests)
- Lint: `npx eslint src/components/contracts/CreateContractForm.tsx` passes with zero errors