### PR TITLE
a11y(reputation): add history list semantics

### DIFF
--- a/docs/components/ReputationProfile.md
+++ b/docs/components/ReputationProfile.md
@@ -141,6 +141,12 @@ Accessibility markers worth knowing:
 - The profile card is a `<section>` with `aria-labelledby="profile-heading"`;
   the heading itself is `sr-only`.
 - The level legend is a `<ul aria-labelledby="reputation-legend-title">`.
+- The history list is an `<ol aria-labelledby="reputation-history-heading">`
+  so assistive tech announces the list's purpose. Each `<li>` carries
+  `aria-labelledby` referencing three ids — `reputation-event-type-{id}`,
+  `reputation-event-summary-{id}`, and `reputation-event-date-{id}` — so
+  every entry's type, summary, and date are programmatically associated
+  into a single accessible name.
 
 ---
 
@@ -240,6 +246,8 @@ The list below documents only behaviors that are implemented in the current code
 - The profile region uses a named `<section>` with `aria-labelledby="profile-heading"` in [src/components/ReputationProfile.tsx](../../src/components/ReputationProfile.tsx).
 - The reputation score is exposed with `role="meter"` and related ARIA values in [src/components/ReputationProfile.tsx](../../src/components/ReputationProfile.tsx).
 - The reputation legend is labelled with `aria-labelledby="reputation-legend-title"` in [src/components/ReputationProfile.tsx](../../src/components/ReputationProfile.tsx).
+- The history list is an `<ol>` with `aria-labelledby="reputation-history-heading"` so it has an accessible name in [src/components/ReputationProfile.tsx](../../src/components/ReputationProfile.tsx).
+- Each history `<li>` uses `aria-labelledby` to associate its type, summary, and date into one accessible name in [src/components/ReputationProfile.tsx](../../src/components/ReputationProfile.tsx).
 - The page wrapper renders a focusable `<main>` element in [src/app/reputation/ReputationPageClient.tsx](../../src/app/reputation/ReputationPageClient.tsx).
 
 ### Keyboard interactions

--- a/src/app/reputation/__tests__/__snapshots__/page.snapshot.test.tsx.snap
+++ b/src/app/reputation/__tests__/__snapshots__/page.snapshot.test.tsx.snap
@@ -202,7 +202,7 @@ exports[`ReputationPageContent snapshot – empty state (negative score) matches
     Reputation
   </h1>
   <div
-    aria-labelledby="_r_2_"
+    aria-labelledby=":r2:"
     class="flex flex-col items-center justify-center px-4 py-8 text-center sm:px-8 sm:py-10"
     data-testid="empty-state"
     role="region"
@@ -233,7 +233,7 @@ exports[`ReputationPageContent snapshot – empty state (negative score) matches
     </div>
     <h2
       class="mb-2 max-w-xl text-xl font-semibold text-gray-950"
-      id="_r_2_"
+      id=":r2:"
     >
       No reputation yet
     </h2>
@@ -256,7 +256,7 @@ exports[`ReputationPageContent snapshot – empty state (null data) matches snap
     Reputation
   </h1>
   <div
-    aria-labelledby="_r_0_"
+    aria-labelledby=":r0:"
     class="flex flex-col items-center justify-center px-4 py-8 text-center sm:px-8 sm:py-10"
     data-testid="empty-state"
     role="region"
@@ -287,7 +287,7 @@ exports[`ReputationPageContent snapshot – empty state (null data) matches snap
     </div>
     <h2
       class="mb-2 max-w-xl text-xl font-semibold text-gray-950"
-      id="_r_0_"
+      id=":r0:"
     >
       No reputation yet
     </h2>
@@ -310,7 +310,7 @@ exports[`ReputationPageContent snapshot – empty state (null score) matches sna
     Reputation
   </h1>
   <div
-    aria-labelledby="_r_3_"
+    aria-labelledby=":r3:"
     class="flex flex-col items-center justify-center px-4 py-8 text-center sm:px-8 sm:py-10"
     data-testid="empty-state"
     role="region"
@@ -341,7 +341,7 @@ exports[`ReputationPageContent snapshot – empty state (null score) matches sna
     </div>
     <h2
       class="mb-2 max-w-xl text-xl font-semibold text-gray-950"
-      id="_r_3_"
+      id=":r3:"
     >
       No reputation yet
     </h2>
@@ -364,7 +364,7 @@ exports[`ReputationPageContent snapshot – empty state (undefined data) matches
     Reputation
   </h1>
   <div
-    aria-labelledby="_r_1_"
+    aria-labelledby=":r1:"
     class="flex flex-col items-center justify-center px-4 py-8 text-center sm:px-8 sm:py-10"
     data-testid="empty-state"
     role="region"
@@ -395,7 +395,7 @@ exports[`ReputationPageContent snapshot – empty state (undefined data) matches
     </div>
     <h2
       class="mb-2 max-w-xl text-xl font-semibold text-gray-950"
-      id="_r_1_"
+      id=":r1:"
     >
       No reputation yet
     </h2>
@@ -651,6 +651,7 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
         <div>
           <h2
             class="text-xl font-semibold text-[var(--foreground)]"
+            id="reputation-history-heading"
           >
             Reputation history
           </h2>
@@ -796,9 +797,11 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
           </div>
         </div>
         <ol
+          aria-labelledby="reputation-history-heading"
           class="space-y-4"
         >
           <li
+            aria-labelledby="reputation-event-type-ev-1 reputation-event-summary-ev-1 reputation-event-date-ev-1"
             class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
           >
             <div
@@ -815,11 +818,13 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
                 <span>
                   <span
                     class="block text-sm font-medium text-[var(--muted-foreground)]"
+                    id="reputation-event-type-ev-1"
                   >
                     Verification
                   </span>
                   <span
                     class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                    id="reputation-event-summary-ev-1"
                   >
                     Completed identity verification
                   </span>
@@ -831,6 +836,7 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
                 <time
                   class="text-sm text-[var(--muted-foreground)] sm:text-right"
                   datetime="2026-04-24"
+                  id="reputation-event-date-ev-1"
                 >
                   2026-04-24
                 </time>
@@ -881,6 +887,7 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
             </div>
           </li>
           <li
+            aria-labelledby="reputation-event-type-ev-2 reputation-event-summary-ev-2 reputation-event-date-ev-2"
             class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
           >
             <div
@@ -897,11 +904,13 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
                 <span>
                   <span
                     class="block text-sm font-medium text-[var(--muted-foreground)]"
+                    id="reputation-event-type-ev-2"
                   >
                     On-chain review
                   </span>
                   <span
                     class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                    id="reputation-event-summary-ev-2"
                   >
                     Received positive trust signal
                   </span>
@@ -913,6 +922,7 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
                 <time
                   class="text-sm text-[var(--muted-foreground)] sm:text-right"
                   datetime="2026-04-23"
+                  id="reputation-event-date-ev-2"
                 >
                   2026-04-23
                 </time>
@@ -963,6 +973,7 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
             </div>
           </li>
           <li
+            aria-labelledby="reputation-event-type-ev-3 reputation-event-summary-ev-3 reputation-event-date-ev-3"
             class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
           >
             <div
@@ -979,11 +990,13 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
                 <span>
                   <span
                     class="block text-sm font-medium text-[var(--muted-foreground)]"
+                    id="reputation-event-type-ev-3"
                   >
                     Referral
                   </span>
                   <span
                     class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                    id="reputation-event-summary-ev-3"
                   >
                     Referred two new community members
                   </span>
@@ -995,6 +1008,7 @@ exports[`ReputationPageContent snapshot – loaded state (default userName) matc
                 <time
                   class="text-sm text-[var(--muted-foreground)] sm:text-right"
                   datetime="2026-04-20"
+                  id="reputation-event-date-ev-3"
                 >
                   2026-04-20
                 </time>
@@ -1302,6 +1316,7 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
         <div>
           <h2
             class="text-xl font-semibold text-[var(--foreground)]"
+            id="reputation-history-heading"
           >
             Reputation history
           </h2>
@@ -1447,9 +1462,11 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
           </div>
         </div>
         <ol
+          aria-labelledby="reputation-history-heading"
           class="space-y-4"
         >
           <li
+            aria-labelledby="reputation-event-type-ev-1 reputation-event-summary-ev-1 reputation-event-date-ev-1"
             class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
           >
             <div
@@ -1466,11 +1483,13 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
                 <span>
                   <span
                     class="block text-sm font-medium text-[var(--muted-foreground)]"
+                    id="reputation-event-type-ev-1"
                   >
                     Verification
                   </span>
                   <span
                     class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                    id="reputation-event-summary-ev-1"
                   >
                     Completed identity verification
                   </span>
@@ -1482,6 +1501,7 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
                 <time
                   class="text-sm text-[var(--muted-foreground)] sm:text-right"
                   datetime="2026-04-24"
+                  id="reputation-event-date-ev-1"
                 >
                   2026-04-24
                 </time>
@@ -1532,6 +1552,7 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
             </div>
           </li>
           <li
+            aria-labelledby="reputation-event-type-ev-2 reputation-event-summary-ev-2 reputation-event-date-ev-2"
             class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
           >
             <div
@@ -1548,11 +1569,13 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
                 <span>
                   <span
                     class="block text-sm font-medium text-[var(--muted-foreground)]"
+                    id="reputation-event-type-ev-2"
                   >
                     On-chain review
                   </span>
                   <span
                     class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                    id="reputation-event-summary-ev-2"
                   >
                     Received positive trust signal
                   </span>
@@ -1564,6 +1587,7 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
                 <time
                   class="text-sm text-[var(--muted-foreground)] sm:text-right"
                   datetime="2026-04-23"
+                  id="reputation-event-date-ev-2"
                 >
                   2026-04-23
                 </time>
@@ -1614,6 +1638,7 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
             </div>
           </li>
           <li
+            aria-labelledby="reputation-event-type-ev-3 reputation-event-summary-ev-3 reputation-event-date-ev-3"
             class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
           >
             <div
@@ -1630,11 +1655,13 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
                 <span>
                   <span
                     class="block text-sm font-medium text-[var(--muted-foreground)]"
+                    id="reputation-event-type-ev-3"
                   >
                     Referral
                   </span>
                   <span
                     class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                    id="reputation-event-summary-ev-3"
                   >
                     Referred two new community members
                   </span>
@@ -1646,6 +1673,7 @@ exports[`ReputationPageContent snapshot – loaded state (full reputation) match
                 <time
                   class="text-sm text-[var(--muted-foreground)] sm:text-right"
                   datetime="2026-04-20"
+                  id="reputation-event-date-ev-3"
                 >
                   2026-04-20
                 </time>
@@ -1967,6 +1995,7 @@ exports[`ReputationPageContent snapshot – partial state (score === 0) matches 
         <div>
           <h2
             class="text-xl font-semibold text-[var(--foreground)]"
+            id="reputation-history-heading"
           >
             Reputation history
           </h2>
@@ -2267,6 +2296,7 @@ exports[`ReputationPageContent snapshot – partial state (score, no history) ma
         <div>
           <h2
             class="text-xl font-semibold text-[var(--foreground)]"
+            id="reputation-history-heading"
           >
             Reputation history
           </h2>

--- a/src/components/ReputationProfile.test.tsx
+++ b/src/components/ReputationProfile.test.tsx
@@ -1190,3 +1190,178 @@ describe('ReputationProfile – history filtering and sorting', () => {
     expect(screen.getByText(/Showing 2 events of type On-chain review/i)).toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// 13. History list semantics & accessible name (a11y/reputation-01)
+// ---------------------------------------------------------------------------
+
+describe('ReputationProfile – history list semantics & accessible name (a11y/reputation-01)', () => {
+  /**
+   * Scenario: The history <ol> has an accessible name via aria-labelledby.
+   * The "Reputation history" heading provides the list's accessible name so
+   * assistive tech can announce the list's purpose when focus enters it.
+   */
+  it('exposes the history list with role="list" and an accessible name', () => {
+    renderProfile({ name: 'List Name User', score: 80, history: HISTORY_EVENTS });
+    const list = screen.getByRole('list', { name: /reputation history/i });
+    expect(list).toBeInTheDocument();
+    expect(list.tagName).toBe('OL');
+  });
+
+  /**
+   * Scenario: The history heading carries the id referenced by the list.
+   * The <h2> "Reputation history" must have id="reputation-history-heading"
+   * so the <ol aria-labelledby="reputation-history-heading"> contract holds.
+   */
+  it('renders the history heading with id="reputation-history-heading"', () => {
+    renderProfile({ name: 'Heading Id User', score: 80, history: HISTORY_EVENTS });
+    const heading = document.getElementById('reputation-history-heading');
+    expect(heading).not.toBeNull();
+    expect(heading?.textContent).toMatch(/reputation history/i);
+  });
+
+  /**
+   * Scenario: The <ol> references the heading via aria-labelledby.
+   */
+  it('the <ol> carries aria-labelledby="reputation-history-heading"', () => {
+    renderProfile({ name: 'Ol Labelledby User', score: 80, history: HISTORY_EVENTS });
+    const ol = document.querySelector('ol');
+    expect(ol).not.toBeNull();
+    expect(ol?.getAttribute('aria-labelledby')).toBe('reputation-history-heading');
+  });
+
+  /**
+   * Scenario: Each <li> has an accessible name composed of its key data.
+   * Every entry's type, summary, and date are programmatically associated
+   * via aria-labelledby so screen readers announce the full context.
+   */
+  it('gives each list item an accessible name via aria-labelledby', () => {
+    renderProfile({ name: 'Li Labelledby User', score: 80, history: HISTORY_EVENTS });
+    const items = within(document.querySelector('ol')!).getAllByRole('listitem');
+    expect(items).toHaveLength(HISTORY_EVENTS.length);
+    HISTORY_EVENTS.forEach((ev, idx) => {
+      const labelledby = items[idx].getAttribute('aria-labelledby');
+      expect(labelledby).toBeTruthy();
+      // The aria-labelledby value must reference the three key-data ids.
+      expect(labelledby).toContain(`reputation-event-type-${ev.id}`);
+      expect(labelledby).toContain(`reputation-event-summary-${ev.id}`);
+      expect(labelledby).toContain(`reputation-event-date-${ev.id}`);
+    });
+  });
+
+  /**
+   * Scenario: Each entry's type element has a unique id.
+   */
+  it('renders a type element with a unique id for each event', () => {
+    renderProfile({ name: 'Type Id User', score: 80, history: HISTORY_EVENTS });
+    HISTORY_EVENTS.forEach((ev) => {
+      const typeEl = document.getElementById(`reputation-event-type-${ev.id}`);
+      expect(typeEl).not.toBeNull();
+      expect(typeEl?.textContent).toBe(ev.type);
+    });
+  });
+
+  /**
+   * Scenario: Each entry's summary element has a unique id.
+   */
+  it('renders a summary element with a unique id for each event', () => {
+    renderProfile({ name: 'Summary Id User', score: 80, history: HISTORY_EVENTS });
+    HISTORY_EVENTS.forEach((ev) => {
+      const summaryEl = document.getElementById(`reputation-event-summary-${ev.id}`);
+      expect(summaryEl).not.toBeNull();
+      expect(summaryEl?.textContent).toBe(ev.summary);
+    });
+  });
+
+  /**
+   * Scenario: Each entry's date element has a unique id.
+   */
+  it('renders a date element with a unique id for each event', () => {
+    renderProfile({ name: 'Date Id User', score: 80, history: HISTORY_EVENTS });
+    HISTORY_EVENTS.forEach((ev) => {
+      const dateEl = document.getElementById(`reputation-event-date-${ev.id}`);
+      expect(dateEl).not.toBeNull();
+      expect(dateEl?.textContent).toBe(ev.date);
+    });
+  });
+
+  /**
+   * Scenario: Entries are enumerated in DOM order matching the history array.
+   * The list items must appear in the same order as the supplied history so
+   * the position of each entry is meaningful to assistive technology.
+   */
+  it('enumerates entries in DOM order matching the supplied history array', () => {
+    renderProfile({ name: 'Order User', score: 80, history: HISTORY_EVENTS });
+    const items = within(document.querySelector('ol')!).getAllByRole('listitem');
+    expect(items).toHaveLength(HISTORY_EVENTS.length);
+    HISTORY_EVENTS.forEach((ev, idx) => {
+      const summaryEl = within(items[idx]).getByText(ev.summary);
+      expect(summaryEl).toBeInTheDocument();
+      // The accessible name of the <li> should include the summary text.
+      const liName = items[idx].getAttribute('aria-labelledby');
+      expect(liName).toContain(`reputation-event-summary-${ev.id}`);
+    });
+  });
+
+  /**
+   * Edge case: Empty history renders no list at all.
+   * When history is empty, no <ol> and no list role should be present.
+   */
+  it('renders no list role when history is empty', () => {
+    renderProfile({ name: 'Empty List User', history: [] });
+    expect(screen.queryByRole('list', { name: /reputation history/i })).not.toBeInTheDocument();
+    expect(document.querySelector('ol')).toBeNull();
+  });
+
+  /**
+   * Edge case: A single history entry still gets full semantics.
+   * One event must still produce a labelled <ol> and a labelled <li>.
+   */
+  it('renders full list semantics for a single history entry', () => {
+    const singleEvent: ReputationEvent = {
+      id: 'ev-solo',
+      type: 'Verification',
+      summary: 'Solo identity check',
+      date: '2026-04-24',
+    };
+    renderProfile({ name: 'Single Entry User', score: 80, history: [singleEvent] });
+
+    const list = screen.getByRole('list', { name: /reputation history/i });
+    expect(list).toBeInTheDocument();
+
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+    expect(items[0].getAttribute('aria-labelledby')).toContain('reputation-event-type-ev-solo');
+    expect(items[0].getAttribute('aria-labelledby')).toContain('reputation-event-summary-ev-solo');
+    expect(items[0].getAttribute('aria-labelledby')).toContain('reputation-event-date-ev-solo');
+  });
+
+  /**
+   * Scenario: The history list accessible name is still present after filtering.
+   * Applying a type filter must not remove the list's accessible name.
+   */
+  it('preserves the list accessible name after filtering', () => {
+    renderProfile({ name: 'Filter Name User', score: 80, history: HISTORY_EVENTS });
+    fireEvent.change(screen.getByLabelText(/Filter:/i), {
+      target: { value: 'Verification' },
+    });
+    const list = screen.getByRole('list', { name: /reputation history/i });
+    expect(list).toBeInTheDocument();
+    expect(list.getAttribute('aria-labelledby')).toBe('reputation-history-heading');
+  });
+
+  /**
+   * Scenario: axe audit passes with the new list semantics.
+   */
+  it('full-history state with list semantics has no axe violations', async () => {
+    const { container } = render(
+      <ReputationProfile
+        name="A11y List Semantics User"
+        score={90}
+        level="Expert"
+        history={HISTORY_EVENTS}
+      />
+    );
+    await assertNoA11yViolations(container);
+  });
+});

--- a/src/components/ReputationProfile.tsx
+++ b/src/components/ReputationProfile.tsx
@@ -462,7 +462,12 @@ export default function ReputationProfile({
       <div className="rounded-3xl border-[var(--border)] bg-[var(--card)] p-6 shadow-sm sm:p-8">
         <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold text-[var(--foreground)]">Reputation history</h2>
+            <h2
+              id="reputation-history-heading"
+              className="text-xl font-semibold text-[var(--foreground)]"
+            >
+              Reputation history
+            </h2>
             <p className="mt-1 text-sm text-[var(--muted-foreground)]">
               History is shown as safe, aggregated events with no wallet or personal metadata by default.
             </p>
@@ -587,12 +592,22 @@ export default function ReputationProfile({
                 </button>
               </div>
             </div>
-            <ol className="space-y-4">
+            <ol
+              aria-labelledby="reputation-history-heading"
+              className="space-y-4"
+            >
               {visibleHistory.map((event) => {
                 const isValidDate = event.date && !Number.isNaN(Date.parse(event.date));
                 const isSelected = selectedIds.includes(event.id);
+                const typeId = `reputation-event-type-${event.id}`;
+                const summaryId = `reputation-event-summary-${event.id}`;
+                const dateId = `reputation-event-date-${event.id}`;
                 return (
-                  <li key={event.id} className={`rounded-3xl border p-5 ${isSelected ? 'border-[var(--foreground)] bg-[var(--muted)]' : 'border-[var(--border)] bg-[var(--card)]'}`}>
+                  <li
+                    key={event.id}
+                    aria-labelledby={`${typeId} ${summaryId} ${dateId}`}
+                    className={`rounded-3xl border p-5 ${isSelected ? 'border-[var(--foreground)] bg-[var(--muted)]' : 'border-[var(--border)] bg-[var(--card)]'}`}
+                  >
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                       <label className="flex items-start gap-3">
                         <input
@@ -603,12 +618,23 @@ export default function ReputationProfile({
                           className="mt-1 h-4 w-4 rounded border-[var(--border)] text-[var(--foreground)] focus:ring-[var(--ring)]"
                         />
                         <span>
-                          <span className="block text-sm font-medium text-[var(--muted-foreground)]">{event.type}</span>
-                          <span className="mt-1 block text-base font-semibold text-[var(--foreground)]">{event.summary}</span>
+                          <span
+                            id={typeId}
+                            className="block text-sm font-medium text-[var(--muted-foreground)]"
+                          >
+                            {event.type}
+                          </span>
+                          <span
+                            id={summaryId}
+                            className="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                          >
+                            {event.summary}
+                          </span>
                         </span>
                       </label>
                       <div className="flex items-center gap-2 sm:flex-col sm:items-end">
                         <time
+                          id={dateId}
                           className="text-sm text-[var(--muted-foreground)] sm:text-right"
                           {...(isValidDate ? { dateTime: event.date } : {})}
                         >

--- a/src/components/__snapshots__/ReputationProfile.snapshot.test.tsx.snap
+++ b/src/components/__snapshots__/ReputationProfile.snapshot.test.tsx.snap
@@ -235,6 +235,7 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
       <div>
         <h2
           class="text-xl font-semibold text-[var(--foreground)]"
+          id="reputation-history-heading"
         >
           Reputation history
         </h2>
@@ -380,9 +381,11 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
         </div>
       </div>
       <ol
+        aria-labelledby="reputation-history-heading"
         class="space-y-4"
       >
         <li
+          aria-labelledby="reputation-event-type-ev-1 reputation-event-summary-ev-1 reputation-event-date-ev-1"
           class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
         >
           <div
@@ -399,11 +402,13 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
               <span>
                 <span
                   class="block text-sm font-medium text-[var(--muted-foreground)]"
+                  id="reputation-event-type-ev-1"
                 >
                   Verification
                 </span>
                 <span
                   class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                  id="reputation-event-summary-ev-1"
                 >
                   Completed identity verification
                 </span>
@@ -415,6 +420,7 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
               <time
                 class="text-sm text-[var(--muted-foreground)] sm:text-right"
                 datetime="2026-04-24"
+                id="reputation-event-date-ev-1"
               >
                 2026-04-24
               </time>
@@ -465,6 +471,7 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
           </div>
         </li>
         <li
+          aria-labelledby="reputation-event-type-ev-2 reputation-event-summary-ev-2 reputation-event-date-ev-2"
           class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
         >
           <div
@@ -481,11 +488,13 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
               <span>
                 <span
                   class="block text-sm font-medium text-[var(--muted-foreground)]"
+                  id="reputation-event-type-ev-2"
                 >
                   On-chain review
                 </span>
                 <span
                   class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                  id="reputation-event-summary-ev-2"
                 >
                   Received positive trust signal
                 </span>
@@ -497,6 +506,7 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
               <time
                 class="text-sm text-[var(--muted-foreground)] sm:text-right"
                 datetime="2026-04-23"
+                id="reputation-event-date-ev-2"
               >
                 2026-04-23
               </time>
@@ -547,6 +557,7 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
           </div>
         </li>
         <li
+          aria-labelledby="reputation-event-type-ev-3 reputation-event-summary-ev-3 reputation-event-date-ev-3"
           class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
         >
           <div
@@ -563,11 +574,13 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
               <span>
                 <span
                   class="block text-sm font-medium text-[var(--muted-foreground)]"
+                  id="reputation-event-type-ev-3"
                 >
                   Referral
                 </span>
                 <span
                   class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                  id="reputation-event-summary-ev-3"
                 >
                   Referred two new community members
                 </span>
@@ -579,6 +592,7 @@ exports[`ReputationProfile snapshot – custom maxScore matches snapshot with ma
               <time
                 class="text-sm text-[var(--muted-foreground)] sm:text-right"
                 datetime="2026-04-20"
+                id="reputation-event-date-ev-3"
               >
                 2026-04-20
               </time>
@@ -891,6 +905,7 @@ exports[`ReputationProfile snapshot – edge: score === 0 matches snapshot (fals
       <div>
         <h2
           class="text-xl font-semibold text-[var(--foreground)]"
+          id="reputation-history-heading"
         >
           Reputation history
         </h2>
@@ -1168,6 +1183,7 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
       <div>
         <h2
           class="text-xl font-semibold text-[var(--foreground)]"
+          id="reputation-history-heading"
         >
           Reputation history
         </h2>
@@ -1313,9 +1329,11 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
         </div>
       </div>
       <ol
+        aria-labelledby="reputation-history-heading"
         class="space-y-4"
       >
         <li
+          aria-labelledby="reputation-event-type-ev-1 reputation-event-summary-ev-1 reputation-event-date-ev-1"
           class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
         >
           <div
@@ -1332,11 +1350,13 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
               <span>
                 <span
                   class="block text-sm font-medium text-[var(--muted-foreground)]"
+                  id="reputation-event-type-ev-1"
                 >
                   Verification
                 </span>
                 <span
                   class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                  id="reputation-event-summary-ev-1"
                 >
                   Completed identity verification
                 </span>
@@ -1348,6 +1368,7 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
               <time
                 class="text-sm text-[var(--muted-foreground)] sm:text-right"
                 datetime="2026-04-24"
+                id="reputation-event-date-ev-1"
               >
                 2026-04-24
               </time>
@@ -1398,6 +1419,7 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
           </div>
         </li>
         <li
+          aria-labelledby="reputation-event-type-ev-2 reputation-event-summary-ev-2 reputation-event-date-ev-2"
           class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
         >
           <div
@@ -1414,11 +1436,13 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
               <span>
                 <span
                   class="block text-sm font-medium text-[var(--muted-foreground)]"
+                  id="reputation-event-type-ev-2"
                 >
                   On-chain review
                 </span>
                 <span
                   class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                  id="reputation-event-summary-ev-2"
                 >
                   Received positive trust signal
                 </span>
@@ -1430,6 +1454,7 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
               <time
                 class="text-sm text-[var(--muted-foreground)] sm:text-right"
                 datetime="2026-04-23"
+                id="reputation-event-date-ev-2"
               >
                 2026-04-23
               </time>
@@ -1480,6 +1505,7 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
           </div>
         </li>
         <li
+          aria-labelledby="reputation-event-type-ev-3 reputation-event-summary-ev-3 reputation-event-date-ev-3"
           class="rounded-3xl border p-5 border-[var(--border)] bg-[var(--card)]"
         >
           <div
@@ -1496,11 +1522,13 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
               <span>
                 <span
                   class="block text-sm font-medium text-[var(--muted-foreground)]"
+                  id="reputation-event-type-ev-3"
                 >
                   Referral
                 </span>
                 <span
                   class="mt-1 block text-base font-semibold text-[var(--foreground)]"
+                  id="reputation-event-summary-ev-3"
                 >
                   Referred two new community members
                 </span>
@@ -1512,6 +1540,7 @@ exports[`ReputationProfile snapshot – full reputation (score + history) matche
               <time
                 class="text-sm text-[var(--muted-foreground)] sm:text-right"
                 datetime="2026-04-20"
+                id="reputation-event-date-ev-3"
               >
                 2026-04-20
               </time>
@@ -1689,6 +1718,7 @@ exports[`ReputationProfile snapshot – no reputation (null score) matches snaps
       <div>
         <h2
           class="text-xl font-semibold text-[var(--foreground)]"
+          id="reputation-history-heading"
         >
           Reputation history
         </h2>
@@ -1845,6 +1875,7 @@ exports[`ReputationProfile snapshot – no reputation (undefined score) matches 
       <div>
         <h2
           class="text-xl font-semibold text-[var(--foreground)]"
+          id="reputation-history-heading"
         >
           Reputation history
         </h2>
@@ -2136,6 +2167,7 @@ exports[`ReputationProfile snapshot – partial reputation (score, no history) m
       <div>
         <h2
           class="text-xl font-semibold text-[var(--foreground)]"
+          id="reputation-history-heading"
         >
           Reputation history
         </h2>


### PR DESCRIPTION
Closes #469 

Added proper list semantics and an accessible name to the reputation history section in `src/components/ReputationProfile.tsx`.

## Changes

### `src/components/ReputationProfile.tsx`
- Added `id="reputation-history-heading"` to the "Reputation history" `<h2>`.
- Added `aria-labelledby="reputation-history-heading"` to the `<ol>` so the list has an accessible name describing its purpose.
- Added unique ids to each entry's key data elements: `reputation-event-type-{id}`, `reputation-event-summary-{id}`, `reputation-event-date-{id}`.
- Added `aria-labelledby` to each `<li>` referencing those three ids, so every entry's type, summary, and date are programmatically associated into one accessible name.

### `src/components/ReputationProfile.test.tsx`
- New describe block "history list semantics & accessible name (a11y/reputation-01)" with 12 tests covering:
  - List role + accessible name (`getByRole('list', { name: /reputation history/i })`)
  - Heading id (`reputation-history-heading`)
  - `<ol>` `aria-labelledby` contract
  - Per-item `aria-labelledby` referencing type/summary/date ids
  - Unique element ids for type, summary, and date
  - DOM order enumeration matching the supplied history array
  - Empty-history edge case (no list role rendered)
  - Single-entry edge case (full semantics still present)
  - Filter-preserved accessible name
  - jest-axe audit (no violations)

### Snapshots updated
- `src/components/__snapshots__/ReputationProfile.snapshot.test.tsx.snap`
- `src/app/reputation/__tests__/__snapshots__/page.snapshot.test.tsx.snap`

### `docs/components/ReputationProfile.md`
- Documented the new history list accessible name and per-entry `aria-labelledby` contract in both the Rendering States and Accessibility sections.

## Test results
All 345 reputation-related tests pass (12 test suites):
```
Test Suites: 12 passed, 12 total
Tests:       345 passed, 345 total
Snapshots:   15 passed, 15 total
```

`npm run lint` and `npm run build` both show only pre-existing failures unrelated to these changes (duplicate import in `src/app/milestones/page.tsx`, unused vars in other files).


No change to the data.