### PR TITLE
feat(contracts): add created-date sort

### DIFF
--- a/docs/lib/sortContracts.md
+++ b/docs/lib/sortContracts.md
@@ -1,0 +1,68 @@
+# `sortContracts`
+
+Deterministic client-side ordering for the Contracts list toolbar.
+
+**Module:** [`src/lib/sortContracts.ts`](../../src/lib/sortContracts.ts)
+**Consumer:** [`src/app/contracts/page.tsx`](../../src/app/contracts/page.tsx)
+
+## Why this exists
+
+The Contracts list needs to surface recently created contracts first. Ordering
+used to be an inline comparator inside the page component, which made it hard to
+test and left ties (contracts sharing a `createdAt` value) resolved by whatever
+order `listContracts()` happened to return. This module extracts the comparator,
+gives it a stable tie-break, and makes it testable in isolation.
+
+## API
+
+| Export | Purpose |
+| --- | --- |
+| `ContractSortOrder` | Union of the four supported orderings. |
+| `DEFAULT_CONTRACT_SORT_ORDER` | `'date-desc'` — newest created first. |
+| `CONTRACT_SORT_OPTIONS` | Toolbar `<option>` values and labels, in display order. |
+| `isContractSortOrder(value)` | Type guard for an arbitrary value. |
+| `toContractSortOrder(value)` | Coerces a `<select>` value, falling back to the default. |
+| `compareContracts(a, b, order)` | The comparator, for callers that compose their own sort. |
+| `sortContracts(contracts, order?)` | Returns a **new** ordered array; never mutates the input. |
+
+## Ordering rules
+
+1. **`date-desc` / `date-asc`** compare `Date.parse(createdAt)`.
+   `createdAt` is a display string, so values that fail to parse are treated as
+   the oldest possible date — they group together at one end of the list rather
+   than scattering.
+2. **`value-desc` / `value-asc`** compare `totalValue`.
+3. **Every ordering** falls back to an ascending comparison of `id`. Contracts
+   that tie on the primary key therefore always come out in the same order, no
+   matter how the incoming array was arranged.
+
+Because the tie-break is total, `sortContracts` is a pure function of the list's
+contents: re-sorting an already-sorted list, or sorting a shuffled copy, yields
+identical output.
+
+## Composing with search
+
+The page filters first and sorts second:
+
+```tsx
+const filteredContracts = useMemo(() => /* search by name/party */, [contracts, searchQuery]);
+const sortedContracts = useMemo(
+  () => sortContracts(filteredContracts, sortOrder),
+  [filteredContracts, sortOrder],
+);
+```
+
+Changing the search query or the sort order re-derives the list without
+refetching, and the exports (CSV/JSON) and result count both read from
+`sortedContracts`, so what you see is what you export.
+
+## Tests
+
+- [`src/lib/__tests__/sortContracts.test.ts`](../../src/lib/__tests__/sortContracts.test.ts)
+  — ordering in both directions, human-readable and ISO dates, same-day
+  timestamps, equal-timestamp tie-breaks, duplicate ids, unparsable dates,
+  empty and single-item lists, input immutability, and the sort-order helpers.
+  100% statement/branch/function/line coverage of the module.
+- [`src/app/contracts/__tests__/page.test.tsx`](../../src/app/contracts/__tests__/page.test.tsx)
+  — toolbar integration: default ordering, switching to oldest-first, tie-break
+  through the rendered list, and combining the sort with the search filter.

--- a/src/app/contracts/__tests__/page.test.tsx
+++ b/src/app/contracts/__tests__/page.test.tsx
@@ -388,6 +388,97 @@ describe('ContractsPage', () => {
       expect(sortSelect).toHaveValue('value-asc');
     });
 
+    describe('created-date sort', () => {
+      /** Names of the contracts currently rendered, in list order. */
+      const renderedNames = () =>
+        screen
+          .getAllByRole('listitem')
+          .map((item) => item.textContent);
+
+      const dated = [
+        makeContract({ id: 'b', contractName: 'Mobile App', createdAt: '2025-03-15' }),
+        makeContract({ id: 'a', contractName: 'Web App', createdAt: '2025-01-02' }),
+        makeContract({ id: 'c', contractName: 'Data Pipeline', createdAt: '2025-07-30' }),
+      ];
+
+      it('defaults to newest first', () => {
+        mockListContracts.mockReturnValue(dated);
+        render(<ContractsPage />);
+
+        expect(screen.getByLabelText(/sort/i)).toHaveValue('date-desc');
+        expect(renderedNames()).toEqual(['Data Pipeline', 'Mobile App', 'Web App']);
+      });
+
+      it('reorders oldest first when date-asc is selected', () => {
+        mockListContracts.mockReturnValue(dated);
+        render(<ContractsPage />);
+
+        fireEvent.change(screen.getByLabelText(/sort/i), {
+          target: { value: 'date-asc' },
+        });
+
+        expect(renderedNames()).toEqual(['Web App', 'Mobile App', 'Data Pipeline']);
+      });
+
+      it('breaks equal created dates on id in both directions', () => {
+        mockListContracts.mockReturnValue([
+          makeContract({ id: 'c', contractName: 'Charlie', createdAt: '2025-01-01' }),
+          makeContract({ id: 'a', contractName: 'Alpha', createdAt: '2025-01-01' }),
+          makeContract({ id: 'b', contractName: 'Bravo', createdAt: '2025-01-01' }),
+        ]);
+        render(<ContractsPage />);
+
+        expect(renderedNames()).toEqual(['Alpha', 'Bravo', 'Charlie']);
+
+        fireEvent.change(screen.getByLabelText(/sort/i), {
+          target: { value: 'date-asc' },
+        });
+
+        expect(renderedNames()).toEqual(['Alpha', 'Bravo', 'Charlie']);
+      });
+
+      it('combines the created-date sort with the search filter', () => {
+        mockListContracts.mockReturnValue([
+          makeContract({ id: 'a', contractName: 'App Alpha', createdAt: '2025-02-01' }),
+          makeContract({ id: 'b', contractName: 'App Bravo', createdAt: '2025-05-01' }),
+          makeContract({ id: 'c', contractName: 'Unrelated', createdAt: '2025-09-01' }),
+        ]);
+        render(<ContractsPage />);
+
+        fireEvent.change(screen.getByPlaceholderText(/search/i), {
+          target: { value: 'app' },
+        });
+        fireEvent.change(screen.getByLabelText(/sort/i), {
+          target: { value: 'date-asc' },
+        });
+
+        expect(renderedNames()).toEqual(['App Alpha', 'App Bravo']);
+
+        fireEvent.change(screen.getByLabelText(/sort/i), {
+          target: { value: 'date-desc' },
+        });
+
+        expect(renderedNames()).toEqual(['App Bravo', 'App Alpha']);
+      });
+
+      it('keeps the empty search state when sorting a filtered-out list', () => {
+        mockListContracts.mockReturnValue([
+          makeContract({ id: 'a', contractName: 'Web App', createdAt: '2025-01-01' }),
+        ]);
+        render(<ContractsPage />);
+
+        fireEvent.change(screen.getByPlaceholderText(/search/i), {
+          target: { value: 'Nonexistent' },
+        });
+        fireEvent.change(screen.getByLabelText(/sort/i), {
+          target: { value: 'date-asc' },
+        });
+
+        expect(screen.getByText('No contracts match your search')).toBeInTheDocument();
+        expect(screen.queryByTestId('contracts-list')).not.toBeInTheDocument();
+      });
+    });
+
     it('renders empty state when search yields no matches', () => {
       const contracts = [makeContract({ contractName: 'Web App' })];
       mockListContracts.mockReturnValue(contracts);

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -8,6 +8,13 @@ import { listContracts, saveContract } from '@/lib/repository';
 import { downloadContractsCsv, downloadContractsJson } from '@/lib/exportContracts';
 import { useToast } from '@/components/toast/toast-provider';
 import { usePreferences } from '@/lib/preferences';
+import {
+  CONTRACT_SORT_OPTIONS,
+  DEFAULT_CONTRACT_SORT_ORDER,
+  sortContracts,
+  toContractSortOrder,
+  type ContractSortOrder,
+} from '@/lib/sortContracts';
 import type { Contract } from '@/types/domain';
 
 type ContractsFetchState =
@@ -27,7 +34,7 @@ const ContractsPage: React.FC = () => {
   const [fetchState, setFetchState] = useState<ContractsFetchState>(getInitialFetchState);
   const [showForm, setShowForm] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortOrder, setSortOrder] = useState<'date-desc' | 'date-asc' | 'value-desc' | 'value-asc'>('date-desc');
+  const [sortOrder, setSortOrder] = useState<ContractSortOrder>(DEFAULT_CONTRACT_SORT_ORDER);
   const { showError } = useToast();
   const { preferences, updatePreference } = usePreferences();
   const { contracts } = fetchState;
@@ -108,26 +115,11 @@ const ContractsPage: React.FC = () => {
     });
   }, [contracts, searchQuery]);
 
-  const sortedContracts = useMemo(() => {
-    const result = [...filteredContracts];
-    result.sort((a, b) => {
-      if (sortOrder === 'value-desc' || sortOrder === 'value-asc') {
-        const diff = a.totalValue - b.totalValue;
-        if (diff !== 0) {
-          return sortOrder === 'value-desc' ? -diff : diff;
-        }
-      }
-      
-      const timeA = Date.parse(a.createdAt);
-      const timeB = Date.parse(b.createdAt);
-      // fallback to date if values are equal, or if sorting by date
-      if (sortOrder === 'date-desc' || sortOrder === 'value-desc' || sortOrder === 'value-asc') {
-        return timeB - timeA;
-      }
-      return timeA - timeB; // date-asc
-    });
-    return result;
-  }, [filteredContracts, sortOrder]);
+  // Ordering is applied on top of the search results, so the two combine.
+  const sortedContracts = useMemo(
+    () => sortContracts(filteredContracts, sortOrder),
+    [filteredContracts, sortOrder],
+  );
 
   return (
     <main className="min-h-screen p-8 pb-24">
@@ -210,13 +202,14 @@ const ContractsPage: React.FC = () => {
               <select
                 id="contracts-sort"
                 value={sortOrder}
-                onChange={(e) => setSortOrder(e.target.value as any)}
+                onChange={(e) => setSortOrder(toContractSortOrder(e.target.value))}
                 className="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
               >
-                <option value="date-desc">Newest first</option>
-                <option value="date-asc">Oldest first</option>
-                <option value="value-desc">Value (High to Low)</option>
-                <option value="value-asc">Value (Low to High)</option>
+                {CONTRACT_SORT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
               </select>
             </div>
             <div className="flex items-center gap-2">

--- a/src/lib/__tests__/sortContracts.test.ts
+++ b/src/lib/__tests__/sortContracts.test.ts
@@ -1,0 +1,206 @@
+import {
+  CONTRACT_SORT_OPTIONS,
+  DEFAULT_CONTRACT_SORT_ORDER,
+  compareContracts,
+  isContractSortOrder,
+  sortContracts,
+  toContractSortOrder,
+} from '@/lib/sortContracts';
+import type { Contract } from '@/types/domain';
+
+function makeContract(overrides: Partial<Contract> = {}): Contract {
+  return {
+    id: 'contract-id',
+    contractName: 'Website Redesign',
+    parties: [],
+    totalValue: 1000,
+    currency: 'USD',
+    status: 'Active',
+    createdAt: '2025-01-01',
+    milestoneCount: 0,
+    ...overrides,
+  };
+}
+
+const ids = (contracts: Contract[]) => contracts.map((contract) => contract.id);
+
+describe('sortContracts', () => {
+  describe('created-date ordering', () => {
+    const unordered = [
+      makeContract({ id: 'b', createdAt: '2025-03-15' }),
+      makeContract({ id: 'a', createdAt: '2025-01-02' }),
+      makeContract({ id: 'c', createdAt: '2025-07-30' }),
+    ];
+
+    it('orders newest first for date-desc', () => {
+      expect(ids(sortContracts(unordered, 'date-desc'))).toEqual(['c', 'b', 'a']);
+    });
+
+    it('orders oldest first for date-asc', () => {
+      expect(ids(sortContracts(unordered, 'date-asc'))).toEqual(['a', 'b', 'c']);
+    });
+
+    it('defaults to newest first when no order is given', () => {
+      expect(ids(sortContracts(unordered))).toEqual(['c', 'b', 'a']);
+      expect(DEFAULT_CONTRACT_SORT_ORDER).toBe('date-desc');
+    });
+
+    it('parses human-readable created dates', () => {
+      const contracts = [
+        makeContract({ id: 'a', createdAt: 'Jan 1, 2025' }),
+        makeContract({ id: 'b', createdAt: 'Dec 31, 2024' }),
+        makeContract({ id: 'c', createdAt: 'Mar 4, 2025' }),
+      ];
+
+      expect(ids(sortContracts(contracts, 'date-asc'))).toEqual(['b', 'a', 'c']);
+    });
+
+    it('distinguishes timestamps on the same day', () => {
+      const contracts = [
+        makeContract({ id: 'late', createdAt: '2025-01-01T18:00:00Z' }),
+        makeContract({ id: 'early', createdAt: '2025-01-01T06:00:00Z' }),
+      ];
+
+      expect(ids(sortContracts(contracts, 'date-asc'))).toEqual(['early', 'late']);
+      expect(ids(sortContracts(contracts, 'date-desc'))).toEqual(['late', 'early']);
+    });
+
+    it('does not mutate the input array', () => {
+      const contracts = [
+        makeContract({ id: 'a', createdAt: '2025-01-01' }),
+        makeContract({ id: 'b', createdAt: '2025-06-01' }),
+      ];
+      const snapshot = [...contracts];
+
+      sortContracts(contracts, 'date-desc');
+
+      expect(contracts).toEqual(snapshot);
+    });
+  });
+
+  describe('tie-breaks', () => {
+    it('breaks equal created dates on id, ascending, in both directions', () => {
+      const sameDay = [
+        makeContract({ id: 'c', createdAt: '2025-01-01' }),
+        makeContract({ id: 'a', createdAt: '2025-01-01' }),
+        makeContract({ id: 'b', createdAt: '2025-01-01' }),
+      ];
+
+      expect(ids(sortContracts(sameDay, 'date-desc'))).toEqual(['a', 'b', 'c']);
+      expect(ids(sortContracts(sameDay, 'date-asc'))).toEqual(['a', 'b', 'c']);
+    });
+
+    it('produces the same order regardless of input order', () => {
+      const base = [
+        makeContract({ id: 'a', createdAt: '2025-01-01' }),
+        makeContract({ id: 'b', createdAt: '2025-01-01' }),
+        makeContract({ id: 'c', createdAt: '2025-02-01' }),
+      ];
+      const reversed = [...base].reverse();
+
+      expect(ids(sortContracts(base, 'date-desc'))).toEqual(
+        ids(sortContracts(reversed, 'date-desc')),
+      );
+      expect(ids(sortContracts(base, 'date-asc'))).toEqual(
+        ids(sortContracts(reversed, 'date-asc')),
+      );
+    });
+
+    it('keeps identical ids adjacent without throwing', () => {
+      const duplicates = [
+        makeContract({ id: 'dupe', createdAt: '2025-01-01' }),
+        makeContract({ id: 'dupe', createdAt: '2025-01-01' }),
+      ];
+
+      expect(ids(sortContracts(duplicates, 'date-desc'))).toEqual(['dupe', 'dupe']);
+      expect(compareContracts(duplicates[0], duplicates[1], 'date-desc')).toBe(0);
+    });
+
+    it('groups unparsable created dates deterministically by id', () => {
+      const contracts = [
+        makeContract({ id: 'z', createdAt: 'not a date' }),
+        makeContract({ id: 'm', createdAt: '2025-01-01' }),
+        makeContract({ id: 'a', createdAt: 'unknown' }),
+      ];
+
+      // Unparsable dates sort as the oldest possible value.
+      expect(ids(sortContracts(contracts, 'date-asc'))).toEqual(['a', 'z', 'm']);
+      expect(ids(sortContracts(contracts, 'date-desc'))).toEqual(['m', 'a', 'z']);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns an empty array for an empty list', () => {
+      expect(sortContracts([], 'date-desc')).toEqual([]);
+      expect(sortContracts([], 'date-asc')).toEqual([]);
+    });
+
+    it('returns a single contract unchanged', () => {
+      const only = [makeContract({ id: 'only' })];
+
+      expect(ids(sortContracts(only, 'date-desc'))).toEqual(['only']);
+    });
+
+    it('accepts a readonly array', () => {
+      const contracts: readonly Contract[] = [
+        makeContract({ id: 'b', createdAt: '2025-01-02' }),
+        makeContract({ id: 'a', createdAt: '2025-01-01' }),
+      ];
+
+      expect(ids(sortContracts(contracts, 'date-asc'))).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('value ordering', () => {
+    const contracts = [
+      makeContract({ id: 'mid', totalValue: 500, createdAt: '2025-01-01' }),
+      makeContract({ id: 'high', totalValue: 900, createdAt: '2025-01-02' }),
+      makeContract({ id: 'low', totalValue: 100, createdAt: '2025-01-03' }),
+    ];
+
+    it('orders high to low for value-desc', () => {
+      expect(ids(sortContracts(contracts, 'value-desc'))).toEqual(['high', 'mid', 'low']);
+    });
+
+    it('orders low to high for value-asc', () => {
+      expect(ids(sortContracts(contracts, 'value-asc'))).toEqual(['low', 'mid', 'high']);
+    });
+
+    it('breaks equal values on id rather than on created date', () => {
+      const equalValues = [
+        makeContract({ id: 'b', totalValue: 250, createdAt: '2025-05-05' }),
+        makeContract({ id: 'a', totalValue: 250, createdAt: '2024-01-01' }),
+      ];
+
+      expect(ids(sortContracts(equalValues, 'value-desc'))).toEqual(['a', 'b']);
+      expect(ids(sortContracts(equalValues, 'value-asc'))).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('sort order helpers', () => {
+    it.each(CONTRACT_SORT_OPTIONS.map((option) => option.value))(
+      'recognises %s as a valid sort order',
+      (value) => {
+        expect(isContractSortOrder(value)).toBe(true);
+        expect(toContractSortOrder(value)).toBe(value);
+      },
+    );
+
+    it.each([['name-asc'], [''], [null], [undefined], [42], [{}]])(
+      'rejects %p and falls back to the default',
+      (value) => {
+        expect(isContractSortOrder(value)).toBe(false);
+        expect(toContractSortOrder(value)).toBe(DEFAULT_CONTRACT_SORT_ORDER);
+      },
+    );
+
+    it('exposes the toolbar options in display order', () => {
+      expect(CONTRACT_SORT_OPTIONS.map((option) => option.value)).toEqual([
+        'date-desc',
+        'date-asc',
+        'value-desc',
+        'value-asc',
+      ]);
+    });
+  });
+});

--- a/src/lib/sortContracts.ts
+++ b/src/lib/sortContracts.ts
@@ -1,0 +1,108 @@
+/**
+ * @file sortContracts.ts
+ *
+ * Pure, deterministic ordering helpers for the Contracts list toolbar.
+ *
+ * The list is sorted entirely on the client, on top of whatever the active
+ * search/filter has already narrowed the collection down to. Every ordering
+ * ends with a tie-break on `id`, so contracts that compare equal on the
+ * primary key (identical `createdAt` timestamps, identical values) always
+ * come back in the same order regardless of the input order.
+ */
+
+import type { Contract } from '@/types/domain';
+
+/** Ordering options offered by the Contracts list toolbar. */
+export type ContractSortOrder =
+  | 'date-desc'
+  | 'date-asc'
+  | 'value-desc'
+  | 'value-asc';
+
+/** The default ordering: most recently created contracts first. */
+export const DEFAULT_CONTRACT_SORT_ORDER: ContractSortOrder = 'date-desc';
+
+/** Toolbar option list, in the order the `<select>` renders them. */
+export const CONTRACT_SORT_OPTIONS: ReadonlyArray<{
+  value: ContractSortOrder;
+  label: string;
+}> = [
+  { value: 'date-desc', label: 'Newest first' },
+  { value: 'date-asc', label: 'Oldest first' },
+  { value: 'value-desc', label: 'Value (High to Low)' },
+  { value: 'value-asc', label: 'Value (Low to High)' },
+];
+
+const SORT_ORDER_VALUES = new Set<string>(
+  CONTRACT_SORT_OPTIONS.map((option) => option.value),
+);
+
+/** Narrows an arbitrary string (e.g. a `<select>` value) to a sort order. */
+export const isContractSortOrder = (value: unknown): value is ContractSortOrder =>
+  typeof value === 'string' && SORT_ORDER_VALUES.has(value);
+
+/**
+ * Coerces an arbitrary value to a sort order, falling back to the default
+ * when it is not one of the supported options.
+ */
+export const toContractSortOrder = (value: unknown): ContractSortOrder =>
+  isContractSortOrder(value) ? value : DEFAULT_CONTRACT_SORT_ORDER;
+
+/**
+ * Parses a contract's `createdAt` string to a comparable timestamp.
+ *
+ * `createdAt` is a display string (`"Jan 1, 2025"`, an ISO date, …) so it can
+ * fail to parse. Unparsable dates are treated as the oldest possible value in
+ * ascending order — combined with the `id` tie-break this keeps them grouped
+ * deterministically at one end of the list instead of scattering them.
+ */
+const parseCreatedAt = (contract: Contract): number => {
+  const time = Date.parse(contract.createdAt);
+  return Number.isNaN(time) ? Number.NEGATIVE_INFINITY : time;
+};
+
+/** Locale-independent, stable comparison of two contract ids. */
+const compareIds = (a: Contract, b: Contract): number => {
+  if (a.id === b.id) return 0;
+  return a.id < b.id ? -1 : 1;
+};
+
+/**
+ * Compares two contracts under the given ordering.
+ *
+ * Exported for reuse by callers that need to merge this ordering into a
+ * larger comparison (and to keep the tie-break rule testable in isolation).
+ */
+export const compareContracts = (
+  a: Contract,
+  b: Contract,
+  sortOrder: ContractSortOrder,
+): number => {
+  if (sortOrder === 'value-desc' || sortOrder === 'value-asc') {
+    const diff = a.totalValue - b.totalValue;
+    if (diff !== 0) {
+      return sortOrder === 'value-desc' ? -diff : diff;
+    }
+  } else {
+    const diff = parseCreatedAt(a) - parseCreatedAt(b);
+    // `Infinity - Infinity` is NaN, so guard: two unparsable dates are equal.
+    if (diff !== 0 && !Number.isNaN(diff)) {
+      return sortOrder === 'date-desc' ? -diff : diff;
+    }
+  }
+
+  return compareIds(a, b);
+};
+
+/**
+ * Returns a new array of contracts ordered by `sortOrder`.
+ *
+ * The input array is never mutated. Contracts that tie on the primary key are
+ * ordered by `id`, so the result is fully determined by the contents of the
+ * list rather than by its incoming order.
+ */
+export const sortContracts = (
+  contracts: readonly Contract[],
+  sortOrder: ContractSortOrder = DEFAULT_CONTRACT_SORT_ORDER,
+): Contract[] =>
+  [...contracts].sort((a, b) => compareContracts(a, b, sortOrder));


### PR DESCRIPTION
Closes #494 

## Summary

Adds a created-date ascending/descending sort to the Contracts list, applied client-side on top of the existing search filter, with a stable tie-break on `id`.

The toolbar already exposed "Newest first" / "Oldest first", but the ordering was an inline comparator inside `ContractsPage` with two problems:

1. **No tie-break.** Contracts sharing a `createdAt` value rendered in whatever order `listContracts()` happened to return, so the list could reshuffle between renders.
2. **Direction ignored on the value sorts.** When `totalValue` was equal, the comparator fell through to a date branch that always applied `date-desc`, regardless of the selected option.

This PR extracts the comparator into a pure, fully tested module and fixes both.

## Changes

| File | Change |
| --- | --- |
| `src/lib/sortContracts.ts` | **New.** `ContractSortOrder`, `DEFAULT_CONTRACT_SORT_ORDER`, `CONTRACT_SORT_OPTIONS`, `isContractSortOrder`, `toContractSortOrder`, `compareContracts`, `sortContracts`. |
| `src/app/contracts/page.tsx` | Inline sort replaced by `sortContracts(filteredContracts, sortOrder)`. The `<select>` renders from `CONTRACT_SORT_OPTIONS` and narrows its value via `toContractSortOrder` instead of `as any`. |
| `src/lib/__tests__/sortContracts.test.ts` | **New.** 27 unit tests. |
| `src/app/contracts/__tests__/page.test.tsx` | 5 new toolbar integration tests. |
| `docs/lib/sortContracts.md` | **New.** API table, ordering rules, composition with search. |

### Ordering rules

1. `date-desc` / `date-asc` compare `Date.parse(createdAt)`. `createdAt` is a display string (`"Jan 1, 2025"`, ISO, …), so values that fail to parse are treated as the oldest possible date — they group together at one end of the list instead of scattering.
2. `value-desc` / `value-asc` compare `totalValue`, honouring the selected direction.
3. **Every** ordering falls back to an ascending comparison of `id`. Ties therefore always resolve the same way, so `sortContracts` is a pure function of the list's contents — sorting a shuffled copy yields identical output.

`sortContracts` returns a new array and never mutates its input.

### Composition with search

The page filters first and sorts second, so the two combine:

```tsx
const filteredContracts = useMemo(() => /* search by name/party */, [contracts, searchQuery]);
const sortedContracts = useMemo(
  () => sortContracts(filteredContracts, sortOrder),
  [filteredContracts, sortOrder],
);
```

The result count and the CSV/JSON exports both read from `sortedContracts`, so what you see is what you export.

## Edge cases covered

- Equal timestamps (tie-break on `id`, verified in both directions)
- Duplicate `id`s (comparator returns `0`, no throw)
- Unparsable `createdAt` strings
- Same-day timestamps that differ only by time
- Empty list and single-item list
- Input array immutability
- `readonly` array inputs
- Invalid `<select>` values coerced back to the default

## Test output

```
$ npx jest src/lib/__tests__/sortContracts.test.ts src/app/contracts/__tests__/page.test.tsx --verbose --coverage --collectCoverageFrom='src/lib/sortContracts.ts'

PASS src/app/contracts/__tests__/page.test.tsx
  ContractsPage
    empty state
      ✓ renders empty state when no contracts exist
      ✓ allows creating a contract from empty state
    contracts list rendering
      ✓ renders contracts list when contracts exist
      ✓ displays create button when contracts exist
      ✓ hides form when showing contracts list
    form interactions
      ✓ shows form when create button is clicked
      ✓ hides form when cancel is clicked
      ✓ persists contract and updates list on form submission
    Contract Persistence
      ✓ adds the contract optimistically and keeps the list in sync on success
      ✓ handles large contract lists efficiently
      ✓ rolls back the optimistic contract and shows an error toast on save failure
      ✓ closes form after successful submission
      ✓ maintains memoization when form state changes
    Search and Sort
      ✓ filters contracts by search term in contract name or parties
      ✓ sorts contracts by value and date correctly
      ✓ renders empty state when search yields no matches
      created-date sort
        ✓ defaults to newest first
        ✓ reorders oldest first when date-asc is selected
        ✓ breaks equal created dates on id in both directions
        ✓ combines the created-date sort with the search filter
        ✓ keeps the empty search state when sorting a filtered-out list
    edge cases
      ✓ handles repository errors gracefully
      ✓ renders a recoverable error instead of the empty state when loading fails
      ✓ re-fetches contracts when retry is activated
      ✓ handles rapid form toggles
      ✓ preserves contracts list when switching between empty and non-empty states
    Page Structure
      ✓ renders page heading
      ✓ renders main landmark
    density toggle
      ✓ passes density="comfortable" to ContractsList by default
      ✓ passes onToggleDensity to ContractsList when contracts are present
      ✓ density toggle button is absent when no contracts exist
    load more data
      ✓ renders persisted contracts when storage already contains data
      ✓ load-more append behavior
      ✓ end-of-list behavior

PASS src/lib/__tests__/sortContracts.test.ts
  sortContracts
    created-date ordering
      ✓ orders newest first for date-desc
      ✓ orders oldest first for date-asc
      ✓ defaults to newest first when no order is given
      ✓ parses human-readable created dates
      ✓ distinguishes timestamps on the same day
      ✓ does not mutate the input array
    tie-breaks
      ✓ breaks equal created dates on id, ascending, in both directions
      ✓ produces the same order regardless of input order
      ✓ keeps identical ids adjacent without throwing
      ✓ groups unparsable created dates deterministically by id
    edge cases
      ✓ returns an empty array for an empty list
      ✓ returns a single contract unchanged
      ✓ accepts a readonly array
    value ordering
      ✓ orders high to low for value-desc
      ✓ orders low to high for value-asc
      ✓ breaks equal values on id rather than on created date
    sort order helpers
      ✓ recognises date-desc as a valid sort order
      ✓ recognises date-asc as a valid sort order
      ✓ recognises value-desc as a valid sort order
      ✓ recognises value-asc as a valid sort order
      ✓ rejects "name-asc" and falls back to the default
      ✓ rejects "" and falls back to the default
      ✓ rejects null and falls back to the default
      ✓ rejects undefined and falls back to the default
      ✓ rejects 42 and falls back to the default
      ✓ rejects {} and falls back to the default
      ✓ exposes the toolbar options in display order

------------------|---------|----------|---------|---------|-------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------------|---------|----------|---------|---------|-------------------
All files         |     100 |      100 |     100 |     100 |
 sortContracts.ts |     100 |      100 |     100 |     100 |
------------------|---------|----------|---------|---------|-------------------

Test Suites: 2 passed, 2 total
Tests:       61 passed, 61 total
Snapshots:   0 total
Time:        1.292 s
```

Coverage of the impacted module is **100%** across statements, branches, functions and lines (requirement: ≥95%).

## Pre-existing breakage on this branch

`npm run lint`, the full `npm test` run, and `npm run build` are all already failing on `main`. I verified this branch does not add to it, and deliberately left the unrelated failures alone rather than widening scope:

- **`npm run lint`** — 21 errors, none in the files this PR touches. Identical count with these changes stashed. Includes an unresolved **merge conflict marker in `src/components/settings/SettingsPanel.tsx:3`**.
- **`npm test`** — I diffed per-test results against a stashed baseline: **126 failed before, 126 failed after — zero new failures, zero fixed.** Total tests 3237 → 3269 (the 32 added here).
- **`npm run build`** — fails compiling `src/app/reputation/page.tsx:10` (`listReputationEvents` imported twice), a file this PR does not touch. The build cannot go green on any branch until that and `SettingsPanel.tsx` are repaired.


