### PR TITLE
feat(toast): add command-palette entry

### DIFF
--- a/src/components/toast/ToastCommand.tsx
+++ b/src/components/toast/ToastCommand.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useToast } from '@/components/toast/toast-provider';
+import { useRegisterCommandAction } from '@/components/CommandPalette';
+
+export default function ToastCommand() {
+  console.log('ToastCommand mounted');
+
+  const { showSuccess } = useToast();
+
+  const toastAction = useMemo(
+    () => ({
+      id: 'show-toast',
+      label: 'Show Toast',
+      keywords: [
+        'toast',
+        'notification',
+        'alert',
+        'message',
+        'success',
+      ],
+      section: 'Dialogs',
+      onSelect: () =>
+        showSuccess({
+          title: 'Toast preview',
+          description: 'Command palette action executed.',
+        }),
+    }),
+    [showSuccess],
+  );
+
+  useRegisterCommandAction(toastAction);
+
+  return null;
+}

--- a/src/components/toast/__tests__/ToastCommand.test.tsx
+++ b/src/components/toast/__tests__/ToastCommand.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ToastCommand from '../ToastCommand';
+import { useToast } from '@/components/toast/toast-provider';
+import { useRegisterCommandAction } from '@/components/CommandPalette';
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: jest.fn(),
+}));
+
+jest.mock('@/components/CommandPalette', () => ({
+  useRegisterCommandAction: jest.fn(),
+}));
+
+describe('ToastCommand', () => {
+  const showSuccess = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useToast as jest.Mock).mockReturnValue({
+      showSuccess,
+    });
+  });
+
+  it('registers the toast command with the command palette', () => {
+    render(<ToastCommand />);
+
+    expect(useRegisterCommandAction).toHaveBeenCalledTimes(1);
+
+    const action = (useRegisterCommandAction as jest.Mock).mock.calls[0][0];
+
+    expect(action.id).toBe('show-toast');
+    expect(action.label).toBe('Show Toast');
+    expect(action.keywords).toEqual(
+      expect.arrayContaining([
+        'toast',
+        'notification',
+        'alert',
+        'message',
+        'success',
+      ]),
+    );
+  });
+
+  it('shows a toast when the command is activated', () => {
+    render(<ToastCommand />);
+
+    const action = (useRegisterCommandAction as jest.Mock).mock.calls[0][0];
+
+    action.onSelect();
+
+    expect(showSuccess).toHaveBeenCalledWith({
+      title: 'Toast preview',
+      description: 'Command palette action executed.',
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds a new command-palette action that allows power users to trigger toast notifications directly from the command palette.

The new command is registered with a clear label and searchable keywords, allowing users to discover and activate it through keyboard navigation.

## Changes Made

- Added `ToastCommand` component to register a toast command-palette action.
- Added a searchable command label and keywords for discoverability.
- Added command activation handling to trigger toast notifications.
- Added tests covering:
  - Command registration
  - Command metadata validation
  - Command activation behavior

## Acceptance Criteria

✅ Register a command-palette action  
- Added a dedicated command registration for triggering toast notifications.

✅ Keyboard-operable  
- Command palette activation executes the registered action without requiring mouse interaction.

✅ No duplicate entries  
- Command registration uses a unique command identifier to prevent duplicate palette entries.

✅ Cover registration and activation in tests  
- Added Jest tests verifying registration and activation behavior.

## Testing

### Feature tests

```bash
npm test -- ToastCommand

##Result:
PASS src/components/toast/__tests__/ToastCommand.test.tsx

✓ registers the toast command with the command palette
✓ shows a toast when the command is activated

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total

##Additional validation
npx eslint src/components/toast/ToastCommand.tsx src/components/toast/__tests__/ToastCommand.test.tsx
Passed successfully.

Notes:
`npm run lint` and `npm run build` currently report unrelated existing issues outside the toast command changes, including missing references in milestone and reputation modules. These errors are not introduced by this PR.

Closes #731