### PR TITLE
feat(wallet): add copy-to-clipboard for wallet identifiers

### DIFF
--- a/src/components/ReputationProfile.tsx
+++ b/src/components/ReputationProfile.tsx
@@ -68,6 +68,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { ConfirmDialog } from './ConfirmDialog';
 import { useToast } from './toast/toast-provider';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { execCommandFallback } from '@/lib/clipboardFallback';
 import {
   DEFAULT_DIR,
   DEFAULT_TYPE,
@@ -86,40 +87,12 @@ export const REPUTATION_PAGE_SIZE = 5;
 
 // ---------------------------------------------------------------------------
 // execCommandFallback — documented clipboard fallback when Clipboard API is
-// unavailable (e.g. non-HTTPS, older browsers).
+// unavailable (e.g. non-HTTPS, older browsers). Lives in `@/lib/clipboardFallback`
+// so it can be shared with other copy-to-clipboard controls (e.g. wallet
+// identifiers in WalletItemList); re-exported here for backwards compatibility.
 // ---------------------------------------------------------------------------
 
-/**
- * Falls back to the deprecated `document.execCommand('copy')` API when the
- * Clipboard API is not available. Creates an off-screen textarea, selects its
- * value, and invokes execCommand. The textarea is always removed from the DOM.
- *
- * @param text - The string to copy to the clipboard.
- * @returns `true` if the execCommand succeeded; `false` otherwise.
- */
-export function execCommandFallback(text: string): boolean {
-  if (typeof document === 'undefined') return false;
-
-  const textarea = document.createElement('textarea');
-  textarea.value = text;
-  textarea.style.position = 'fixed';
-  textarea.style.top = '-9999px';
-  textarea.style.left = '-9999px';
-  textarea.setAttribute('aria-hidden', 'true');
-  document.body.appendChild(textarea);
-  textarea.focus();
-  textarea.select();
-
-  let success = false;
-  try {
-    success = document.execCommand('copy');
-  } catch {
-    // execCommand not supported — success remains false
-  } finally {
-    document.body.removeChild(textarea);
-  }
-  return success;
-}
+export { execCommandFallback } from '@/lib/clipboardFallback';
 
 // ---------------------------------------------------------------------------
 // CopyIdButton — accessible copy control for a single reputation event ID

--- a/src/components/__tests__/wallet-a11y-comprehensive.test.tsx
+++ b/src/components/__tests__/wallet-a11y-comprehensive.test.tsx
@@ -870,14 +870,20 @@ describe('a11y: WalletItemList - keyboard navigation', () => {
     
     const selectAll = screen.getByTestId('select-all-checkbox');
     const itemCheckbox = screen.getByTestId('select-item-checkbox-w-1');
-    const deleteBtn = screen.getByRole('button', { name: /delete/i });
-    
+    const copyAddressBtn = screen.getByTestId('copy-wallet-address-btn-w-1');
+    const deleteBtn = screen.getByRole('button', { name: 'Delete Stellar Lumens (XLM)' });
+
     selectAll.focus();
     expect(selectAll).toHaveFocus();
-    
+
     await user.tab();
     expect(itemCheckbox).toHaveFocus();
-    
+
+    // w-1 has an address, so its copy-address button is the next tab stop
+    // before the delete button.
+    await user.tab();
+    expect(copyAddressBtn).toHaveFocus();
+
     await user.tab();
     expect(deleteBtn).toHaveFocus();
   });

--- a/src/components/wallet/WalletItemList.tsx
+++ b/src/components/wallet/WalletItemList.tsx
@@ -2,6 +2,77 @@
 
 import React, { useCallback, useEffect, useRef } from 'react';
 import type { WalletItem } from '@/types/domain';
+import { useToast } from '@/components/toast/toast-provider';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { execCommandFallback } from '@/lib/clipboardFallback';
+
+interface CopyWalletAddressButtonProps {
+  /** Full (untruncated) wallet address/identifier to copy. */
+  address: string;
+  /** Display name of the wallet item, used to build a descriptive aria-label. */
+  itemName: string;
+  /** Wallet item id, used to build a stable test id. */
+  itemId: string;
+}
+
+/**
+ * Icon-button that copies a wallet item's address/identifier to the clipboard.
+ *
+ * - Uses the Clipboard API with a documented `execCommand` fallback
+ *   (`@/lib/clipboardFallback`) for contexts where `navigator.clipboard` is
+ *   unavailable (e.g. non-HTTPS, older browsers).
+ * - Surfaces success/failure through the global toast system.
+ * - Keyboard-operable (native `<button>`) with a descriptive `aria-label`.
+ * - `aria-pressed` reflects the transient "copied" confirmation state.
+ */
+function CopyWalletAddressButton({ address, itemName, itemId }: CopyWalletAddressButtonProps) {
+  const { showSuccess, showError } = useToast();
+
+  const { copied, copy } = useCopyToClipboard({
+    onSuccess: () => {
+      showSuccess({ title: `Copied wallet address for ${itemName} to clipboard.` });
+    },
+    onError: () => {
+      // Documented fallback: try execCommand when the Clipboard API is unavailable
+      const success = execCommandFallback(address);
+      if (success) {
+        showSuccess({ title: `Copied wallet address for ${itemName} to clipboard.` });
+      } else {
+        showError({ title: `Failed to copy wallet address for ${itemName}. Please copy it manually.` });
+      }
+    },
+  });
+
+  const handleClick = useCallback(() => {
+    copy(address);
+  }, [copy, address]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={`Copy wallet address for ${itemName}`}
+      aria-pressed={copied}
+      data-testid={`copy-wallet-address-btn-${itemId}`}
+      title="Copy wallet address"
+      className={`inline-flex shrink-0 items-center rounded p-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+        copied
+          ? 'text-emerald-600 dark:text-emerald-400'
+          : 'text-slate-400 hover:bg-slate-200 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-slate-200'
+      }`}
+    >
+      {copied ? (
+        <svg aria-hidden="true" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      ) : (
+        <svg aria-hidden="true" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+        </svg>
+      )}
+    </button>
+  );
+}
 
 export interface WalletItemListProps {
   /** Array of wallet items to render */
@@ -93,8 +164,11 @@ export const WalletItemList: React.FC<WalletItemListProps> = ({
                 <td className="px-4 py-4 font-semibold text-slate-900 dark:text-slate-100">
                   {item.name}
                   {item.address && (
-                    <span className="block font-mono text-xs text-slate-400 truncate max-w-[160px]">
-                      {item.address}
+                    <span className="mt-0.5 flex items-center gap-1">
+                      <span className="font-mono text-xs text-slate-400 truncate max-w-[160px]" title={item.address}>
+                        {item.address}
+                      </span>
+                      <CopyWalletAddressButton address={item.address} itemName={item.name} itemId={item.id} />
                     </span>
                   )}
                 </td>

--- a/src/components/wallet/__tests__/WalletItemListCopyAddress.test.tsx
+++ b/src/components/wallet/__tests__/WalletItemListCopyAddress.test.tsx
@@ -1,0 +1,341 @@
+/**
+ * WalletItemListCopyAddress.test.tsx
+ *
+ * Tests for the copy-to-clipboard affordance added to wallet identifiers in
+ * WalletItemList (issue #853).
+ * Covers:
+ *  - Copy button renders only for rows with an address
+ *  - Accessible label and aria-pressed state
+ *  - Clipboard API success path -> toast shown, "Copied" state
+ *  - Clipboard API unavailable -> execCommand fallback -> toast shown
+ *  - Both fallback paths fail -> error toast shown
+ *  - Clipboard API rejects -> execCommand fallback -> toast shown
+ *  - Keyboard operability
+ *  - "copied" state resets after the delay and is isolated per row
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { WalletItemList } from '../WalletItemList';
+import type { WalletItem } from '@/types/domain';
+
+// ---------------------------------------------------------------------------
+// Toast mock
+// ---------------------------------------------------------------------------
+
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+    dismissToast: jest.fn(),
+    toasts: [],
+  }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ITEMS: WalletItem[] = [
+  {
+    id: 'w-1',
+    name: 'Stellar Lumens (XLM)',
+    type: 'Native Asset',
+    balance: 12500,
+    currency: 'XLM',
+    address: 'GAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQDZ7H',
+    status: 'Active',
+    createdAt: '2026-01-15',
+  },
+  {
+    id: 'w-2',
+    name: 'USD Coin (USDC)',
+    type: 'Stablecoin',
+    balance: 3200,
+    currency: 'USDC',
+    address: 'GA2C456789ABCDEF0123456789ABCDEF0123456789ABCDEF',
+    status: 'Pending',
+    createdAt: '2026-02-01',
+  },
+  {
+    id: 'w-3',
+    name: 'Archived Client Token',
+    type: 'Custom Asset',
+    balance: 50,
+    currency: 'ACT',
+    status: 'Archived',
+    createdAt: '2025-11-20',
+  },
+];
+
+function renderList(items = ITEMS) {
+  return render(
+    <WalletItemList
+      items={items}
+      selectedIds={new Set()}
+      onToggleSelect={jest.fn()}
+      onToggleSelectAll={jest.fn()}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Clipboard helpers
+// ---------------------------------------------------------------------------
+
+let originalClipboard: typeof navigator.clipboard;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  originalClipboard = navigator.clipboard;
+  mockShowSuccess.mockClear();
+  mockShowError.mockClear();
+});
+
+afterEach(() => {
+  act(() => { jest.runAllTimers(); });
+  jest.useRealTimers();
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: originalClipboard });
+});
+
+function mockClipboard(impl: () => Promise<void> = () => Promise.resolve()) {
+  const writeText = jest.fn().mockImplementation(impl);
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+  return writeText;
+}
+
+function removeClipboard() {
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
+}
+
+// ---------------------------------------------------------------------------
+// Render: copy button present only when an address exists
+// ---------------------------------------------------------------------------
+
+describe('WalletItemList — copy address button renders', () => {
+  it('renders a copy button for each row with an address', () => {
+    mockClipboard();
+    renderList();
+    expect(screen.getByTestId('copy-wallet-address-btn-w-1')).toBeInTheDocument();
+    expect(screen.getByTestId('copy-wallet-address-btn-w-2')).toBeInTheDocument();
+  });
+
+  it('does not render a copy button for a row without an address', () => {
+    mockClipboard();
+    renderList();
+    expect(screen.queryByTestId('copy-wallet-address-btn-w-3')).not.toBeInTheDocument();
+  });
+
+  it('button has a descriptive aria-label containing the item name', () => {
+    mockClipboard();
+    renderList();
+    expect(
+      screen.getByRole('button', { name: 'Copy wallet address for Stellar Lumens (XLM)' }),
+    ).toBeInTheDocument();
+  });
+
+  it('button has aria-pressed="false" before any copy', () => {
+    mockClipboard();
+    renderList();
+    expect(screen.getByTestId('copy-wallet-address-btn-w-1')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('still renders the raw address text next to the button', () => {
+    mockClipboard();
+    renderList();
+    expect(screen.getByText(ITEMS[0].address!)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clipboard API success path
+// ---------------------------------------------------------------------------
+
+describe('WalletItemList — Clipboard API success', () => {
+  it('calls navigator.clipboard.writeText with the full (untruncated) address', async () => {
+    const writeText = mockClipboard();
+    renderList();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-wallet-address-btn-w-1'));
+    });
+
+    expect(writeText).toHaveBeenCalledWith(ITEMS[0].address);
+  });
+
+  it('shows a success toast after a successful copy', async () => {
+    mockClipboard();
+    renderList();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-wallet-address-btn-w-1'));
+    });
+
+    expect(mockShowSuccess).toHaveBeenCalledTimes(1);
+    expect(mockShowSuccess.mock.calls[0][0]).toMatchObject({
+      title: expect.stringContaining('Stellar Lumens (XLM)'),
+    });
+  });
+
+  it('sets aria-pressed="true" after a successful copy', async () => {
+    mockClipboard();
+    renderList();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-wallet-address-btn-w-1'));
+    });
+
+    expect(screen.getByTestId('copy-wallet-address-btn-w-1')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('resets aria-pressed back to "false" after the delay', async () => {
+    mockClipboard();
+    renderList();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-wallet-address-btn-w-1'));
+    });
+
+    act(() => { jest.advanceTimersByTime(2000); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('copy-wallet-address-btn-w-1')).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
+
+  it('only the clicked row shows the "copied" state; other rows are unaffected', async () => {
+    mockClipboard();
+    renderList();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-wallet-address-btn-w-1'));
+    });
+
+    expect(screen.getByTestId('copy-wallet-address-btn-w-1')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('copy-wallet-address-btn-w-2')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('does not show an error toast on success', async () => {
+    mockClipboard();
+    renderList();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-wallet-address-btn-w-1'));
+    });
+
+    expect(mockShowError).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clipboard API unavailable — execCommand fallback
+// ---------------------------------------------------------------------------
+
+describe('WalletItemList — execCommand fallback (Clipboard API unavailable)', () => {
+  it('falls back to execCommand when navigator.clipboard is absent', async () => {
+    removeClipboard();
+    document.execCommand = jest.fn().mockReturnValue(true);
+    renderList();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-wallet-address-btn-w-1'));
+    });
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(mockShowSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error toast when both Clipboard API and execCommand fail', async () => {
+    removeClipboard();
+    document.execCommand = jest.fn().mockReturnValue(false);
+    renderList();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-wallet-address-btn-w-1'));
+    });
+
+    expect(mockShowError).toHaveBeenCalledTimes(1);
+    expect(mockShowError.mock.calls[0][0]).toMatchObject({
+      title: expect.stringContaining('Stellar Lumens (XLM)'),
+    });
+  });
+
+  it('falls back to execCommand when Clipboard API rejects', async () => {
+    mockClipboard(() => Promise.reject(new Error('Permission denied')));
+    document.execCommand = jest.fn().mockReturnValue(true);
+    renderList();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-wallet-address-btn-w-1'));
+    });
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(mockShowSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error toast when Clipboard API rejects and execCommand also fails', async () => {
+    mockClipboard(() => Promise.reject(new Error('Permission denied')));
+    document.execCommand = jest.fn().mockReturnValue(false);
+    renderList();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('copy-wallet-address-btn-w-1'));
+    });
+
+    expect(mockShowError).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard operability
+// ---------------------------------------------------------------------------
+
+describe('WalletItemList — copy button keyboard operability', () => {
+  it('button is in the tab order (not disabled)', () => {
+    mockClipboard();
+    renderList();
+    expect(screen.getByTestId('copy-wallet-address-btn-w-1')).not.toBeDisabled();
+  });
+
+  it('is reachable via Tab and copies via keyboard activation (Enter)', async () => {
+    const writeText = mockClipboard();
+    renderList();
+
+    const btn = screen.getByTestId('copy-wallet-address-btn-w-1');
+
+    await act(async () => {
+      btn.focus();
+      fireEvent.keyDown(btn, { key: 'Enter' });
+      fireEvent.click(btn);
+    });
+
+    expect(btn).toHaveFocus();
+    expect(writeText).toHaveBeenCalledWith(ITEMS[0].address);
+  });
+
+  it('copies via keyboard activation (Space) as well', async () => {
+    const writeText = mockClipboard();
+    renderList();
+
+    const btn = screen.getByTestId('copy-wallet-address-btn-w-2');
+
+    await act(async () => {
+      btn.focus();
+      fireEvent.keyDown(btn, { key: ' ' });
+      fireEvent.click(btn);
+    });
+
+    expect(writeText).toHaveBeenCalledWith(ITEMS[1].address);
+  });
+
+  it('has a title attribute for a visible tooltip label', () => {
+    mockClipboard();
+    renderList();
+    expect(screen.getByTestId('copy-wallet-address-btn-w-1')).toHaveAttribute('title', 'Copy wallet address');
+  });
+});

--- a/src/components/wallet/__tests__/WalletItemListKeyboard.test.tsx
+++ b/src/components/wallet/__tests__/WalletItemListKeyboard.test.tsx
@@ -74,9 +74,18 @@ describe('WalletItemList — keyboard operation', () => {
     await user.tab();
     expect(screen.getByTestId('select-item-checkbox-w-1')).toHaveFocus();
 
+    // w-1 has an address, so its copy-address button is the next tab stop.
+    await user.tab();
+    expect(screen.getByTestId('copy-wallet-address-btn-w-1')).toHaveFocus();
+
     await user.tab();
     expect(screen.getByTestId('select-item-checkbox-w-2')).toHaveFocus();
 
+    // w-2 also has an address.
+    await user.tab();
+    expect(screen.getByTestId('copy-wallet-address-btn-w-2')).toHaveFocus();
+
+    // w-3 has no address, so its checkbox follows directly with no copy button.
     await user.tab();
     expect(screen.getByTestId('select-item-checkbox-w-3')).toHaveFocus();
   });
@@ -151,7 +160,8 @@ describe('WalletItemList — keyboard operation', () => {
       />
     );
 
-    // tab through select-all, row 1 checkbox, row 1 delete, row 2 checkbox, row 2 delete, row 3 checkbox, row 3 delete
+    // tab through select-all, row 1 checkbox, row 1 copy-address, row 1 delete
+    await user.tab();
     await user.tab();
     await user.tab();
     await user.tab();
@@ -288,7 +298,8 @@ describe('WalletItemList — keyboard operation', () => {
       );
 
       // In a table, focusable elements follow DOM order which is column-major:
-      // all checkboxes first (from thead + tbody), then all delete buttons
+      // all checkboxes first (from thead + tbody), then all buttons (copy-address
+      // and delete, in per-row DOM order: copy comes before delete within a row)
       const allCheckboxes = screen.getAllByRole('checkbox');
       const allButtons = screen.getAllByRole('button');
       const focusableOrder = [...allCheckboxes, ...allButtons];
@@ -302,7 +313,9 @@ describe('WalletItemList — keyboard operation', () => {
         'Select Stellar Lumens (XLM)',
         'Select USD Coin (USDC)',
         'Select Archived Client Token',
+        'Copy wallet address for Stellar Lumens (XLM)',
         'Delete Stellar Lumens (XLM)',
+        'Copy wallet address for USD Coin (USDC)',
         'Delete USD Coin (USDC)',
         'Delete Archived Client Token',
       ];

--- a/src/lib/__tests__/bundleBudget.test.ts
+++ b/src/lib/__tests__/bundleBudget.test.ts
@@ -1,6 +1,3 @@
-import { existsSync, readFileSync, statSync } from 'fs';
-import { resolve } from 'path';
-
 // ── Fixtures ─────────────────────────────────────────────────────────
 // We don't want an actual `next build` in unit tests, so we construct
 // minimal in-memory manifest fixtures and test the script's core logic

--- a/src/lib/clipboardFallback.ts
+++ b/src/lib/clipboardFallback.ts
@@ -1,0 +1,33 @@
+/**
+ * Falls back to the deprecated `document.execCommand('copy')` API when the
+ * Clipboard API is not available (e.g. non-HTTPS contexts, older browsers,
+ * or browsers that block `navigator.clipboard` outside a user gesture).
+ * Creates an off-screen textarea, selects its value, and invokes
+ * execCommand. The textarea is always removed from the DOM.
+ *
+ * @param text - The string to copy to the clipboard.
+ * @returns `true` if the execCommand succeeded; `false` otherwise.
+ */
+export function execCommandFallback(text: string): boolean {
+  if (typeof document === 'undefined') return false;
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.left = '-9999px';
+  textarea.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  let success = false;
+  try {
+    success = document.execCommand('copy');
+  } catch {
+    // execCommand not supported — success remains false
+  } finally {
+    document.body.removeChild(textarea);
+  }
+  return success;
+}


### PR DESCRIPTION
Closes #853

---

Wallet addresses in the Wallet Management table (WalletItemList) had no way to copy them; users had to select the truncated/CSS-clipped text by hand. Adds an accessible copy-to-clipboard button next to each wallet address, using the Clipboard API with a documented execCommand fallback and toast feedback, matching the pattern already used for reputation event IDs.

- Extract execCommandFallback from ReputationProfile.tsx into a shared src/lib/clipboardFallback.ts so it can be reused outside that file; ReputationProfile re-exports it for backwards compatibility with existing imports/tests.
- Add CopyWalletAddressButton in WalletItemList.tsx: copies the full (untruncated) address via useCopyToClipboard, falls back to execCommandFallback when navigator.clipboard is unavailable, and surfaces success/failure via the toast system. Keyboard-operable native <button> with a descriptive aria-label and aria-pressed for the transient "copied" state.
- Update existing keyboard/focus-order tests (WalletItemListKeyboard, wallet-a11y-comprehensive) to account for the new tab stop.
- Add WalletItemListCopyAddress.test.tsx covering: render only when an address exists, accessible label/aria-pressed, Clipboard API success, execCommand fallback (API missing, API rejects), both paths failing, and keyboard activation.
- Remove unused imports in bundleBudget.test.ts (pre-existing lint errors unrelated to this feature that blocked `npm run build`'s lint gate).

## Description

<!-- Summarize the changes in this PR and the motivation behind them. -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

<!-- Briefly describe the test cases you added or updated, and any manual testing performed. -->

---

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->

### Security

<!-- Does this PR touch authentication, authorization, wallet logic, API calls, or
     user-supplied input? Describe any security considerations or "N/A" if not applicable. -->
