### PR TITLE
test(reputation): add keyboard navigation tests

### DIFF
--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -112,6 +112,17 @@ Source: `src/components/CommandPalette.tsx:185`.
 |----------|-----------|-----------|
 | `Enter` | Open / navigate to contract row details | `ContractRowItem` (`src/components/contracts/ContractRowItem.tsx:78`) |
 
+### Reputation history
+
+All controls are standard focusable elements (native tab order, no custom
+arrow-key handling): type filter → sort direction → select-all checkbox →
+toolbar (Export selected → Delete selected → Clear selection, each
+`disabled` — and so skipped in tab order — until at least one item is
+selected) → per-item checkbox → that item's copy-id button, repeated per
+row → "Load more" (when more history exists beyond the current page).
+Checkboxes and buttons activate on `Space`/`Enter` per native semantics.
+Source: `src/components/ReputationProfile.tsx`.
+
 ---
 
 ## Screen-reader announcement model

--- a/src/components/ReputationProfile.tsx
+++ b/src/components/ReputationProfile.tsx
@@ -2,9 +2,6 @@ import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { execCommandFallback } from '@/lib/clipboardFallback';
 import { useOptimisticReputationMutation } from '@/hooks/useOptimisticReputationMutation';
 import { formatRelativeTime, toISOString } from '@/lib/formatRelativeTime';
-import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
-import { execCommandFallback } from '@/lib/clipboardFallback';
-import { useOptimisticReputationMutation } from '@/hooks/useOptimisticReputationMutation';
 
 export type ReputationEvent = {
   id: string;
@@ -80,6 +77,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ConfirmDialog } from './ConfirmDialog';
 import { useToast } from './toast/toast-provider';
+import { useFormAnnouncer } from '@/hooks/useFormAnnouncer';
 
 import {
   DEFAULT_DIR,
@@ -273,7 +271,6 @@ export default function ReputationProfile({
   const availableTypes = useMemo(() => getAvailableHistoryTypes(history), [history]);
   const typeOptions = useMemo(() => [DEFAULT_TYPE, ...availableTypes], [availableTypes]);
 
-  const syncUrl = true;
   const [selectedType, setSelectedType] = useState<string>(() =>
     syncUrl ? getValidType(searchParams.get('type'), availableTypes) : DEFAULT_TYPE
   );

--- a/src/components/__tests__/ReputationKeyboardNavigation.test.tsx
+++ b/src/components/__tests__/ReputationKeyboardNavigation.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * ReputationKeyboardNavigation.test.tsx
+ *
+ * Keyboard-operability coverage for ReputationProfile's interactive
+ * controls (select-all checkbox, per-item checkboxes, copy-id buttons,
+ * toolbar actions, "Load more"): tab order and Enter/Space activation.
+ * Mirrors the existing wallet keyboard test's approach
+ * (`src/components/wallet/__tests__/WalletItemListKeyboard.test.tsx`).
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ReputationProfile, {
+  ReputationEvent,
+  ReputationProfileProps,
+} from '../ReputationProfile';
+
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+
+jest.mock('../toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+    dismissToast: jest.fn(),
+    toasts: [],
+  }),
+}));
+
+const HISTORY: ReputationEvent[] = [
+  { id: 'ev-1', type: 'Verification', summary: 'Completed identity verification', date: '2026-04-24' },
+  { id: 'ev-2', type: 'On-chain review', summary: 'Received positive trust signal', date: '2026-04-23' },
+];
+
+function renderProfile(props: ReputationProfileProps) {
+  return render(<ReputationProfile syncUrl={false} {...props} />);
+}
+
+describe('ReputationProfile — keyboard operation', () => {
+  it('tabs from the type filter through the sort control to select-all', async () => {
+    const user = userEvent.setup();
+    renderProfile({ name: 'Nav User', score: 70, history: HISTORY });
+
+    const typeFilter = screen.getByTestId('reputation-type-filter');
+    const sortDir = screen.getByTestId('reputation-sort-dir');
+    const selectAll = screen.getByLabelText('Select all reputation items');
+
+    typeFilter.focus();
+    expect(typeFilter).toHaveFocus();
+
+    await user.tab();
+    expect(sortDir).toHaveFocus();
+
+    await user.tab();
+    expect(selectAll).toHaveFocus();
+  });
+
+  it('tabs through the toolbar buttons in DOM order once they are enabled by a selection', async () => {
+    const user = userEvent.setup();
+    renderProfile({ name: 'Toolbar Nav User', score: 70, history: HISTORY });
+
+    // Export/Delete/Clear are disabled (and so skipped in tab order) until
+    // at least one item is selected.
+    const selectAll = screen.getByLabelText(
+      'Select all reputation items'
+    ) as HTMLInputElement;
+    await user.click(selectAll);
+    expect(selectAll.checked).toBe(true);
+
+    selectAll.focus();
+
+    await user.tab();
+    expect(screen.getByLabelText('Export selected reputation items')).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByLabelText('Delete selected reputation items')).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByLabelText('Clear selected reputation items; clear selection')).toHaveFocus();
+  });
+
+  it('tabs from a history item checkbox to its copy-id button', async () => {
+    const user = userEvent.setup();
+    renderProfile({ name: 'Row Nav User', score: 70, history: HISTORY });
+
+    screen.getByLabelText(/Select reputation item Verification/i).focus();
+
+    await user.tab();
+    expect(screen.getByTestId('copy-reputation-id-btn-ev-1')).toHaveFocus();
+  });
+
+  it('toggles a history item checkbox via the keyboard (Space)', async () => {
+    const user = userEvent.setup();
+    renderProfile({ name: 'Space User', score: 70, history: HISTORY });
+
+    const checkbox = screen.getByLabelText(
+      /Select reputation item Verification/i
+    ) as HTMLInputElement;
+    checkbox.focus();
+    expect(checkbox.checked).toBe(false);
+
+    await user.keyboard(' ');
+    expect(checkbox.checked).toBe(true);
+
+    await user.keyboard(' ');
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('activates "Export selected" via the keyboard (Enter) once an item is selected', async () => {
+    const user = userEvent.setup();
+    mockShowSuccess.mockClear();
+    renderProfile({ name: 'Enter User', score: 70, history: HISTORY });
+
+    await user.click(screen.getByLabelText(/Select reputation item Verification/i));
+    screen.getByLabelText('Export selected reputation items').focus();
+    await user.keyboard('{Enter}');
+
+    expect(mockShowSuccess).toHaveBeenCalled();
+  });
+
+  it('export/delete/clear toolbar buttons are keyboard-disabled (not tab-reachable via activation) until a selection exists', () => {
+    renderProfile({ name: 'Disabled User', score: 70, history: HISTORY });
+
+    expect(screen.getByLabelText('Export selected reputation items')).toBeDisabled();
+    expect(screen.getByLabelText('Delete selected reputation items')).toBeDisabled();
+    expect(screen.getByLabelText('Clear selected reputation items; clear selection')).toBeDisabled();
+  });
+
+  it('activates "Load more" via the keyboard (Enter) when more history exists beyond the first page', async () => {
+    const user = userEvent.setup();
+    const manyEvents: ReputationEvent[] = Array.from({ length: 7 }, (_, i) => ({
+      id: `ev-${i + 1}`,
+      type: 'Verification',
+      summary: `Event number ${i + 1}`,
+      date: '2026-04-24',
+    }));
+    renderProfile({ name: 'Load More User', score: 70, history: manyEvents });
+
+    const loadMore = screen.getByRole('button', { name: /Showing 5 of 7 events\. Load more/i });
+    loadMore.focus();
+    expect(screen.queryByText('Event number 6')).not.toBeInTheDocument();
+
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByText('Event number 6')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
No test in the repo verified that `ReputationProfile`'s interactive controls (type filter, sort direction, select-all, per-item checkboxes, copy-id buttons, toolbar actions, "Load more") are actually keyboard-operable — `ReputationProfilePagination.test.tsx` covers pagination logic and `page.interaction.test.tsx` covers error-boundary recovery, but neither exercises tab order or Enter/Space activation. Adds `ReputationKeyboardNavigation.test.tsx`, mirroring the existing `WalletItemListKeyboard.test.tsx` approach: tab order across the filter/sort/select-all/toolbar chain, tab order from a row's checkbox to its copy button, checkbox toggling via Space, toolbar Export activation via Enter, toolbar buttons correctly excluded from tab order while disabled (no selection), and "Load more" activation via Enter. Documents the tab-order contract in `docs/keyboard.md`'s "List / row navigation" section. 7/7 pass.

## Same pre-existing blocking bugs as #1068 (overlapping fix)
This PR's base commit has the same `ReputationProfile.tsx` breakage described in #1068 — duplicated import block, a stray `const syncUrl = true` shadowing/hardcoding the prop, and a missing `useFormAnnouncer` import — all of which block every test in the file, including these new ones, from even running. Rather than stack this branch on #1068 (which would make this PR's diff include all of that PR's unrelated changes), I re-applied the same three minimal fixes independently here. **These two PRs overlap on those three lines only** — whichever merges first, the other will show a trivial conflict there that resolves to the same result; no need to merge both.

## Tests
`npx jest src/components/ReputationProfile.test.tsx src/components/__tests__/ReputationKeyboardNavigation.test.tsx`: 7/7 new tests pass; existing suite is 112/117 (same 5 pre-existing, unrelated `a11y/reputation-31` CSS-token failures noted in #1068). `npx eslint` on touched files: only the same pre-existing errors noted in #1068 (unused vars, one `selectedEvents is not defined`), none on lines this PR added.

Closes #1014