### PR TITLE
feat(reputation): add keyboard shortcuts

### DIFF
--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -76,6 +76,16 @@ The `BulkActionToolbar` implements the [WAI-ARIA toolbar pattern](https://www.w3
 
 Source: `src/components/milestones/BulkActionToolbar.tsx:51`.
 
+`ReputationProfile`'s selection toolbar (Export selected / Delete selected /
+Clear selection) implements the same arrow-key/Home/End/Escape pattern
+inline, with one deliberate difference: Escape additionally bails out when
+the event target is a form control (`input` / `textarea` / `select` /
+`contenteditable`) anywhere on the page, so it never fires while the user is
+typing or operating the history type/sort dropdowns — the
+`BulkActionToolbar` precedent above does not guard Escape this way. A
+`KbdHint` (`Esc — to clear selection`) becomes visible next to the toolbar
+once a selection is active. Source: `src/components/ReputationProfile.tsx`.
+
 ---
 
 ## Radio group arrow-key navigation

--- a/src/components/ReputationProfile.test.tsx
+++ b/src/components/ReputationProfile.test.tsx
@@ -1172,3 +1172,142 @@ describe('ReputationProfile – last-updated timestamp (issue #62)', () => {
     await assertNoA11yViolations(container);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Keyboard shortcuts for the selection toolbar (issue: keyboard shortcuts
+// for reputation's primary actions)
+// ---------------------------------------------------------------------------
+
+describe('ReputationProfile – keyboard shortcuts for the selection toolbar', () => {
+  const FULL_PROPS: ReputationProfileProps = {
+    name: 'Verified User',
+    score: 88,
+    history: HISTORY_EVENTS,
+  };
+
+  function selectFirstTwo() {
+    fireEvent.click(
+      screen.getByRole('checkbox', {
+        name: `Select reputation item ${HISTORY_EVENTS[0].type}: ${HISTORY_EVENTS[0].summary}`,
+      })
+    );
+    fireEvent.click(
+      screen.getByRole('checkbox', {
+        name: `Select reputation item ${HISTORY_EVENTS[1].type}: ${HISTORY_EVENTS[1].summary}`,
+      })
+    );
+  }
+
+  function exportButton() {
+    return screen.getByRole('button', { name: /export selected reputation items/i });
+  }
+  function deleteButton() {
+    return screen.getByRole('button', { name: /delete selected reputation items/i });
+  }
+  function clearButton() {
+    return screen.getByRole('button', { name: /clear selected reputation items/i });
+  }
+
+  it('Escape clears the selection and disables the toolbar buttons', () => {
+    renderProfile(FULL_PROPS);
+    selectFirstTwo();
+    expect(exportButton()).toBeEnabled();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(exportButton()).toBeDisabled();
+    expect(deleteButton()).toBeDisabled();
+    expect(clearButton()).toBeDisabled();
+  });
+
+  it('does nothing when Escape is pressed with no active selection', () => {
+    renderProfile(FULL_PROPS);
+    // No selection made; toolbar buttons already disabled — Escape should
+    // be a harmless no-op rather than throwing or doing anything odd.
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(exportButton()).toBeDisabled();
+  });
+
+  // Keydown is fired on the currently-focused element (not `document`) so
+  // `event.target` matches what a real, bubbled browser event would carry —
+  // firing directly on `document` would set target=document, which the
+  // isInsideToolbar check would (correctly) treat as outside the toolbar.
+
+  it('ArrowRight moves focus to the next toolbar button and wraps around', () => {
+    renderProfile(FULL_PROPS);
+    selectFirstTwo();
+
+    exportButton().focus();
+    fireEvent.keyDown(exportButton(), { key: 'ArrowRight' });
+    expect(deleteButton()).toHaveFocus();
+
+    fireEvent.keyDown(deleteButton(), { key: 'ArrowRight' });
+    expect(clearButton()).toHaveFocus();
+
+    fireEvent.keyDown(clearButton(), { key: 'ArrowRight' });
+    expect(exportButton()).toHaveFocus();
+  });
+
+  it('ArrowLeft moves focus to the previous toolbar button and wraps around', () => {
+    renderProfile(FULL_PROPS);
+    selectFirstTwo();
+
+    exportButton().focus();
+    fireEvent.keyDown(exportButton(), { key: 'ArrowLeft' });
+    expect(clearButton()).toHaveFocus();
+  });
+
+  it('Home and End jump to the first and last toolbar button', () => {
+    renderProfile(FULL_PROPS);
+    selectFirstTwo();
+
+    deleteButton().focus();
+    fireEvent.keyDown(deleteButton(), { key: 'End' });
+    expect(clearButton()).toHaveFocus();
+
+    fireEvent.keyDown(clearButton(), { key: 'Home' });
+    expect(exportButton()).toHaveFocus();
+  });
+
+  it('arrow keys do nothing when focus is outside the toolbar', () => {
+    renderProfile(FULL_PROPS);
+    selectFirstTwo();
+
+    const selectAll = screen.getByRole('checkbox', { name: 'Select all reputation items' });
+    selectAll.focus();
+    fireEvent.keyDown(selectAll, { key: 'ArrowRight' });
+
+    expect(selectAll).toHaveFocus();
+  });
+
+  it('does not fire Escape while a select control has focus (respects input focus)', () => {
+    renderProfile(FULL_PROPS);
+    selectFirstTwo();
+
+    const sortSelect = screen.getByTestId('reputation-sort-dir');
+    sortSelect.focus();
+    fireEvent.keyDown(sortSelect, { key: 'Escape' });
+
+    // Selection must be untouched — the toolbar is still enabled.
+    expect(exportButton()).toBeEnabled();
+  });
+
+  it('shows a discoverable Escape hint only once a selection is active', () => {
+    renderProfile(FULL_PROPS);
+    expect(screen.queryByText(/to clear selection/i)).not.toBeInTheDocument();
+
+    selectFirstTwo();
+    expect(screen.getByText(/to clear selection/i)).toBeInTheDocument();
+  });
+
+  it('removes the global keydown listener on unmount', () => {
+    const { unmount } = renderProfile(FULL_PROPS);
+    selectFirstTwo();
+    const removeSpy = jest.spyOn(document, 'removeEventListener');
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+    removeSpy.mockRestore();
+  });
+});

--- a/src/components/ReputationProfile.tsx
+++ b/src/components/ReputationProfile.tsx
@@ -2,9 +2,6 @@ import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { execCommandFallback } from '@/lib/clipboardFallback';
 import { useOptimisticReputationMutation } from '@/hooks/useOptimisticReputationMutation';
 import { formatRelativeTime, toISOString } from '@/lib/formatRelativeTime';
-import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
-import { execCommandFallback } from '@/lib/clipboardFallback';
-import { useOptimisticReputationMutation } from '@/hooks/useOptimisticReputationMutation';
 
 export type ReputationEvent = {
   id: string;
@@ -76,10 +73,12 @@ export function resolveReputationLevel(score: number, maxScore: number): string 
 const reputationSummary =
   'Reputation represents verified trust signals and activity history, not sensitive personal metadata. Privacy-friendly defaults keep your profile safe.';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ConfirmDialog } from './ConfirmDialog';
 import { useToast } from './toast/toast-provider';
+import { useFormAnnouncer } from '@/hooks/useFormAnnouncer';
+import { KbdHint } from './KbdHint';
 
 import {
   DEFAULT_DIR,
@@ -267,13 +266,83 @@ export default function ReputationProfile({
     setConfirmOpen(false);
   };
 
+  // ---------------------------------------------------------------------------
+  // Keyboard shortcuts for the selection toolbar (Export / Delete / Clear).
+  //
+  // Mirrors the WAI-ARIA toolbar pattern already used by BulkActionToolbar
+  // (src/components/milestones/BulkActionToolbar.tsx) for the same shape of
+  // bulk-action toolbar: arrow keys cycle focus between toolbar buttons,
+  // Escape clears the selection. Arrow-key handling is scoped to only fire
+  // when focus is already inside the toolbar, so it can never hijack the
+  // history type/sort <select> elements' own native arrow-key behaviour.
+  // Both handlers additionally bail out whenever the event target is a
+  // form control (input/textarea/select) anywhere on the page, so the
+  // shortcuts never fire while a user is typing or operating another
+  // control — this repo's existing BulkActionToolbar precedent does not
+  // guard Escape this way; this implementation intentionally does.
+  // ---------------------------------------------------------------------------
+
+  const toolbarRef = useRef<HTMLDivElement>(null);
+
+  const getFocusableInToolbar = useCallback((): HTMLElement[] => {
+    const toolbar = toolbarRef.current;
+    if (!toolbar) return [];
+    return Array.from(
+      toolbar.querySelectorAll<HTMLElement>('button:not([disabled])'),
+    );
+  }, []);
+
+  useEffect(() => {
+    if (selectedCount === 0) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      const isFormControl =
+        tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target?.isContentEditable;
+      if (isFormControl) return;
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        clearSelection();
+        return;
+      }
+
+      const toolbar = toolbarRef.current;
+      const isInsideToolbar = toolbar && target && toolbar.contains(target);
+      if (!isInsideToolbar) return;
+
+      const focusable = getFocusableInToolbar();
+      if (focusable.length === 0) return;
+
+      const currentIndex = focusable.indexOf(document.activeElement as HTMLElement);
+      if (currentIndex === -1) return;
+
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        event.preventDefault();
+        focusable[(currentIndex + 1) % focusable.length].focus();
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        focusable[(currentIndex - 1 + focusable.length) % focusable.length].focus();
+      } else if (event.key === 'Home') {
+        event.preventDefault();
+        focusable[0].focus();
+      } else if (event.key === 'End') {
+        event.preventDefault();
+        focusable[focusable.length - 1].focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [selectedCount, getFocusableInToolbar, clearSelection]);
+
   const searchParams = useSearchParams();
   const router = useRouter();
 
   const availableTypes = useMemo(() => getAvailableHistoryTypes(history), [history]);
   const typeOptions = useMemo(() => [DEFAULT_TYPE, ...availableTypes], [availableTypes]);
 
-  const syncUrl = true;
   const [selectedType, setSelectedType] = useState<string>(() =>
     syncUrl ? getValidType(searchParams.get('type'), availableTypes) : DEFAULT_TYPE
   );
@@ -577,9 +646,17 @@ export default function ReputationProfile({
                 />
                 Select all
               </label>
+              {selectedCount > 0 && (
+                <KbdHint
+                  keys={['Esc']}
+                  label="to clear selection"
+                  className="hidden sm:inline-flex"
+                />
+              )}
               <div
+                ref={toolbarRef}
                 role="toolbar"
-                aria-label="Reputation history actions"
+                aria-label="Reputation history actions. Use arrow keys to move between actions, Escape to clear the selection."
                 className="flex flex-wrap gap-2"
               >
                 <button


### PR DESCRIPTION
Closes #1012

## Summary

Adds keyboard shortcuts to reputation's selection toolbar (Export selected / Delete selected / Clear selection), mirroring the WAI-ARIA toolbar pattern this repo already uses for the identically-shaped milestones bulk-action toolbar (`BulkActionToolbar`, documented in `docs/keyboard.md`):

- **Arrow keys** (`→`/`↓`, `←`/`↑`) cycle focus between the three toolbar buttons, wrapping around at each end.
- **Home** / **End** jump to the first/last toolbar button.
- **Escape** clears the selection (works from anywhere on the page, not just inside the toolbar — matching the milestones precedent).
- A `KbdHint` (`Esc — to clear selection`, using the existing, previously-unused `KbdHint` component) becomes visible next to the toolbar once a selection is active — the "discoverable hint" this issue asks for.

**Respecting input focus** (explicit issue requirement): both handlers bail out immediately when the event target is a form control (`input`/`textarea`/`select`/`contenteditable`) anywhere on the page. This is stricter than the existing `BulkActionToolbar` precedent (whose Escape handler doesn't guard this way) — added deliberately so the shortcuts can never fire while typing, and so they can never hijack the existing history type/sort `<select>` dropdowns' own native arrow-key behavior. Arrow-key handling is additionally scoped to only act when focus is already inside the toolbar (via a new `toolbarRef`).

No shortcut clashes with browser/native keys — arrow keys and Escape only act while a toolbar button already has focus or (for Escape) a selection is active, and the form-control guard above prevents any interference with page-native controls.

## Pre-existing corruption found in this exact file — full disclosure

Before I could write or test anything here, I discovered `ReputationProfile.tsx` **could not even be parsed** by Jest/Babel — a hard `SyntaxError`, not just a failing test. I root-caused and fixed only what was strictly necessary to make my own new code parseable and testable; I did **not** attempt to fix anything beyond that, since it's out of scope for a keyboard-shortcuts issue and some of it requires judgment calls about original intent I'm not positioned to make correctly.

**Fixed (both are exact, unambiguous, mechanical duplicate-removal — zero judgment calls):**
1. **Duplicate import block** at the top of the file (4 imports repeated verbatim). This is the exact same "duplicate content from an unrebased merge" pattern I've now encountered in several repos this campaign; `git log` shows the two most recent commits touching this file (`d99d9b7`, `8328272`) are unrelated feature PRs, consistent with a bad merge silently duplicating a shared import block.
2. **Duplicate `syncUrl` declaration**: `const syncUrl = true;` was redeclaring the already-destructured `syncUrl` prop (which itself defaults to `true`), which is both a `SyntaxError` (can't redeclare a binding in the same scope) *and* a functional bug — it silently forced `syncUrl` to always be `true`, ignoring whatever the caller actually passed. Removing the redundant `const` fixes both.
3. **Missing `useFormAnnouncer` import**: the hook is called (`useFormAnnouncer({...})` for `politeMessage`/`assertiveMessage`) but was never imported anywhere in the file — a `ReferenceError` at render time, previously masked by the parse error above. Added the import (`@/hooks/useFormAnnouncer`, matching how it's imported everywhere else per `docs/keyboard.md`).

**Found but deliberately NOT fixed (disclosed, out of scope):**
- `pageSize` prop is destructured but never actually used anywhere — pagination always uses the hardcoded `REPUTATION_PAGE_SIZE` constant regardless of what's passed. Causes 3 pre-existing failures in `ReputationProfilePagination.test.tsx`.
- `announce` (the actual announcer function from `useFormAnnouncer`) is destructured as `announce: _announceResult` and never called anywhere — `politeMessage`/`assertiveMessage` never update, so the aria-live announcer is currently non-functional. Causes 2 pre-existing failures in `ReputationProfile.test.tsx` (`confirms destructive bulk delete...`, `announces export results...`) whose assertions expect toast/announcer text that never renders.
- The reputation-score card uses hardcoded `border-slate-200`/`bg-slate-50`/`text-slate-500`/`text-slate-950` classes instead of the `--border`/`--surface`/`--muted-foreground`/`--foreground` CSS-variable tokens every other card on the page uses. Causes 3 pre-existing failures in the `a11y/reputation-31` describe block in `ReputationProfile.test.tsx`.
- Five functions (`toggleAll`, `handleExportSelected`, `handleDeleteSelected`, `toggleSelection`, `confirmDeleteSelected`) are defined but never called anywhere — dead code from what looks like an abandoned first draft of the same selection/toolbar feature, superseded by the inline `onClick` handlers actually wired into the JSX. `handleExportSelected` additionally references a `selectedEvents` variable that doesn't exist anywhere in the file (`no-undef`). These 9 lint errors (`npx eslint`) are all pre-existing, on lines I never touched.
- 14 stale snapshots across `page.snapshot.test.tsx` and `ReputationProfile.snapshot.test.tsx`. I initially ran `-u` to update them, then **reverted that** on inspection: the diff mixed a harmless React `useId()` format change (`:r0:` → `_r_0_`, a React/testing-library version artifact) together with the CSS-token regression described above. Updating the snapshot would have silently "locked in" that regression as the new expected baseline, which I didn't want to do under a keyboard-shortcuts PR. Left these snapshot tests failing/unmodified.

**Before/after, for scale**: on unmodified `main`, 8 of 9 reputation-related test suites fail to even parse (only 42 tests total can run, all from the one suite that doesn't transitively import this file). After my two necessary fixes: 302 of 324 tests pass; the remaining 22 failures are the pre-existing issues itemized above (14 snapshot + 5 announcer/CSS-token + 3 pageSize), none caused by this PR.

## My new tests

9 new tests in `src/components/ReputationProfile.test.tsx`, all passing:

- Escape clears the selection and disables the toolbar buttons
- Escape is a no-op with no active selection
- ArrowRight cycles focus forward through all three buttons and wraps around
- ArrowLeft cycles focus backward and wraps around
- Home/End jump to the first/last button
- Arrow keys do nothing when focus is outside the toolbar
- Escape does not fire while a `<select>` has focus (the input-focus-respecting requirement)
- The `KbdHint` only appears once a selection is active
- The global `keydown` listener is removed on unmount

(One implementation note for reviewers: these fire `keyDown` on the actually-focused element, not on `document` — firing directly on `document` sets `event.target = document`, which doesn't match how a real bubbled browser event behaves and would make the `isInsideToolbar` check always false.)

## Verification

```
PASS (new tests) — 9/9
src/components/ReputationProfile.test.tsx — 114/119 passing (5 pre-existing failures, see above)
```

`npx eslint` on my two changed `.tsx` files — 9 pre-existing errors (all on lines I didn't touch, see above), zero new ones introduced by my code. `npm run build` not independently verified; `main` currently fails to build for a separate, unrelated reason (`src/app/reputation/page.tsx` duplicate imports — a smaller instance of the same bug class, which I left alone since it's a different file outside my scope here — see my PR for #1009 in this repo for that disclosure).
