### PR TITLE
a11y(reputation): support high-contrast mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -209,6 +209,48 @@ body {
   [data-wallet-table] button {
     border: 1px solid ButtonText !important;
   }
+
+  /* ── Reputation-specific high-contrast rules ──
+     Ensures the reputation score meter, history list, selected items, and
+     toolbar remain legible and clearly distinguishable when forced-colors
+     mode is active (e.g. Windows High Contrast). */
+
+  /* Score meter fill visibility (mirrors the [role="progressbar"] treatment
+     above; reputation's score indicator uses role="meter" instead). */
+  [role="meter"] {
+    border: 1px solid CanvasText !important;
+    forced-color-adjust: none;
+  }
+
+  /* Reputation history list: visible container boundary */
+  [data-reputation-list] {
+    border: 0; /* the list itself has no visual chrome; each item does */
+  }
+
+  [data-reputation-list] li {
+    border: 1px solid CanvasText !important;
+  }
+
+  /* Selected reputation history items: highlighted background with
+     high-contrast text, matching the selected-wallet-row treatment. */
+  [data-reputation-list] li[data-selected] {
+    background-color: Highlight !important;
+    color: HighlightText !important;
+    border: 1px solid Highlight !important;
+    forced-color-adjust: none;
+  }
+
+  /* Reputation toolbar (export/delete/clear selection): visible border */
+  [data-reputation-toolbar] {
+    border: 1px solid CanvasText !important;
+    padding: 0.25rem;
+  }
+
+  /* Reputation toolbar and copy-id buttons: ensure visible boundaries */
+  [data-reputation-toolbar] button,
+  [data-reputation-list] button {
+    border: 1px solid ButtonText !important;
+  }
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/components/ReputationProfile.tsx
+++ b/src/components/ReputationProfile.tsx
@@ -2,9 +2,6 @@ import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { execCommandFallback } from '@/lib/clipboardFallback';
 import { useOptimisticReputationMutation } from '@/hooks/useOptimisticReputationMutation';
 import { formatRelativeTime, toISOString } from '@/lib/formatRelativeTime';
-import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
-import { execCommandFallback } from '@/lib/clipboardFallback';
-import { useOptimisticReputationMutation } from '@/hooks/useOptimisticReputationMutation';
 
 export type ReputationEvent = {
   id: string;
@@ -80,6 +77,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ConfirmDialog } from './ConfirmDialog';
 import { useToast } from './toast/toast-provider';
+import { useFormAnnouncer } from '@/hooks/useFormAnnouncer';
 
 import {
   DEFAULT_DIR,
@@ -273,7 +271,6 @@ export default function ReputationProfile({
   const availableTypes = useMemo(() => getAvailableHistoryTypes(history), [history]);
   const typeOptions = useMemo(() => [DEFAULT_TYPE, ...availableTypes], [availableTypes]);
 
-  const syncUrl = true;
   const [selectedType, setSelectedType] = useState<string>(() =>
     syncUrl ? getValidType(searchParams.get('type'), availableTypes) : DEFAULT_TYPE
   );
@@ -580,6 +577,7 @@ export default function ReputationProfile({
               <div
                 role="toolbar"
                 aria-label="Reputation history actions"
+                data-reputation-toolbar
                 className="flex flex-wrap gap-2"
               >
                 <button
@@ -617,6 +615,7 @@ export default function ReputationProfile({
             </div>
             <ol
               aria-labelledby="reputation-history-heading"
+              data-reputation-list
               className="space-y-4"
             >
               {visibleHistory.map((event) => {
@@ -629,6 +628,7 @@ export default function ReputationProfile({
                   <li
                     key={event.id}
                     aria-labelledby={`${typeId} ${summaryId} ${dateId}`}
+                    {...(isSelected ? { 'data-selected': true } : {})}
                     className={`rounded-3xl border p-5 ${isSelected ? 'border-[var(--foreground)] bg-[var(--muted)]' : 'border-[var(--border)] bg-[var(--card)]'}`}
                   >
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">

--- a/src/components/__tests__/reputation-a11y-high-contrast.test.tsx
+++ b/src/components/__tests__/reputation-a11y-high-contrast.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * reputation-a11y-high-contrast.test.tsx
+ *
+ * Structural coverage for forced-colors / high-contrast support on
+ * ReputationProfile (issue: "Add high-contrast mode support to
+ * reputation"). jsdom does not evaluate `@media (forced-colors: active)`,
+ * so — mirroring the existing wallet high-contrast tests
+ * (`wallet-a11y-motion-contrast.test.tsx`) — these assert the presence of
+ * the `data-*` hooks the CSS in `globals.css` targets, plus an axe audit
+ * of the rendered structure.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ReputationProfile, {
+  ReputationEvent,
+  ReputationProfileProps,
+} from '../ReputationProfile';
+import { assertNoA11yViolations } from '@/test-utils/a11y';
+
+jest.mock('../toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+    dismissToast: jest.fn(),
+    toasts: [],
+  }),
+}));
+
+const HISTORY: ReputationEvent[] = [
+  { id: 'ev-1', type: 'Verification', summary: 'Completed identity verification', date: '2026-04-24' },
+  { id: 'ev-2', type: 'On-chain review', summary: 'Received positive trust signal', date: '2026-04-23' },
+];
+
+function renderProfile(props: ReputationProfileProps) {
+  return render(<ReputationProfile syncUrl={false} {...props} />);
+}
+
+describe('a11y: high-contrast — ReputationProfile', () => {
+  it('score meter has role="meter" for forced-colors targeting', () => {
+    renderProfile({ name: 'Score User', score: 70, history: HISTORY });
+    expect(screen.getByRole('meter')).toBeInTheDocument();
+  });
+
+  it('history list has data-reputation-list attribute for forced-colors targeting', () => {
+    const { container } = renderProfile({ name: 'List User', score: 70, history: HISTORY });
+    expect(container.querySelector('[data-reputation-list]')).toBeInTheDocument();
+  });
+
+  it('toolbar has data-reputation-toolbar attribute for forced-colors targeting', () => {
+    const { container } = renderProfile({ name: 'Toolbar User', score: 70, history: HISTORY });
+    expect(container.querySelector('[data-reputation-toolbar]')).toBeInTheDocument();
+  });
+
+  it('toolbar retains role="toolbar" for assistive technology in high-contrast', () => {
+    renderProfile({ name: 'Toolbar Role User', score: 70, history: HISTORY });
+    expect(screen.getByRole('toolbar', { name: 'Reputation history actions' })).toBeInTheDocument();
+  });
+
+  it('selected history items gain data-selected for forced-colors highlighting, unselected do not', () => {
+    const { container } = renderProfile({ name: 'Select User', score: 70, history: HISTORY });
+
+    const firstCheckbox = screen.getByLabelText(/Select reputation item Verification/i);
+    fireEvent.click(firstCheckbox);
+
+    const items = container.querySelectorAll('[data-reputation-list] li');
+    expect(items[0]).toHaveAttribute('data-selected', 'true');
+    expect(items[1]).not.toHaveAttribute('data-selected');
+  });
+
+  it('data-selected is removed again when the item is deselected', () => {
+    const { container } = renderProfile({ name: 'Deselect User', score: 70, history: HISTORY });
+
+    const firstCheckbox = screen.getByLabelText(/Select reputation item Verification/i);
+    fireEvent.click(firstCheckbox);
+    fireEvent.click(firstCheckbox);
+
+    const items = container.querySelectorAll('[data-reputation-list] li');
+    expect(items[0]).not.toHaveAttribute('data-selected');
+  });
+
+  it('has no axe violations with an item selected (structural a11y for high-contrast rendering)', async () => {
+    const { container } = renderProfile({ name: 'Axe User', score: 70, history: HISTORY });
+    fireEvent.click(screen.getByLabelText(/Select reputation item Verification/i));
+    await assertNoA11yViolations(container);
+  });
+});


### PR DESCRIPTION
## Summary
Adds `forced-colors: active` (Windows High Contrast) support for `ReputationProfile`, mirroring the existing wallet high-contrast rules in `globals.css`:

- New "Reputation-specific high-contrast rules" block: score meter (`role="meter"`) border + fill visibility, history list item borders, selected-item highlight (`Highlight`/`HighlightText`), toolbar border, and button borders — all scoped via new `data-reputation-toolbar` / `data-reputation-list` / `data-selected` attributes on the corresponding elements (same targeting pattern as `data-wallet-table` etc.)
- No layout or class changes in normal (non-forced-colors) mode — only new `data-*` attributes and an additive CSS block.

## Pre-existing bugs found and fixed (blocking, unrelated to high-contrast)
While verifying this against the test suite, `ReputationProfile.tsx` failed to even parse/render on `main` at HEAD, for three unrelated pre-existing reasons (confirmed via `git diff main` — none of these lines are part of the high-contrast change):
1. The whole import block was duplicated verbatim (7 lines → syntax error: `Identifier 'useCopyToClipboard' has already been declared`).
2. A stray `const syncUrl = true;` inside the function body redeclared the `syncUrl` prop (syntax error), and — worse — silently hardcoded URL-sync to always-on regardless of the `syncUrl` prop tests pass (`syncUrl={false}`).
3. `useFormAnnouncer` was called but never imported (`ReferenceError` at render time).

Fixing these three was necessary just to get `ReputationProfile.test.tsx` (117 tests) and my new test file running at all — before this PR, **zero** tests in this file could execute. I did not touch anything beyond these three specific breakages plus my own additions; a handful of pre-existing, unrelated lint errors (unused vars, one `selectedEvents is not defined` reference around `handleExportSelected`) and 5 pre-existing test failures under `ReputationProfile – high-contrast theme tokens (a11y/reputation-31)` (about CSS-variable-token migration for `bg-slate-*`/`text-slate-*`/`border-slate-200`, unrelated to forced-colors) remain — out of scope for this issue.

## Tests
New `reputation-a11y-high-contrast.test.tsx`, mirroring `wallet-a11y-motion-contrast.test.tsx`'s structural approach (jsdom can't evaluate `forced-colors` media queries, so these assert the `data-*` hooks plus an axe audit): meter role present, list/toolbar data attributes present, `data-selected` toggles on select/deselect, toolbar role retained, no axe violations with an item selected. 7/7 pass.

`npx jest src/components/ReputationProfile.test.tsx src/components/__tests__/reputation-a11y-high-contrast.test.tsx`: 112/117 + 7/7 pass (5 pre-existing unrelated failures noted above). `npx eslint` on the touched files: only pre-existing errors/warnings, none on lines this PR added.

Closes #1013