### PR TITLE
feat(wallet): add keyboard shortcuts

### DIFF
--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -11,6 +11,8 @@ A comprehensive reference of keyboard shortcuts, focus-trap behaviours, and scre
 | `Ctrl/Cmd + K` | Open / close command palette | `CommandPalette` (`src/components/CommandPalette.tsx:168`) |
 | `Ctrl/Cmd + Enter` | Submit create-stream form | `CreateStreamForm` (`src/components/CreateStreamForm.tsx:212`) |
 | `Ctrl + Space` | Toggle contract row selection | `ContractRowItem` (`src/components/contracts/ContractRowItem.tsx:53`) |
+| `Ctrl/Cmd + Shift + A` | Select all wallet items (toggle) | `WalletPage` (`src/app/wallet/page.tsx`) |
+| `Ctrl/Cmd + Shift + E` | Export selected wallet items | `WalletPage` (`src/app/wallet/page.tsx`) |
 | `Escape` | Clear bulk selection (wallet) | `WalletBulkToolbar` (`src/components/wallet/WalletBulkToolbar.tsx:37`) |
 | `Escape` | Clear bulk selection (milestones) | `BulkActionToolbar` (`src/components/milestones/BulkActionToolbar.tsx:59`) |
 | `Escape` | Cancel stream creation | `CreateStreamForm` (`src/components/CreateStreamForm.tsx:216`) |

--- a/src/app/wallet/__tests__/WalletKeyboardShortcuts.test.tsx
+++ b/src/app/wallet/__tests__/WalletKeyboardShortcuts.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import WalletPage from '../page';
+import { listWalletItems, deleteWalletItems } from '@/lib/repository';
+import { ToastProvider } from '@/components/toast/toast-provider';
+import { PreferencesProvider } from '@/lib/preferences';
+import type { WalletItem } from '@/types/domain';
+
+jest.mock('@/lib/repository', () => ({
+  listWalletItems: jest.fn(),
+  saveWalletItem: jest.fn(),
+  updateWalletItem: jest.fn(),
+  deleteWalletItems: jest.fn(),
+}));
+
+const mockListWalletItems = jest.mocked(listWalletItems);
+const mockDeleteWalletItems = jest.mocked(deleteWalletItems);
+
+const ITEMS: WalletItem[] = [
+  {
+    id: 'w-1',
+    name: 'Stellar Lumens (XLM)',
+    type: 'Native Asset',
+    balance: 12500,
+    currency: 'XLM',
+    status: 'Active',
+    createdAt: '2026-01-15',
+  },
+  {
+    id: 'w-2',
+    name: 'USD Coin (USDC)',
+    type: 'Stablecoin',
+    balance: 3200,
+    currency: 'USDC',
+    status: 'Pending',
+    createdAt: '2026-02-01',
+  },
+];
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(
+    <PreferencesProvider>
+      <ToastProvider>{ui}</ToastProvider>
+    </PreferencesProvider>
+  );
+};
+
+describe('WalletPage keyboard shortcuts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListWalletItems.mockReturnValue(ITEMS);
+    mockDeleteWalletItems.mockReturnValue(true);
+  });
+
+  it('renders discoverable hints for the shortcuts when items exist', () => {
+    renderWithProviders(<WalletPage />);
+    expect(screen.getByLabelText('Ctrl+Shift+A — select all')).toBeInTheDocument();
+    expect(screen.getByLabelText('Ctrl+Shift+E — export selected')).toBeInTheDocument();
+  });
+
+  it('Ctrl+Shift+A selects all wallet items', () => {
+    renderWithProviders(<WalletPage />);
+
+    fireEvent.keyDown(document, { key: 'a', ctrlKey: true, shiftKey: true });
+
+    expect(screen.getByTestId('select-all-checkbox')).toBeChecked();
+  });
+
+  it('Ctrl+Shift+A again clears the selection (toggle)', () => {
+    renderWithProviders(<WalletPage />);
+
+    fireEvent.keyDown(document, { key: 'a', ctrlKey: true, shiftKey: true });
+    expect(screen.getByTestId('select-all-checkbox')).toBeChecked();
+
+    fireEvent.keyDown(document, { key: 'a', ctrlKey: true, shiftKey: true });
+    expect(screen.getByTestId('select-all-checkbox')).not.toBeChecked();
+  });
+
+  it('plain Ctrl+A (no Shift) does not trigger select-all — avoids clashing with browser text selection', () => {
+    renderWithProviders(<WalletPage />);
+
+    fireEvent.keyDown(document, { key: 'a', ctrlKey: true, shiftKey: false });
+
+    expect(screen.getByTestId('select-all-checkbox')).not.toBeChecked();
+  });
+
+  it('Ctrl+Shift+E exports selected items', () => {
+    renderWithProviders(<WalletPage />);
+
+    fireEvent.click(screen.getByTestId('select-all-checkbox'));
+    fireEvent.keyDown(document, { key: 'e', ctrlKey: true, shiftKey: true });
+
+    expect(screen.getByText('Export successful')).toBeInTheDocument();
+  });
+
+  it('shortcuts are ignored while an inline edit input has focus', () => {
+    renderWithProviders(<WalletPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /edit stellar lumens/i }));
+    const nameInput = screen.getByDisplayValue('Stellar Lumens (XLM)');
+    nameInput.focus();
+
+    fireEvent.keyDown(nameInput, { key: 'a', ctrlKey: true, shiftKey: true });
+
+    expect(screen.getByTestId('select-all-checkbox')).not.toBeChecked();
+  });
+
+  it('Meta+Shift+A (Mac) also selects all', () => {
+    renderWithProviders(<WalletPage />);
+
+    fireEvent.keyDown(document, { key: 'a', metaKey: true, shiftKey: true });
+
+    expect(screen.getByTestId('select-all-checkbox')).toBeChecked();
+  });
+});

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -5,10 +5,18 @@ import EmptyState from '../../components/EmptyState';
 import { ConfirmDialog } from '../../components/ConfirmDialog';
 import { WalletBulkToolbar } from '../../components/wallet/WalletBulkToolbar';
 import { WalletItemList } from '../../components/wallet/WalletItemList';
+import { KbdHint } from '@/components/KbdHint';
 import { listWalletItems, saveWalletItem, updateWalletItem, deleteWalletItems } from '@/lib/repository';
 import { useToast } from '@/components/toast/toast-provider';
 import type { WalletItem } from '@/types/domain';
 import { SAMPLE_WALLET_ITEMS } from './constants';
+
+/** True when `target` is a text-entry element that keyboard shortcuts must not fire over. */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable;
+}
 
 export default function WalletPage() {
   const [items, setItems] = useState<WalletItem[]>([]);
@@ -158,6 +166,31 @@ export default function WalletPage() {
     setEditingId(null);
   }, []);
 
+  // Global wallet shortcuts: Ctrl/Cmd+Shift+A (select all) and
+  // Ctrl/Cmd+Shift+E (export selected). Shift is included specifically to
+  // avoid clashing with the browser's own Ctrl/Cmd+A (select-all-text) and
+  // Ctrl/Cmd+E (address-bar search in some browsers). Ignored while a text
+  // input, textarea, or contenteditable element (e.g. inline item editing)
+  // has focus so normal typing/selecting text is never intercepted.
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || !event.shiftKey) return;
+      if (isTypingTarget(event.target)) return;
+
+      const key = event.key.toLowerCase();
+      if (key === 'a') {
+        event.preventDefault();
+        handleToggleSelectAll();
+      } else if (key === 'e') {
+        event.preventDefault();
+        handleExportSelected();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleToggleSelectAll, handleExportSelected]);
+
   const deleteModalTitle = useMemo(() => {
     const count = targetDeleteIds.length;
     return count === 1 ? 'Delete wallet item?' : `Delete ${count} wallet items?`;
@@ -181,6 +214,12 @@ export default function WalletPage() {
             Manage your connected assets, security credentials, and escrow keys.
           </p>
         </div>
+        {items.length > 0 && (
+          <div className="flex flex-wrap items-center gap-3">
+            <KbdHint keys={['Ctrl', 'Shift', 'A']} label="select all" />
+            <KbdHint keys={['Ctrl', 'Shift', 'E']} label="export selected" />
+          </div>
+        )}
       </div>
 
       {items.length > 0 && (


### PR DESCRIPTION
## Summary
Adds two discoverable, global keyboard shortcuts to the wallet page's primary bulk actions:

- **`Ctrl/Cmd + Shift + A`** — toggle select-all wallet items
- **`Ctrl/Cmd + Shift + E`** — export the currently selected items

`Shift` is included specifically to avoid clashing with the browser's native `Ctrl/Cmd+A` (select-all-text) and `Ctrl/Cmd+E` (address-bar search in some browsers) — the issue explicitly calls out avoiding native-key clashes. Both fire from a single document-level `keydown` listener, guarded by `isTypingTarget()` so they never intercept typing inside an `<input>`, `<textarea>`, or `contenteditable` element (e.g. the wallet item's inline-edit name field) — satisfying "respect input focus."

Discoverability: reuses the existing `KbdHint` component (already used by `CommandPalette`/`CreateStreamForm`) to render the two shortcut hints next to the page header, visible whenever there are wallet items to act on.

Documented in `docs/keyboard.md`'s existing "Global shortcuts" table.

## Tests
New `WalletKeyboardShortcuts.test.tsx`: hints render, `Ctrl+Shift+A` selects all and toggles off on a second press, plain `Ctrl+A` (no Shift) is correctly ignored, `Ctrl+Shift+E` triggers export, shortcuts are ignored while an inline-edit input has focus, and the Mac `Meta+Shift+A` variant also works. 7/7 pass. Full `src/app/wallet` suite (46 tests across 3 files) still passes — no regressions.

`npx eslint src/app/wallet/page.tsx src/app/wallet/__tests__/WalletKeyboardShortcuts.test.tsx`: clean.

Closes #1017