### PR TITLE
test(milestones): cover keyboard navigation

### DIFF
--- a/src/app/milestones/page.tsx
+++ b/src/app/milestones/page.tsx
@@ -263,20 +263,20 @@ const MilestonesContent: React.FC = () => {
               </label>
               <button
                 type="button"
+                aria-label="Add Milestone"
+                onClick={handleAddMilestone}
+                className="flex-shrink-0 rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+              >
+                Add Milestone
+              </button>
+              <button
+                type="button"
                 onClick={() => downloadMilestonesICS(sortedMilestones)}
                 aria-label="Add to calendar"
                 className="flex-shrink-0 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
               >
                 <span aria-hidden="true" className="mr-1">📅</span>
                 Add to Calendar
-              </button>
-              <button
-                type="button"
-                aria-label="Add Milestone"
-                onClick={handleAddMilestone}
-                className="flex-shrink-0 rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-              >
-                Add Milestone
               </button>
             </div>
           </div>

--- a/src/components/__tests__/MilestonesKeyboard.test.tsx
+++ b/src/components/__tests__/MilestonesKeyboard.test.tsx
@@ -287,12 +287,16 @@ describe('milestones keyboard — logical tab order', () => {
     expect(allRadio).toHaveFocus();
 
     // Within a radiogroup only the checked radio is in the tab order;
-    // next Tab leaves the group to the sort select, Add Milestone, then links, then dismiss, then scroll region.
+    // next Tab leaves the group to the sort select, Add Milestone, Add to
+    // Calendar, then links, then dismiss, then scroll region.
     await user.tab();
     expect(screen.getByLabelText(/sort milestones/i)).toHaveFocus();
 
     await user.tab();
     expect(screen.getByRole('button', { name: /^add milestone$/i })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: /add to calendar/i })).toHaveFocus();
 
     await user.tab();
     expect(screen.getByRole('button', { name: /switch to compact density/i })).toHaveFocus();
@@ -343,6 +347,47 @@ describe('milestones keyboard — logical tab order', () => {
     await user.keyboard('{ArrowRight}');
 
     expect(onChange).toHaveBeenCalledWith('Active');
+  });
+
+  it('ArrowLeft moves selection backward within the MilestoneFilter radiogroup', async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(
+      <MilestoneFilter selected="Active" onChange={onChange} resultCount={3} />,
+    );
+
+    screen.getByRole('radio', { name: 'Active' }).focus();
+    await user.keyboard('{ArrowLeft}');
+
+    expect(onChange).toHaveBeenCalledWith('All');
+  });
+});
+
+describe('milestones keyboard — Escape', () => {
+  it('Escape closes MilestoneCreationForm and calls onCancel', async () => {
+    const onCancel = jest.fn();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<MilestoneCreationForm onSubmit={jest.fn()} onCancel={onCancel} />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape from the full milestones page returns focus to Add Milestone', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await renderMilestonesPage();
+
+    const addBtn = screen.getByRole('button', { name: /^add milestone$/i });
+    addBtn.focus();
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(addBtn).toHaveFocus();
   });
 });
 


### PR DESCRIPTION
Closes #1009

## Summary

Milestones' keyboard navigation was already substantially tested (`src/components/__tests__/MilestonesKeyboard.test.tsx` covers focus styles, Enter/Space activation, tab order, and axe checks). Running the suite before touching anything surfaced two real, concrete gaps and one pre-existing regression:

### 1. Found and fixed a real defect: broken tab order

The existing `tabs from filter radios to Add Milestone...` test was **failing** on `main` before this change. A newer "Add to Calendar" button (`src/app/milestones/page.tsx`) had been inserted into the DOM *before* the primary "Add Milestone" button, so Tab visited the secondary action first — silently breaking the already-documented, already-tested tab order.

Fix: reordered the two `<button>` elements so "Add Milestone" (primary CTA) precedes "Add to Calendar" (secondary), restoring the intended tab sequence. Updated the test to also assert the new "Add to Calendar" stop in between (it's a legitimate addition to the sequence, just misordered).

This falls within this issue's explicit scope: "Do not change behaviour unless a defect is found" — a defect was found (a failing pre-existing test), so I fixed it rather than working around it.

### 2. Added missing arrow/Escape coverage

- `MilestoneFilter` uses native `<input type="radio">` grouped by `name`, so `ArrowRight` was already tested but `ArrowLeft` (backward direction) was not — added `ArrowLeft moves selection backward within the MilestoneFilter radiogroup`.
- `MilestoneCreationForm` already implements Escape-to-cancel (via the shared `useDialogFocusTrap` hook) and it's tested in `src/app/milestones/__tests__/focus.test.tsx` — but not in this canonically-named "keyboard navigation" suite that this issue points at. Added a new `describe('milestones keyboard — Escape')` block with two tests: Escape calls `onCancel` on the form in isolation, and Escape from the full page closes the dialog and returns focus to "Add Milestone".

No other production behavior was changed.

## Test output

```
PASS src/components/__tests__/MilestonesKeyboard.test.tsx
  milestones keyboard — visible focus styles (6 tests)
  milestones keyboard — Enter/Space activation (8 tests)
  milestones keyboard — logical tab order (4 tests, incl. the 2 new/fixed ones)
  milestones keyboard — Escape (2 new tests)
  milestones keyboard — axe (2 tests)

Test Suites: 1 passed, 1 total
Tests:       22 passed, 22 total
```

`npx eslint src/app/milestones/page.tsx src/components/__tests__/MilestonesKeyboard.test.tsx` — clean, no warnings.

## Note on pre-existing, unrelated failures found while verifying

- **6 pre-existing test failures** in `src/app/milestones/__tests__/page.test.tsx` (optimistic-save/error-toast flows, e.g. `adds a milestone optimistically and keeps it visible on success`). Confirmed via `git stash`/checkout comparison against unmodified `main` — fail identically with none of my changes present. Unrelated to keyboard navigation. Left untouched, out of scope for this issue.
- **`npm run build` currently fails on `main`**, unrelated to this PR: `src/app/reputation/page.tsx` has duplicate imports (`ReputationProfile`, `listReputationEvents` each imported twice), a Turbopack hard error. Confirmed via the same before/after comparison that this is 100% pre-existing and untouched by this PR's two files.

## Verification

- `npx jest src/components/__tests__/MilestonesKeyboard.test.tsx` — 22/22 passing (see above).
- `npx eslint` on both changed files — clean.
- `npm run build` — **could not verify**; fails on unmodified `main` for the unrelated pre-existing reason described above. Flagging rather than silently omitting.