### PR TITLE
a11y(milestones): support high-contrast mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -209,6 +209,28 @@ body {
   [data-wallet-table] button {
     border: 1px solid ButtonText !important;
   }
+
+  /* ── Milestone-specific high-contrast rules ──
+     The selected/unselected milestone-row distinction is normally carried
+     by border-indigo-300/bg-indigo-50 vs border-slate-200/bg-slate-50,
+     which forced-colors mode strips (same class of issue as wallet rows
+     above). StatusBadge and the MilestoneFilter radiogroup already fall
+     under the generic [role="status"] / fieldset label rules further up
+     in this block, so only the row-selection state needs a dedicated rule
+     here. */
+
+  /* Milestone row container: visible border for every row */
+  [data-milestone-row] {
+    border: 1px solid CanvasText !important;
+  }
+
+  /* Selected milestone row: highlighted background with high-contrast text */
+  [data-milestone-row][data-selected="true"] {
+    background-color: Highlight !important;
+    color: HighlightText !important;
+    border: 1px solid Highlight !important;
+    forced-color-adjust: none;
+  }
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/components/__tests__/MilestonesList.test.tsx
+++ b/src/components/__tests__/MilestonesList.test.tsx
@@ -781,6 +781,39 @@ describe('MilestonesList – multi-select and bulk actions', () => {
       expect(article).toHaveAttribute('data-selected', 'true');
       expect(cb.checked).toBe(true);
     });
+
+    it('rows carry a data-milestone-row attribute for forced-colors targeting', () => {
+      render(<MilestonesList milestones={THREE_SAMPLE} />);
+
+      const article = screen.getByRole('article', { name: /Milestone Two/i });
+      expect(article).toHaveAttribute('data-milestone-row');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // High-contrast / forced-colors
+  // ---------------------------------------------------------------------------
+
+  describe('a11y: high-contrast — selected row', () => {
+    it('selected row keeps both data-milestone-row and data-selected="true" so the forced-colors rule can target it', async () => {
+      const user = userEvent.setup();
+      render(<MilestonesList milestones={THREE_SAMPLE} />);
+
+      const article = screen.getByRole('article', { name: /Milestone Two/i });
+      await user.click(itemCheckbox('m2'));
+
+      expect(article).toHaveAttribute('data-milestone-row');
+      expect(article).toHaveAttribute('data-selected', 'true');
+    });
+
+    it('has no axe violations with a row selected', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<MilestonesList milestones={THREE_SAMPLE} />);
+
+      await user.click(itemCheckbox('m2'));
+
+      expect(await axe(container)).toHaveNoViolations();
+    });
   });
 
   describe('multi row selection', () => {

--- a/src/components/__tests__/__snapshots__/MilestonesList.structure.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/MilestonesList.structure.test.tsx.snap
@@ -143,6 +143,7 @@ exports[`MilestonesList structural/snapshot tests edge cases matches the structu
     <article
       aria-label="Local milestone"
       class="rounded-3xl border p-4 shadow-sm transition-colors border-slate-200 bg-slate-50"
+      data-milestone-row="true"
       data-selected="false"
       id="milestone-m1"
     >
@@ -238,6 +239,7 @@ exports[`MilestonesList structural/snapshot tests edge cases matches the structu
     <article
       aria-label="Foreign milestone"
       class="rounded-3xl border p-4 shadow-sm transition-colors border-slate-200 bg-slate-50"
+      data-milestone-row="true"
       data-selected="false"
       id="milestone-m2"
     >
@@ -496,6 +498,7 @@ exports[`MilestonesList structural/snapshot tests edge cases matches the structu
     <article
       aria-label="Urgent milestone"
       class="rounded-3xl border p-4 shadow-sm transition-colors border-slate-200 bg-slate-50"
+      data-milestone-row="true"
       data-selected="false"
       id="milestone-m1"
     >
@@ -709,6 +712,7 @@ exports[`MilestonesList structural/snapshot tests edge cases renders "Due TBD" a
     <article
       aria-label="Undated milestone"
       class="rounded-3xl border p-4 shadow-sm transition-colors border-slate-200 bg-slate-50"
+      data-milestone-row="true"
       data-selected="false"
       id="milestone-m1"
     >
@@ -1027,6 +1031,7 @@ exports[`MilestonesList structural/snapshot tests loaded state matches the struc
     <article
       aria-label="Kickoff call"
       class="rounded-3xl border p-4 shadow-sm transition-colors border-slate-200 bg-slate-50"
+      data-milestone-row="true"
       data-selected="false"
       id="milestone-m1"
     >
@@ -1122,6 +1127,7 @@ exports[`MilestonesList structural/snapshot tests loaded state matches the struc
     <article
       aria-label="Design handoff"
       class="rounded-3xl border p-4 shadow-sm transition-colors border-slate-200 bg-slate-50"
+      data-milestone-row="true"
       data-selected="false"
       id="milestone-m2"
     >
@@ -1217,6 +1223,7 @@ exports[`MilestonesList structural/snapshot tests loaded state matches the struc
     <article
       aria-label="Final delivery"
       class="rounded-3xl border p-4 shadow-sm transition-colors border-slate-200 bg-slate-50"
+      data-milestone-row="true"
       data-selected="false"
       id="milestone-m3"
     >

--- a/src/components/milestones/MilestoneRow.tsx
+++ b/src/components/milestones/MilestoneRow.tsx
@@ -256,6 +256,7 @@ export const MilestoneRow: React.FC<MilestoneRowProps> = ({
         id={`milestone-${milestone.id}`}
         aria-label={milestone.title}
         data-selected={isSelected}
+        data-milestone-row
         className={`rounded-3xl border p-4 shadow-sm transition-colors ${
           isSelected
             ? 'border-indigo-300 bg-indigo-50'


### PR DESCRIPTION
Closes #1008

## Summary

Milestones' selected/unselected row distinction is carried entirely by Tailwind colors (`border-indigo-300 bg-indigo-50` selected vs `border-slate-200 bg-slate-50` unselected). In `forced-colors` mode (Windows High Contrast), the browser strips these background/border colors, so a selected milestone row would become visually indistinguishable from an unselected one.

The repo already has an established pattern for exactly this class of problem (wallet rows, `src/app/globals.css` `@media (forced-colors: active)` block, using `data-wallet-table`/`data-selected` attribute hooks + `Highlight`/`HighlightText` system colors). This PR applies the same pattern to milestones.

## What was already covered (verified, no changes needed)

- `StatusBadge` (used for each milestone's status pill) already renders `role="status"`, which the existing generic forced-colors rule (`[role="status"] { border: 1px solid CanvasText !important; }`) already covers. It's also already icon+text (never color-only).
- `MilestoneFilter`'s radiogroup pills already fall under the existing generic `fieldset label` / `fieldset label:has(input:checked)` rules (border + `Highlight`/`HighlightText` on the selected pill).
- Focus-visible outlines (`focus-visible:outline-*` classes throughout) are handled automatically by the browser's own forced-colors outline mapping — no explicit rule needed.

## What was missing and is added here

- `src/components/milestones/MilestoneRow.tsx`: added a `data-milestone-row` marker attribute to the row `<article>` (alongside the existing `data-selected`), matching the wallet convention (`data-wallet-table`) of a dedicated attribute hook for CSS targeting.
- `src/app/globals.css`: two new rules inside the existing `@media (forced-colors: active)` block:
  ```css
  [data-milestone-row] {
    border: 1px solid CanvasText !important;
  }
  [data-milestone-row][data-selected="true"] {
    background-color: Highlight !important;
    color: HighlightText !important;
    border: 1px solid Highlight !important;
    forced-color-adjust: none;
  }
  ```
  Mirrors the existing wallet-row selected-state rule exactly, adapted to `MilestoneRow`'s actual `data-selected="true"/"false"` string convention (confirmed via the existing, unmodified test `marks the article data-selected=true ... when a row is selected` in `MilestonesList.test.tsx`, which I deliberately did not touch).

No visual change in normal (non-forced-colors) mode — the new rules only apply inside the `forced-colors: active` media query, and the new `data-milestone-row` attribute carries no styling of its own.

## Tests

Added to `src/components/__tests__/MilestonesList.test.tsx`:
- `rows carry a data-milestone-row attribute for forced-colors targeting`
- `selected row keeps both data-milestone-row and data-selected="true" so the forced-colors rule can target it`
- `has no axe violations with a row selected`

Updated 4 pre-existing structural snapshots in `MilestonesList.structure.test.tsx.snap` to include the new `data-milestone-row="true"` attribute (verified via diff that this is the *only* change in each snapshot).

## Test output

```
PASS src/components/__tests__/MilestonesList.test.tsx
PASS src/components/__tests__/MilestoneRow.test.tsx
PASS src/components/__tests__/MilestonesList.structure.test.tsx

Test Suites: 3 passed, 3 total
Tests:       131 passed, 131 total
Snapshots:   5 passed, 5 total
```

`npx eslint` on both changed `.tsx` files — clean (globals.css isn't covered by the eslint config, expected).

## Verification

- `npx jest src/components/__tests__/MilestonesList.test.tsx src/components/__tests__/MilestoneRow.test.tsx src/components/__tests__/MilestonesList.structure.test.tsx` — 131/131 passing on this branch (based on unmodified `main`).
- `npm run build` — **not independently verified**; `main` currently fails to build for a pre-existing, unrelated reason (duplicate imports in `src/app/reputation/page.tsx` — see my PR for #1009 in this repo for full disclosure). Not implicated by this PR's files.
