### PR TITLE
feat(contracts): add density toggle (#802)

### DIFF
--- a/src/app/contracts/__tests__/page.test.tsx
+++ b/src/app/contracts/__tests__/page.test.tsx
@@ -16,13 +16,18 @@ jest.mock('@/lib/exportContracts', () => ({
 
 jest.mock('@/components/contracts/ContractsList', () => ({
   __esModule: true,
-  default: ({ contracts }: any) => (
-    <ul data-testid="contracts-list">
+  default: ({ contracts, density, onToggleDensity }: any) => (
+    <ul data-testid="contracts-list" data-density={density}>
       {contracts.map((contract: any, idx: number) => (
         <li key={`${contract.contractName}-${idx}`}>
           {contract.contractName}
         </li>
       ))}
+      {onToggleDensity && (
+        <button onClick={onToggleDensity} data-testid="density-toggle">
+          Toggle Density
+        </button>
+      )}
     </ul>
   ),
 }));
@@ -457,6 +462,30 @@ describe('ContractsPage', () => {
       render(<ContractsPage />);
 
       expect(screen.getByRole('main')).toBeInTheDocument();
+    });
+  });
+
+  describe('density toggle', () => {
+    it('passes density="comfortable" to ContractsList by default', () => {
+      mockListContracts.mockReturnValue([makeContract()]);
+      render(<ContractsPage />);
+
+      const list = screen.getByTestId('contracts-list');
+      expect(list).toHaveAttribute('data-density', 'comfortable');
+    });
+
+    it('passes onToggleDensity to ContractsList when contracts are present', () => {
+      mockListContracts.mockReturnValue([makeContract()]);
+      render(<ContractsPage />);
+
+      expect(screen.getByTestId('density-toggle')).toBeInTheDocument();
+    });
+
+    it('density toggle button is absent when no contracts exist', () => {
+      mockListContracts.mockReturnValue([]);
+      render(<ContractsPage />);
+
+      expect(screen.queryByTestId('density-toggle')).not.toBeInTheDocument();
     });
   });
 

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -7,6 +7,7 @@ import { ContractCreationForm } from '../../components/ContractCreationForm';
 import { listContracts, saveContract } from '@/lib/repository';
 import { downloadContractsCsv, downloadContractsJson } from '@/lib/exportContracts';
 import { useToast } from '@/components/toast/toast-provider';
+import { usePreferences } from '@/lib/preferences';
 import type { Contract } from '@/types/domain';
 
 type ContractsFetchState =
@@ -26,7 +27,16 @@ const ContractsPage: React.FC = () => {
   const [fetchState, setFetchState] = useState<ContractsFetchState>(getInitialFetchState);
   const [showForm, setShowForm] = useState(false);
   const { showError } = useToast();
+  const { preferences, updatePreference } = usePreferences();
   const { contracts } = fetchState;
+
+  const contractsDensity = preferences.contractsDensity;
+
+  /** Toggles between compact and comfortable density and persists the choice. */
+  const handleToggleDensity = useCallback(() => {
+    const next = contractsDensity === 'compact' ? 'comfortable' : 'compact';
+    updatePreference('contractsDensity', next);
+  }, [contractsDensity, updatePreference]);
 
   /** Re-reads persisted contracts after a recoverable load failure. */
   const loadContracts = useCallback(() => {
@@ -172,7 +182,11 @@ const ContractsPage: React.FC = () => {
             </button>
           </div>
 
-          <ContractsList contracts={contracts} />
+          <ContractsList
+            contracts={contracts}
+            density={contractsDensity}
+            onToggleDensity={handleToggleDensity}
+          />
         </>
       )}
 

--- a/src/components/contracts/ContractListItem.tsx
+++ b/src/components/contracts/ContractListItem.tsx
@@ -2,10 +2,13 @@
 
 import React, { memo } from 'react';
 import type { Contract } from '@/types/domain';
+import type { ContractsDensity } from '@/lib/preferences';
 
 export interface ContractListItemProps {
   contract: Contract;
   index: number;
+  /** Controls spacing inside the card. Defaults to 'comfortable'. */
+  density?: ContractsDensity;
 }
 
 /**
@@ -19,31 +22,38 @@ export interface ContractListItemProps {
  * @param props - Component props
  * @param props.contract - The contract record to display
  * @param props.index - The index of the contract in the list (used for key)
+ * @param props.density - Optional density override ('comfortable' | 'compact')
  *
  * @example
  * ```tsx
- * <ContractListItem contract={contract} index={0} />
+ * <ContractListItem contract={contract} index={0} density="compact" />
  * ```
  */
 const ContractListItem = memo(
-  ({ contract, index }: ContractListItemProps) => (
-    <li
-      key={`${contract.contractName}-${index}`}
-      className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm"
-    >
-      <p className="font-semibold text-slate-900">{contract.contractName}</p>
-      <p className="text-sm text-slate-500">
-        {contract.status} · Created {contract.createdAt}
-      </p>
-    </li>
-  ),
+  ({ contract, index, density = 'comfortable' }: ContractListItemProps) => {
+    const isCompact = density === 'compact';
+    return (
+      <li
+        key={`${contract.contractName}-${index}`}
+        className={`rounded-3xl border border-slate-200 bg-white shadow-sm transition-[padding] ${
+          isCompact ? 'p-2.5' : 'p-4'
+        }`}
+      >
+        <p className="font-semibold text-slate-900">{contract.contractName}</p>
+        <p className={`text-sm text-slate-500 ${isCompact ? 'mt-0.5' : 'mt-1'}`}>
+          {contract.status} · Created {contract.createdAt}
+        </p>
+      </li>
+    );
+  },
   (prevProps, nextProps) => {
     // Custom equality check: return true if props are equal (don't re-render)
     return (
       prevProps.contract.contractName === nextProps.contract.contractName &&
       prevProps.contract.status === nextProps.contract.status &&
       prevProps.contract.createdAt === nextProps.contract.createdAt &&
-      prevProps.index === nextProps.index
+      prevProps.index === nextProps.index &&
+      prevProps.density === nextProps.density
     );
   },
 );

--- a/src/components/contracts/ContractsList.tsx
+++ b/src/components/contracts/ContractsList.tsx
@@ -1,46 +1,97 @@
 'use client';
 
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
 import ContractListItem from './ContractListItem';
 import type { Contract } from '@/types/domain';
+import type { ContractsDensity } from '@/lib/preferences';
 
 export interface ContractsListProps {
   contracts: Contract[];
+  /** Current density setting; provided by the parent page. */
+  density?: ContractsDensity;
+  /** Called when the user toggles the density button. */
+  onToggleDensity?: () => void;
 }
 
 /**
- * ContractsList renders a list of contracts.
+ * ContractsList renders a list of contracts with a density toggle.
  *
  * Memoized with React.memo to prevent re-renders when the contracts array
  * reference hasn't changed. This allows parent components to re-render without
  * triggering unnecessary re-renders of the entire list and all its child items.
  *
- * Uses ContractListItem (also memoized) to further optimize rendering when
- * individual contracts haven't changed.
+ * The density toggle button switches between 'comfortable' and 'compact' spacing.
+ * Density is persisted via the preferences system and restored on mount.
  *
- * @param props - Component props
  * @param props.contracts - Array of contracts to display
- *
- * @example
- * ```tsx
- * <ContractsList contracts={contracts} />
- * ```
+ * @param props.density   - Active density setting ('comfortable' | 'compact')
+ * @param props.onToggleDensity - Called when the user clicks the toggle button
  */
 const ContractsList = memo(
-  ({ contracts }: ContractsListProps) => (
-    <>
-      <div className="mb-4 flex justify-end">
-        {/* Button moved to parent for event handling */}
-      </div>
-      <ul className="space-y-4">
-        {contracts.map((contract, idx) => (
-          <ContractListItem key={`${contract.contractName}-${idx}`} contract={contract} index={idx} />
-        ))}
-      </ul>
-    </>
-  ),
+  ({ contracts, density = 'comfortable', onToggleDensity }: ContractsListProps) => {
+    const isCompact = density === 'compact';
+
+    return (
+      <>
+        <div className="mb-4 flex justify-end">
+          {onToggleDensity && (
+            <button
+              type="button"
+              onClick={onToggleDensity}
+              aria-pressed={isCompact}
+              aria-label={isCompact ? 'Switch to comfortable density' : 'Switch to compact density'}
+              className="inline-flex items-center gap-1.5 rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-600 transition-colors hover:border-slate-400 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
+            >
+              {/* Density icon */}
+              <svg
+                aria-hidden="true"
+                className="h-3.5 w-3.5"
+                fill="none"
+                viewBox="0 0 16 16"
+                stroke="currentColor"
+                strokeWidth={1.75}
+              >
+                {isCompact ? (
+                  /* Compact → show "expand" lines */
+                  <>
+                    <line x1="2" y1="4" x2="14" y2="4" />
+                    <line x1="2" y1="8" x2="14" y2="8" />
+                    <line x1="2" y1="12" x2="14" y2="12" />
+                  </>
+                ) : (
+                  /* Comfortable → show "compress" lines with gaps */
+                  <>
+                    <line x1="2" y1="3" x2="14" y2="3" />
+                    <line x1="2" y1="6" x2="14" y2="6" />
+                    <line x1="2" y1="10" x2="14" y2="10" />
+                    <line x1="2" y1="13" x2="14" y2="13" />
+                  </>
+                )}
+              </svg>
+              {isCompact ? 'Comfortable' : 'Compact'}
+            </button>
+          )}
+        </div>
+        <ul
+          className={`transition-[gap] ${isCompact ? 'space-y-2' : 'space-y-4'}`}
+          aria-label="Contracts list"
+        >
+          {contracts.map((contract, idx) => (
+            <ContractListItem
+              key={`${contract.contractName}-${idx}`}
+              contract={contract}
+              index={idx}
+              density={density}
+            />
+          ))}
+        </ul>
+      </>
+    );
+  },
   (prevProps, nextProps) => {
     // Return true if props are equal (don't re-render)
+    if (prevProps.density !== nextProps.density) return false;
+    if (prevProps.onToggleDensity !== nextProps.onToggleDensity) return false;
     // Check array length first for quick bail-out
     if (prevProps.contracts.length !== nextProps.contracts.length) {
       return false;

--- a/src/components/contracts/__tests__/ContractListItem.test.tsx
+++ b/src/components/contracts/__tests__/ContractListItem.test.tsx
@@ -39,6 +39,7 @@ describe('ContractListItem', () => {
       expect(li).toHaveClass('border');
       expect(li).toHaveClass('border-slate-200');
       expect(li).toHaveClass('bg-white');
+      // Default density is 'comfortable' → p-4
       expect(li).toHaveClass('p-4');
       expect(li).toHaveClass('shadow-sm');
     });

--- a/src/components/contracts/__tests__/ContractsDensityToggle.test.tsx
+++ b/src/components/contracts/__tests__/ContractsDensityToggle.test.tsx
@@ -1,0 +1,454 @@
+/**
+ * @file ContractsDensityToggle.test.tsx
+ *
+ * Comprehensive tests for the contracts density toggle feature.
+ * Covers:
+ *   - Toggle button rendering and labelling
+ *   - Toggling changes the density value passed down to ContractsList
+ *   - Density is persisted to preferences storage
+ *   - Invalid stored values fall back to 'comfortable'
+ *   - ContractListItem applies correct spacing for each density
+ *   - ContractsList passes density through to ContractListItem
+ *   - Accessibility: aria-pressed, aria-label, keyboard interaction
+ */
+
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  renderHook,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ContractsList from '../ContractsList';
+import ContractListItem from '../ContractListItem';
+import {
+  PreferencesProvider,
+  usePreferences,
+  sanitizePreferences,
+} from '@/lib/preferences';
+import { resetCache } from '@/lib/safeStorage';
+import type { Contract } from '@/types/domain';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContract(overrides: Partial<Contract> = {}): Contract {
+  return {
+    contractName: 'Test Contract',
+    parties: [{ label: 'Client', address: 'GABC1234' }],
+    totalValue: 5000,
+    currency: 'USD',
+    status: 'Active',
+    createdAt: '2025-01-01',
+    milestoneCount: 2,
+    ...overrides,
+  };
+}
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <PreferencesProvider>{children}</PreferencesProvider>
+);
+
+beforeEach(() => {
+  localStorage.clear();
+  resetCache();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// ContractListItem density prop
+// ---------------------------------------------------------------------------
+
+describe('ContractListItem – density prop', () => {
+  it('applies comfortable padding by default', () => {
+    const { container } = render(
+      <ContractListItem contract={makeContract()} index={0} />
+    );
+    const li = container.querySelector('li')!;
+    expect(li.className).toContain('p-4');
+    expect(li.className).not.toContain('p-2.5');
+  });
+
+  it('applies comfortable padding when density="comfortable"', () => {
+    const { container } = render(
+      <ContractListItem contract={makeContract()} index={0} density="comfortable" />
+    );
+    const li = container.querySelector('li')!;
+    expect(li.className).toContain('p-4');
+    expect(li.className).not.toContain('p-2.5');
+  });
+
+  it('applies compact padding when density="compact"', () => {
+    const { container } = render(
+      <ContractListItem contract={makeContract()} index={0} density="compact" />
+    );
+    const li = container.querySelector('li')!;
+    expect(li.className).toContain('p-2.5');
+    expect(li.className).not.toContain('p-4');
+  });
+
+  it('re-renders when density prop changes', () => {
+    const contract = makeContract();
+    const { container, rerender } = render(
+      <ContractListItem contract={contract} index={0} density="comfortable" />
+    );
+    expect(container.querySelector('li')!.className).toContain('p-4');
+
+    rerender(<ContractListItem contract={contract} index={0} density="compact" />);
+    expect(container.querySelector('li')!.className).toContain('p-2.5');
+  });
+
+  it('does not re-render when density is stable', () => {
+    const contract = makeContract();
+    const renderCount = { current: 0 };
+    const Spy = React.memo(
+      ({ contract, index, density }: Parameters<typeof ContractListItem>[0]) => {
+        renderCount.current += 1;
+        return <ContractListItem contract={contract} index={index} density={density} />;
+      }
+    );
+    Spy.displayName = 'Spy';
+
+    const { rerender } = render(
+      <Spy contract={contract} index={0} density="compact" />
+    );
+    const countAfterFirst = renderCount.current;
+    rerender(<Spy contract={contract} index={0} density="compact" />);
+    // React.memo should prevent a second render since props are equal
+    expect(renderCount.current).toBe(countAfterFirst);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ContractsList density toggle button
+// ---------------------------------------------------------------------------
+
+describe('ContractsList – density toggle button', () => {
+  const contracts = [makeContract({ contractName: 'Alpha' })];
+
+  it('renders the toggle button when onToggleDensity is provided', () => {
+    render(
+      <ContractsList
+        contracts={contracts}
+        density="comfortable"
+        onToggleDensity={jest.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: /switch to compact density/i })
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the toggle button when onToggleDensity is omitted', () => {
+    render(<ContractsList contracts={contracts} />);
+    expect(screen.queryByRole('button', { name: /switch to.*density/i })).not.toBeInTheDocument();
+  });
+
+  it('labels the button "Switch to compact density" when density is comfortable', () => {
+    render(
+      <ContractsList
+        contracts={contracts}
+        density="comfortable"
+        onToggleDensity={jest.fn()}
+      />
+    );
+    const btn = screen.getByRole('button', { name: /switch to compact density/i });
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+    expect(btn).toHaveTextContent('Compact');
+  });
+
+  it('labels the button "Switch to comfortable density" when density is compact', () => {
+    render(
+      <ContractsList
+        contracts={contracts}
+        density="compact"
+        onToggleDensity={jest.fn()}
+      />
+    );
+    const btn = screen.getByRole('button', { name: /switch to comfortable density/i });
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    expect(btn).toHaveTextContent('Comfortable');
+  });
+
+  it('calls onToggleDensity when the button is clicked', () => {
+    const onToggle = jest.fn();
+    render(
+      <ContractsList
+        contracts={contracts}
+        density="comfortable"
+        onToggleDensity={onToggle}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /switch to compact density/i })
+    );
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes density="compact" down to list items when compact', () => {
+    const { container } = render(
+      <ContractsList
+        contracts={contracts}
+        density="compact"
+        onToggleDensity={jest.fn()}
+      />
+    );
+    const li = container.querySelector('li')!;
+    expect(li.className).toContain('p-2.5');
+  });
+
+  it('passes density="comfortable" down to list items when comfortable', () => {
+    const { container } = render(
+      <ContractsList
+        contracts={contracts}
+        density="comfortable"
+        onToggleDensity={jest.fn()}
+      />
+    );
+    const li = container.querySelector('li')!;
+    expect(li.className).toContain('p-4');
+  });
+
+  it('uses compact list spacing when density="compact"', () => {
+    const { container } = render(
+      <ContractsList
+        contracts={[makeContract(), makeContract({ contractName: 'Beta' })]}
+        density="compact"
+        onToggleDensity={jest.fn()}
+      />
+    );
+    const ul = container.querySelector('ul')!;
+    expect(ul.className).toContain('space-y-2');
+    expect(ul.className).not.toContain('space-y-4');
+  });
+
+  it('uses comfortable list spacing when density="comfortable"', () => {
+    const { container } = render(
+      <ContractsList
+        contracts={[makeContract(), makeContract({ contractName: 'Beta' })]}
+        density="comfortable"
+        onToggleDensity={jest.fn()}
+      />
+    );
+    const ul = container.querySelector('ul')!;
+    expect(ul.className).toContain('space-y-4');
+    expect(ul.className).not.toContain('space-y-2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Preference persistence via usePreferences
+// ---------------------------------------------------------------------------
+
+describe('contractsDensity preference – persistence', () => {
+  it('defaults to comfortable', () => {
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    expect(result.current.preferences.contractsDensity).toBe('comfortable');
+  });
+
+  it('persists contractsDensity=compact to localStorage', () => {
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+
+    act(() => {
+      result.current.updatePreference('contractsDensity', 'compact');
+    });
+
+    expect(result.current.preferences.contractsDensity).toBe('compact');
+    const saved = JSON.parse(
+      localStorage.getItem('talenttrust-user-preferences') || '{}'
+    );
+    expect(saved.contractsDensity).toBe('compact');
+  });
+
+  it('persists contractsDensity=comfortable to localStorage', () => {
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+
+    act(() => {
+      result.current.updatePreference('contractsDensity', 'compact');
+    });
+    act(() => {
+      result.current.updatePreference('contractsDensity', 'comfortable');
+    });
+
+    const saved = JSON.parse(
+      localStorage.getItem('talenttrust-user-preferences') || '{}'
+    );
+    expect(saved.contractsDensity).toBe('comfortable');
+  });
+
+  it('restores contractsDensity on mount (simulates page reload)', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ contractsDensity: 'compact' })
+    );
+
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    expect(result.current.preferences.contractsDensity).toBe('compact');
+  });
+
+  it('falls back to comfortable when stored value is invalid', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ contractsDensity: 'ultra-wide' })
+    );
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    expect(result.current.preferences.contractsDensity).toBe('comfortable');
+  });
+
+  it('falls back to comfortable when stored value is a number', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ contractsDensity: 1 })
+    );
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    expect(result.current.preferences.contractsDensity).toBe('comfortable');
+  });
+
+  it('falls back to comfortable when stored value is null', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ contractsDensity: null })
+    );
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    expect(result.current.preferences.contractsDensity).toBe('comfortable');
+  });
+
+  it('falls back to comfortable when stored value is boolean', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ contractsDensity: true })
+    );
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    expect(result.current.preferences.contractsDensity).toBe('comfortable');
+  });
+
+  it('does not persist contractsDensity before hydration', () => {
+    // The provider should not overwrite localStorage with defaults before
+    // it has read the stored value.
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ contractsDensity: 'compact' })
+    );
+
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    // After hydration the value should be the stored one, not the default.
+    expect(result.current.preferences.contractsDensity).toBe('compact');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizePreferences – contractsDensity
+// ---------------------------------------------------------------------------
+
+describe('sanitizePreferences – contractsDensity', () => {
+  it('accepts "comfortable"', () => {
+    const result = sanitizePreferences({ contractsDensity: 'comfortable' });
+    expect(result.contractsDensity).toBe('comfortable');
+  });
+
+  it('accepts "compact"', () => {
+    const result = sanitizePreferences({ contractsDensity: 'compact' });
+    expect(result.contractsDensity).toBe('compact');
+  });
+
+  it('falls back to comfortable for unknown string', () => {
+    const result = sanitizePreferences({ contractsDensity: 'huge' });
+    expect(result.contractsDensity).toBe('comfortable');
+  });
+
+  it('falls back to comfortable for number', () => {
+    const result = sanitizePreferences({
+      contractsDensity: 42,
+    } as unknown as Parameters<typeof sanitizePreferences>[0]);
+    expect(result.contractsDensity).toBe('comfortable');
+  });
+
+  it('falls back to comfortable for null', () => {
+    const result = sanitizePreferences({
+      contractsDensity: null,
+    } as unknown as Parameters<typeof sanitizePreferences>[0]);
+    expect(result.contractsDensity).toBe('comfortable');
+  });
+
+  it('falls back to comfortable when absent', () => {
+    const result = sanitizePreferences({});
+    expect(result.contractsDensity).toBe('comfortable');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: ContractsList + preferences toggle
+// ---------------------------------------------------------------------------
+
+describe('ContractsList – toggle integration', () => {
+  it('density toggle cycles comfortable→compact→comfortable', () => {
+    const contracts = [makeContract({ contractName: 'Cycle Test' })];
+    let currentDensity: 'comfortable' | 'compact' = 'comfortable';
+    const onToggle = jest.fn(() => {
+      currentDensity = currentDensity === 'comfortable' ? 'compact' : 'comfortable';
+    });
+
+    const { rerender, container } = render(
+      <ContractsList contracts={contracts} density={currentDensity} onToggleDensity={onToggle} />
+    );
+
+    // Initial: comfortable
+    expect(container.querySelector('li')!.className).toContain('p-4');
+
+    // Click once → compact
+    fireEvent.click(screen.getByRole('button', { name: /switch to compact density/i }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ContractsList contracts={contracts} density={currentDensity} onToggleDensity={onToggle} />
+    );
+    expect(container.querySelector('li')!.className).toContain('p-2.5');
+
+    // Click again → comfortable
+    fireEvent.click(screen.getByRole('button', { name: /switch to comfortable density/i }));
+    expect(onToggle).toHaveBeenCalledTimes(2);
+
+    rerender(
+      <ContractsList contracts={contracts} density={currentDensity} onToggleDensity={onToggle} />
+    );
+    expect(container.querySelector('li')!.className).toContain('p-4');
+  });
+
+  it('renders correctly with empty contracts list at both densities', () => {
+    const { rerender, container } = render(
+      <ContractsList contracts={[]} density="comfortable" onToggleDensity={jest.fn()} />
+    );
+    expect(container.querySelector('ul')!.children).toHaveLength(0);
+
+    rerender(
+      <ContractsList contracts={[]} density="compact" onToggleDensity={jest.fn()} />
+    );
+    expect(container.querySelector('ul')!.children).toHaveLength(0);
+  });
+
+  it('all items adopt the new density when the prop changes', () => {
+    const contracts = Array.from({ length: 5 }, (_, i) =>
+      makeContract({ contractName: `Contract ${i + 1}` })
+    );
+
+    const { container, rerender } = render(
+      <ContractsList contracts={contracts} density="comfortable" onToggleDensity={jest.fn()} />
+    );
+
+    const allLi = () => Array.from(container.querySelectorAll('li'));
+
+    allLi().forEach((li) => expect(li.className).toContain('p-4'));
+
+    rerender(
+      <ContractsList contracts={contracts} density="compact" onToggleDensity={jest.fn()} />
+    );
+
+    allLi().forEach((li) => expect(li.className).toContain('p-2.5'));
+  });
+});

--- a/src/components/contracts/__tests__/ContractsList.test.tsx
+++ b/src/components/contracts/__tests__/ContractsList.test.tsx
@@ -55,6 +55,7 @@ describe('ContractsList', () => {
 
       const { container } = render(<ContractsList contracts={contracts} />);
 
+      // Default density is 'comfortable' → space-y-4
       const ul = container.querySelector('ul');
       expect(ul).toHaveClass('space-y-4');
     });

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -284,6 +284,19 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                 </div>
               </div>
 
+              <div>
+                <label id="contracts-density-label" className="block text-sm font-medium mb-2 text-[var(--foreground)]">Contracts Density</label>
+                <RadioGroup
+                  options={['comfortable', 'compact'] as const}
+                  value={preferences.contractsDensity}
+                  onChange={(val) => handleUpdate('contractsDensity', val)}
+                  labelId="contracts-density-label"
+                  ariaLabel="Contracts Density"
+                  containerClassName="grid grid-cols-2 gap-2"
+                  textClassName="capitalize"
+                />
+              </div>
+
               <div className="flex items-center justify-between">
                 <div>
                   <label id="quiet-mode-label" className="text-sm font-medium text-[var(--foreground)]">Quiet Mode</label>

--- a/src/lib/__tests__/preferences.test.tsx
+++ b/src/lib/__tests__/preferences.test.tsx
@@ -77,6 +77,7 @@ describe('PreferencesProvider', () => {
       formDensity: 'comfortable',
       milestonesDensity: 'comfortable',
       walletDensity: 'comfortable',
+      contractsDensity: 'comfortable',
       quietMode: false,
       toastDuration: 'normal',
       idleDisconnectMs: 0,
@@ -159,6 +160,36 @@ describe('PreferencesProvider', () => {
     expect(result.current.preferences.formDensity).toBe('comfortable');
   });
 
+  it('uses default contractsDensity when none is stored', () => {
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    expect(result.current.preferences.contractsDensity).toBe('comfortable');
+  });
+
+  it('persists contractsDensity and restores it on hydration', () => {
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+
+    act(() => {
+      result.current.updatePreference('contractsDensity', 'compact');
+    });
+
+    expect(result.current.preferences.contractsDensity).toBe('compact');
+    const saved = JSON.parse(localStorage.getItem('talenttrust-user-preferences') || '{}');
+    expect(saved.contractsDensity).toBe('compact');
+
+    // Remount to simulate reload
+    const { result: r2 } = renderHook(() => usePreferences(), { wrapper });
+    expect(r2.current.preferences.contractsDensity).toBe('compact');
+  });
+
+  it('falls back to comfortable when stored contractsDensity is invalid', () => {
+    localStorage.setItem(
+      'talenttrust-user-preferences',
+      JSON.stringify({ contractsDensity: 'ultra-compact' }),
+    );
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+    expect(result.current.preferences.contractsDensity).toBe('comfortable');
+  });
+
   it('rejects non-boolean quietMode values (truthy coercion guard)', () => {
     localStorage.setItem(
       'talenttrust-user-preferences',
@@ -200,6 +231,7 @@ describe('PreferencesProvider', () => {
     // so we compare with `.sort()` for engine-independent comparison.
     expect(Object.keys(serialized).sort()).toEqual([
       'amountFormat',
+      'contractsDensity',
       'formDensity',
       'idleDisconnectMs',
       'milestonesDensity',
@@ -260,6 +292,7 @@ describe('sanitizePreferences (pure helper)', () => {
     formDensity: 'comfortable',
     milestonesDensity: 'comfortable',
     walletDensity: 'comfortable',
+    contractsDensity: 'comfortable',
     quietMode: false,
     toastDuration: 'normal',
     idleDisconnectMs: 0,
@@ -303,6 +336,7 @@ describe('sanitizePreferences (pure helper)', () => {
       formDensity: 'compact',
       milestonesDensity: 'comfortable',
       walletDensity: 'comfortable',
+      contractsDensity: 'comfortable',
       quietMode: true,
       toastDuration: 'long',
       idleDisconnectMs: 15000,
@@ -319,6 +353,7 @@ describe('sanitizePreferences (pure helper)', () => {
       formDensity: 'comfortable',
       milestonesDensity: 'comfortable',
       walletDensity: 'comfortable',
+      contractsDensity: 'comfortable',
       quietMode: true,
       toastDuration: 'normal',
       idleDisconnectMs: 0,
@@ -384,6 +419,30 @@ describe('sanitizePreferences (pure helper)', () => {
     });
   });
 
+  it('accepts valid contractsDensity values', () => {
+    expect(sanitizePreferences({ contractsDensity: 'compact' })).toEqual({
+      ...DEFAULTS,
+      contractsDensity: 'compact',
+    });
+    expect(sanitizePreferences({ contractsDensity: 'comfortable' })).toEqual({
+      ...DEFAULTS,
+      contractsDensity: 'comfortable',
+    });
+  });
+
+  it('rejects invalid contractsDensity values and falls back to default', () => {
+    expect(sanitizePreferences({ contractsDensity: 'wide' })).toEqual({ ...DEFAULTS });
+    expect(sanitizePreferences({ contractsDensity: 1 } as unknown as UserPreferences)).toEqual({
+      ...DEFAULTS,
+    });
+    expect(sanitizePreferences({ contractsDensity: null } as unknown as UserPreferences)).toEqual({
+      ...DEFAULTS,
+    });
+    expect(sanitizePreferences({ contractsDensity: true } as unknown as UserPreferences)).toEqual({
+      ...DEFAULTS,
+    });
+  });
+
   it('rejects non-boolean quietMode values even when truthy', () => {
     expect(sanitizePreferences({ quietMode: 1 } as unknown as UserPreferences)).toEqual({
       ...DEFAULTS,
@@ -443,6 +502,7 @@ describe('sanitizePreferences (pure helper)', () => {
       formDensity: 'comfortable',
       milestonesDensity: 'compact',
       walletDensity: 'comfortable',
+      contractsDensity: 'comfortable',
       quietMode: false,
       toastDuration: 'persistent',
       idleDisconnectMs: 10000,

--- a/src/lib/preferences.tsx
+++ b/src/lib/preferences.tsx
@@ -9,6 +9,7 @@ export type AmountFormat = 'usd' | 'ngn' | 'compact';
 export type ToastDensity = 'relaxed' | 'compact';
 export type FormDensity = 'comfortable' | 'compact';
 export type ListDensity = 'comfortable' | 'compact';
+export type ContractsDensity = 'comfortable' | 'compact';
 /**
  * Controls the default auto-dismiss duration for toasts when the caller does
  * not supply an explicit `duration`.
@@ -54,6 +55,7 @@ export interface UserPreferences {
   formDensity: FormDensity;
   milestonesDensity: ListDensity;
   walletDensity: ListDensity;
+  contractsDensity: ContractsDensity;
   quietMode: boolean;
   toastDuration: ToastDuration;
   /**
@@ -70,6 +72,7 @@ const DEFAULT_PREFERENCES: UserPreferences = {
   formDensity: 'comfortable',
   milestonesDensity: 'comfortable',
   walletDensity: 'comfortable',
+  contractsDensity: 'comfortable',
   quietMode: false,
   toastDuration: 'normal',
   idleDisconnectMs: 0,
@@ -88,6 +91,7 @@ const KNOWN_KEYS: ReadonlySet<keyof UserPreferences> = new Set([
   'formDensity',
   'milestonesDensity',
   'walletDensity',
+  'contractsDensity',
   'quietMode',
   'toastDuration',
   'idleDisconnectMs',
@@ -112,6 +116,7 @@ const ALLOWED_AMOUNT_FORMATS: ReadonlySet<AmountFormat> = new Set(['usd', 'ngn',
 const ALLOWED_TOAST_DENSITIES: ReadonlySet<ToastDensity> = new Set(['relaxed', 'compact']);
 const ALLOWED_FORM_DENSITIES: ReadonlySet<FormDensity> = new Set(['comfortable', 'compact']);
 const ALLOWED_LIST_DENSITIES: ReadonlySet<ListDensity> = new Set(['comfortable', 'compact']);
+const ALLOWED_CONTRACTS_DENSITIES: ReadonlySet<ContractsDensity> = new Set(['comfortable', 'compact']);
 const ALLOWED_TOAST_DURATIONS: ReadonlySet<ToastDuration> = new Set(['short', 'normal', 'long', 'persistent']);
 
 interface PreferencesContextType {
@@ -166,6 +171,7 @@ export function sanitizePreferences(raw: unknown): UserPreferences {
   let formDensity: FormDensity = DEFAULT_PREFERENCES.formDensity;
   let milestonesDensity: ListDensity = DEFAULT_PREFERENCES.milestonesDensity;
   let walletDensity: ListDensity = DEFAULT_PREFERENCES.walletDensity;
+  let contractsDensity: ContractsDensity = DEFAULT_PREFERENCES.contractsDensity;
   let quietMode: boolean = DEFAULT_PREFERENCES.quietMode;
   let toastDuration: ToastDuration = DEFAULT_PREFERENCES.toastDuration;
   let idleDisconnectMs: number = DEFAULT_PREFERENCES.idleDisconnectMs;
@@ -215,6 +221,11 @@ export function sanitizePreferences(raw: unknown): UserPreferences {
           walletDensity = value as ListDensity;
         }
         break;
+      case 'contractsDensity':
+        if (typeof value === 'string' && ALLOWED_CONTRACTS_DENSITIES.has(value as ContractsDensity)) {
+          contractsDensity = value as ContractsDensity;
+        }
+        break;
       case 'quietMode':
         if (typeof value === 'boolean') {
           quietMode = value;
@@ -246,6 +257,7 @@ export function sanitizePreferences(raw: unknown): UserPreferences {
     formDensity,
     milestonesDensity,
     walletDensity,
+    contractsDensity,
     quietMode,
     toastDuration,
     idleDisconnectMs,


### PR DESCRIPTION
feat(contracts): add density toggle (#802)
Summary
Adds a persisted compact/comfortable density toggle to the contracts list view. Users can switch between spacious and condensed row spacing; the choice survives page reloads and falls back safely on invalid stored values.

Changes
preferences.tsx

Added ContractsDensity = 'comfortable' | 'compact' type
Added contractsDensity: 'comfortable' to DEFAULT_PREFERENCES
Added contractsDensity to KNOWN_KEYS whitelist and sanitizePreferences switch — invalid/missing values fall back to 'comfortable'
ContractListItem.tsx

Accepts optional density prop (ContractsDensity, default 'comfortable')
Applies p-4 for comfortable, p-2.5 for compact; mt-1/mt-0.5 on the subtitle line
ContractsList.tsx

Accepts density and onToggleDensity props
Renders an accessible toggle button with aria-pressed and context-aware aria-label ("Switch to compact density" / "Switch to comfortable density")
Passes density down to each ContractListItem; applies space-y-4 vs space-y-2 on the list
page.tsx

Reads contractsDensity from usePreferences()
handleToggleDensity calls updatePreference('contractsDensity', next) to persist via safeStorage under the namespaced key talenttrust-user-preferences
Passes density and onToggleDensity to ContractsList
Tests
New: 
ContractsDensityToggle.test.tsx
 — 32 tests covering:

ContractListItem padding for both densities and re-render behaviour
Toggle button render, labels, aria-pressed, click handler
Density propagated to list items and list spacing
usePreferences persistence: defaults, persist compact/comfortable, restore on mount
Invalid fallbacks: unknown string, number, null, boolean
sanitizePreferences unit cases
Integration cycle: comfortable → compact → comfortable
Updated: 
page.test.tsx
 — 3 new density tests:

Default density passed to ContractsList is 'comfortable'
onToggleDensity is wired when contracts are present
Toggle is absent when no contracts exist
Test output
PASS src/components/contracts/__tests__/ContractsDensityToggle.test.tsx

  ContractListItem – density prop
    ✓ applies comfortable padding by default
    ✓ applies comfortable padding when density="comfortable"
    ✓ applies compact padding when density="compact"
    ✓ re-renders when density prop changes
    ✓ does not re-render when density is stable

  ContractsList – density toggle button
    ✓ renders the toggle button when onToggleDensity is provided
    ✓ does not render the toggle button when onToggleDensity is omitted
    ✓ labels the button "Switch to compact density" when density is comfortable
    ✓ labels the button "Switch to comfortable density" when density is compact
    ✓ calls onToggleDensity when the button is clicked
    ✓ passes density="compact" down to list items when compact
    ✓ passes density="comfortable" down to list items when comfortable
    ✓ uses compact list spacing when density="compact"
    ✓ uses comfortable list spacing when density="comfortable"

  contractsDensity preference – persistence
    ✓ defaults to comfortable
    ✓ persists contractsDensity=compact to localStorage
    ✓ persists contractsDensity=comfortable to localStorage
    ✓ restores contractsDensity on mount (simulates page reload)
    ✓ falls back to comfortable when stored value is invalid
    ✓ falls back to comfortable when stored value is a number
    ✓ falls back to comfortable when stored value is null
    ✓ falls back to comfortable when stored value is boolean
    ✓ does not persist contractsDensity before hydration

  sanitizePreferences – contractsDensity
    ✓ accepts "comfortable"
    ✓ accepts "compact"
    ✓ falls back to comfortable for unknown string
    ✓ falls back to comfortable for number
    ✓ falls back to comfortable for null
    ✓ falls back to comfortable when absent

  ContractsList – toggle integration
    ✓ density toggle cycles comfortable→compact→comfortable
    ✓ renders correctly with empty contracts list at both densities
    ✓ all items adopt the new density when the prop changes

Tests: 32 passed, 32 total
Notes
5 pre-existing failures in page.test.tsx (pagination/filter "load more" tests) were already failing on main before this branch. Confirmed by running the baseline against main directly — those failures are out of scope for this PR.


closes #802