### PR TITLE
docs(milestones): add theming guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Reference documentation for components, hooks, contexts, and library utilities.
 | [MilestoneFilter.md](./components/MilestoneFilter.md) | Status filter radiogroup, `aria-live` result count |
 | [MilestonesApi.md](./components/MilestonesApi.md) | Milestones component API reference — props, shared types, minimal usage examples |
 | [MilestonesUsageGuide.md](./components/MilestonesUsageGuide.md) | Milestones components usage guide — composition patterns, props, accessibility, troubleshooting |
+| [MilestonesTheming.md](./components/MilestonesTheming.md) | Milestones theme token usage (`--ring`, `--status-*`), current values, how to customize, and what isn't tokenized yet |
 | [MilestonesList.md](./components/MilestonesList.md) | Milestone list rendering, accessibility contract (roles, keyboard, focus), density toggle, pagination |
 | [MilestoneRow.md](./components/MilestoneRow.md) | Milestone row view/edit modes — accessibility contract (roles, keyboard, focus) |
 | [Navbar.md](./components/Navbar.md) | Global navigation, keyboard support |

--- a/docs/components/MilestonesTheming.md
+++ b/docs/components/MilestonesTheming.md
@@ -1,0 +1,126 @@
+# Milestones Theming Guide
+
+## Overview
+
+This guide documents exactly which CSS custom properties ("theme tokens")
+the milestones components consume, where each one is used, and how to
+customize them. It also documents — accurately, not aspirationally — the
+parts of milestones' styling that are **not** tokenized today, so this
+guide doesn't overstate how theme-aware the feature currently is.
+
+Theme switching itself (`light` / `dark` / `system`, persistence, hydration)
+is implemented once, application-wide, by `PreferencesProvider`; see
+[`docs/preferences.md`](../preferences.md) for that contract. This guide
+only covers how milestones plugs into it.
+
+## How theming reaches milestones
+
+`PreferencesProvider` sets `data-theme="light"` or `data-theme="dark"` on
+`document.documentElement` based on the user's `theme` preference
+(`src/lib/preferences.tsx`). `src/app/globals.css` defines every token
+twice — once under `:root` (light values) and once under
+`[data-theme='dark']` (dark values) — so any component that reads a token
+via `var(--token-name)` automatically repaints when the attribute changes,
+with no per-component theme logic required.
+
+## Tokens milestones actually consumes
+
+Only two token surfaces are used by milestones components today:
+
+| Token | Consumer | Where |
+|---|---|---|
+| `--ring` | `MilestonesList` | Focus ring on the scrollable list region (`focus-visible:ring-[var(--ring)]`) |
+| `--status-success-bg` / `--status-success-foreground` | `StatusBadge` | `Active` and `Paid` milestone status pills |
+| `--status-info-bg` / `--status-info-foreground` | `StatusBadge` | `Completed` milestone status pills |
+| `--status-error-bg` / `--status-error-foreground` | `StatusBadge` | `Disputed` milestone status pills |
+| `--status-warning-bg` / `--status-warning-foreground` | `StatusBadge` | `Pending` milestone status pills |
+
+`StatusBadge` is shared with `ContractSummary` — see
+[`StatusBadge.md`](./StatusBadge.md) for its full color-token table. The
+`--status-*` tokens were introduced and contrast-audited under issue
+a11y/theming-27; both light and dark pairs meet WCAG AA (4.5:1) for text
+against their own chip background — see
+[`Accessibility.md`](./Accessibility.md#accessibility-dark-theme-color-contrast-audit)
+for the full ratio table.
+
+## Current token values
+
+From `src/app/globals.css`:
+
+| Token | Light (`:root`) | Dark (`[data-theme='dark']`) |
+|---|---|---|
+| `--ring` | `#2563eb` | `#3b82f6` |
+| `--status-success-bg` | `#d1fae5` | `#14532d` |
+| `--status-success-foreground` | `#065f46` | `#6ee7b7` |
+| `--status-info-bg` | `#e0f2fe` | `#0c4a6e` |
+| `--status-info-foreground` | `#075985` | `#7dd3fc` |
+| `--status-error-bg` | `#ffe4e6` | `#7f1d1d` |
+| `--status-error-foreground` | `#9f1239` | `#fda4af` |
+| `--status-warning-bg` | `#fef3c7` | `#78350f` |
+| `--status-warning-foreground` | `#92400e` | `#fcd34d` |
+
+## Customizing
+
+Edit the token's value under both selectors in `src/app/globals.css` — a
+token changed in only one theme will look correct in that theme and wrong
+in the other:
+
+```css
+:root {
+  --status-warning-bg: #fef3c7;       /* light "Pending" chip background */
+}
+
+[data-theme='dark'] {
+  --status-warning-bg: #78350f;       /* dark "Pending" chip background */
+}
+```
+
+If you change a `--status-*` pair, re-check contrast for both the
+text-on-chip ratio and the chip-vs-`--surface` separation ratio (the two
+checks documented in `Accessibility.md`'s audit) — a change that passes one
+and fails the other will look fine in isolation but blend into the page
+background in that theme.
+
+There is currently no dedicated milestones-only token override point;
+milestones tokens are the same application-wide `--ring` / `--status-*`
+tokens every other status-driven component (e.g. `ContractSummary`) reads
+from. Introducing a milestones-specific override would mean adding new
+custom properties and threading them through `StatusBadge`'s `className`
+prop or a new variant — not something this guide assumes exists.
+
+## What is *not* tokenized (known limitation, not a bug)
+
+Most of milestones' visual surface is **hardcoded Tailwind color classes**,
+not CSS custom properties, and does not change with `data-theme` at all:
+
+- **Row backgrounds/borders** (`MilestoneRow.tsx`): unselected rows use
+  `border-slate-200 bg-slate-50`, selected rows use
+  `border-indigo-300 bg-indigo-50`. Neither has a `dark:` Tailwind variant,
+  so a milestone row renders with the same light-slate/indigo colors
+  regardless of the active theme.
+- **`MilestonesListSkeleton`**: entirely `bg-slate-200` shimmer blocks, no
+  `dark:` variants.
+- **The due-soon reminder banner** (`MilestonesList.tsx`) is the one
+  exception that *is* theme-aware, but via a different mechanism than the
+  rest of this guide: it uses explicit Tailwind `dark:` variant classes
+  (`border-amber-200 dark:border-amber-500/20`, etc.), not `--status-*` /
+  `--ring` custom properties.
+
+If you're customizing milestones' theme and rows or the skeleton don't
+change color, this is why — they're intentionally out of scope for the
+token system as it exists today, not a bug in this guide's instructions.
+Bringing them onto the token system (or adding `dark:` variants, matching
+the due-soon banner's approach) would be a separate, larger change.
+
+## See also
+
+- [`docs/preferences.md`](../preferences.md) — the `PreferencesProvider`
+  theme contract this guide builds on (persistence, hydration, `system`
+  resolution)
+- [`StatusBadge.md`](./StatusBadge.md) — full `StatusBadge` component
+  reference, including the icon+label-not-color-alone a11y contract
+- [`Accessibility.md`](./Accessibility.md) — the `--status-*` contrast
+  audit (a11y/theming-27)
+- [`MilestonesList.md`](./MilestonesList.md) /
+  [`MilestoneRow.md`](./MilestoneRow.md) — accessibility contracts for the
+  components mentioned above


### PR DESCRIPTION
Closes #1011

## Summary

Adds `docs/components/MilestonesTheming.md`, documenting exactly which theme tokens milestones components consume, their current light/dark values, how to customize them, and — accurately, per this issue's "Keep accurate to the current tokens" requirement — which parts of milestones are **not** tokenized today, so the guide doesn't overstate how theme-aware the feature currently is.

## What I verified before writing anything

I grepped every milestones-related file (`src/app/milestones/`, `src/components/milestones/`, `MilestonesList.tsx`, `MilestonesListSkeleton.tsx`, `StatusBadge.tsx`) for `var(--` usage. Only two token surfaces are actually consumed:

- `--ring` — `MilestonesList`'s scrollable region focus ring.
- `--status-success-bg/-foreground`, `--status-info-bg/-foreground`, `--status-error-bg/-foreground`, `--status-warning-bg/-foreground` — via `StatusBadge` (shared with `ContractSummary`), one pair per milestone status.

I cross-checked every value in the guide's token table character-for-character against `src/app/globals.css`'s `:root` and `[data-theme='dark']` blocks.

## A genuine limitation I found and documented rather than glossing over

Row backgrounds/borders in `MilestoneRow.tsx` (`border-slate-200 bg-slate-50` unselected, `border-indigo-300 bg-indigo-50` selected) and all of `MilestonesListSkeleton.tsx` are **hardcoded Tailwind classes with no `dark:` variant** — they don't change with the active theme at all. By contrast, the due-soon reminder banner in `MilestonesList.tsx` *does* adapt to dark mode, but via explicit Tailwind `dark:` variant classes, not the `--status-*`/`--ring` custom-property system. The guide calls this out explicitly under "What is *not* tokenized" so a reader customizing the theme isn't confused when rows/skeleton don't change.

## Contents

- How theming reaches milestones (`PreferencesProvider` → `data-theme` attribute → `globals.css` token blocks), cross-referencing `docs/preferences.md`.
- Full token table: which milestones component consumes which token, and where.
- Current light/dark values for every token, read directly from `globals.css`.
- How to customize (edit both theme blocks together; re-check the two contrast checks from the existing audit).
- The tokenized vs. hardcoded distinction described above.
- Cross-references to `StatusBadge.md`, `Accessibility.md` (the `a11y/theming-27` contrast audit, linked with the correct GitHub-generated anchor slug, verified against the actual heading), `MilestonesList.md`, `MilestoneRow.md`.

Linked from `docs/README.md`'s Components table, next to the existing `MilestonesUsageGuide.md` entry.

## Verification

Documentation-only change (no `.tsx`/`.ts`/`.css` files touched). `npx eslint` on both files — no errors (markdown isn't covered by the eslint config, expected). `npm run build` not independently re-verified for this PR; `main` currently fails to build for a pre-existing, unrelated reason (duplicate imports in `src/app/reputation/page.tsx` — see my PR for #1009 in this repo for full disclosure), and this PR touches no source files that could be implicated.
