### PR TITLE
feat(milestones): add keyboard shortcuts

### DIFF
--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -13,6 +13,8 @@ A comprehensive reference of keyboard shortcuts, focus-trap behaviours, and scre
 | `Ctrl + Space` | Toggle contract row selection | `ContractRowItem` (`src/components/contracts/ContractRowItem.tsx:53`) |
 | `Ctrl/Cmd + Shift + A` | Select all wallet items (toggle) | `WalletPage` (`src/app/wallet/page.tsx`) |
 | `Ctrl/Cmd + Shift + E` | Export selected wallet items | `WalletPage` (`src/app/wallet/page.tsx`) |
+| `Ctrl/Cmd + Shift + N` | Add milestone | `MilestonesPage` (`src/hooks/useMilestonesKeyboardShortcuts.ts`) |
+| `Ctrl/Cmd + Shift + C` | Add milestones to calendar (.ics download) | `MilestonesPage` (`src/hooks/useMilestonesKeyboardShortcuts.ts`) |
 | `Escape` | Clear bulk selection (wallet) | `WalletBulkToolbar` (`src/components/wallet/WalletBulkToolbar.tsx:37`) |
 | `Escape` | Clear bulk selection (milestones) | `BulkActionToolbar` (`src/components/milestones/BulkActionToolbar.tsx:59`) |
 | `Escape` | Cancel stream creation | `CreateStreamForm` (`src/components/CreateStreamForm.tsx:216`) |

--- a/src/app/milestones/__tests__/MilestonesKeyboardShortcuts.test.tsx
+++ b/src/app/milestones/__tests__/MilestonesKeyboardShortcuts.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import MilestonesPage from '../page';
+import { listMilestones, saveMilestone } from '@/lib/repository';
+import { downloadMilestonesICS } from '@/lib/icsExport';
+import type { Milestone } from '@/types/domain';
+
+const mockSearchParams = {
+  get: jest.fn(() => null),
+  toString: jest.fn(() => ''),
+};
+const mockReplace = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ replace: mockReplace, push: jest.fn(), prefetch: jest.fn() }),
+}));
+
+jest.mock('@/lib/repository', () => ({
+  listMilestones: jest.fn(),
+  saveMilestone: jest.fn(),
+}));
+
+jest.mock('@/lib/icsExport', () => ({
+  downloadMilestonesICS: jest.fn(),
+}));
+
+const mockedListMilestones = jest.mocked(listMilestones);
+const mockedSaveMilestone = jest.mocked(saveMilestone);
+const mockedDownloadMilestonesICS = jest.mocked(downloadMilestonesICS);
+
+const persisted: Milestone[] = [
+  {
+    id: 'kb-1',
+    title: 'Keyboard Kickoff',
+    status: 'Pending',
+    payout: 1000,
+    currency: 'USD',
+    dueDate: '2026-07-25',
+  },
+];
+
+async function renderMilestonesPage() {
+  const result = render(<MilestonesPage />);
+  await act(async () => {});
+  return result;
+}
+
+beforeEach(() => {
+  mockedListMilestones.mockReturnValue(persisted);
+  mockedSaveMilestone.mockImplementation(() => {});
+  mockSearchParams.get.mockReturnValue(null);
+  mockSearchParams.toString.mockReturnValue('');
+  mockReplace.mockReset();
+  mockedDownloadMilestonesICS.mockReset();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('milestones keyboard shortcuts', () => {
+  it('renders discoverable hints for the shortcuts', async () => {
+    await renderMilestonesPage();
+
+    expect(screen.getByLabelText('Ctrl+Shift+N — add milestone')).toBeInTheDocument();
+    expect(screen.getByLabelText('Ctrl+Shift+C — add to calendar')).toBeInTheDocument();
+  });
+
+  it('Ctrl+Shift+C downloads the calendar file', async () => {
+    await renderMilestonesPage();
+
+    fireEvent.keyDown(document, { key: 'c', ctrlKey: true, shiftKey: true });
+
+    expect(mockedDownloadMilestonesICS).toHaveBeenCalledTimes(1);
+    expect(mockedDownloadMilestonesICS).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ id: 'kb-1' })]),
+    );
+  });
+
+  it('Meta+Shift+C (Mac) also downloads the calendar file', async () => {
+    await renderMilestonesPage();
+
+    fireEvent.keyDown(document, { key: 'c', metaKey: true, shiftKey: true });
+
+    expect(mockedDownloadMilestonesICS).toHaveBeenCalledTimes(1);
+  });
+
+  it('plain Ctrl+C (no Shift) does not trigger the shortcut — avoids clashing with copy', async () => {
+    await renderMilestonesPage();
+
+    fireEvent.keyDown(document, { key: 'c', ctrlKey: true, shiftKey: false });
+
+    expect(mockedDownloadMilestonesICS).not.toHaveBeenCalled();
+  });
+
+  it('is ignored while the sort control has focus', async () => {
+    await renderMilestonesPage();
+
+    const sortSelect = screen.getByLabelText(/sort milestones/i);
+    sortSelect.focus();
+
+    fireEvent.keyDown(sortSelect, { key: 'c', ctrlKey: true, shiftKey: true });
+
+    expect(mockedDownloadMilestonesICS).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/milestones/page.tsx
+++ b/src/app/milestones/page.tsx
@@ -20,6 +20,8 @@ import { getItem, setItem } from '@/lib/safeStorage';
 import { useToast } from '@/components/toast/toast-provider';
 import SafeBoundary from '@/components/SafeBoundary';
 import { downloadMilestonesICS } from '@/lib/icsExport';
+import { KbdHint } from '@/components/KbdHint';
+import { useMilestonesKeyboardShortcuts } from '@/hooks/useMilestonesKeyboardShortcuts';
 import { SAMPLE_MILESTONES, SAMPLE_DISMISSED_KEY } from './constants';
 import type { Milestone } from '@/types/domain';
 
@@ -165,6 +167,16 @@ const MilestonesContent: React.FC = () => {
     setShowForm(false);
   }, []);
 
+  const handleAddToCalendar = useCallback(() => {
+    downloadMilestonesICS(sortedMilestones);
+  }, [sortedMilestones]);
+
+  useMilestonesKeyboardShortcuts({
+    onAddMilestone: handleAddMilestone,
+    onAddToCalendar: handleAddToCalendar,
+    enabled: !showForm,
+  });
+
   const handleUpdateMilestone = useCallback(
     (id: string, patch: Partial<Milestone>): boolean => {
       try {
@@ -270,13 +282,17 @@ const MilestonesContent: React.FC = () => {
               </button>
               <button
                 type="button"
-                onClick={() => downloadMilestonesICS(sortedMilestones)}
+                onClick={handleAddToCalendar}
                 aria-label="Add to calendar"
                 className="flex-shrink-0 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
               >
                 <span aria-hidden="true" className="mr-1">📅</span>
                 Add to Calendar
               </button>
+              <div className="flex flex-wrap items-center gap-3">
+                <KbdHint keys={['Ctrl', 'Shift', 'N']} label="add milestone" />
+                <KbdHint keys={['Ctrl', 'Shift', 'C']} label="add to calendar" />
+              </div>
             </div>
           </div>
 

--- a/src/hooks/__tests__/useMilestonesKeyboardShortcuts.test.ts
+++ b/src/hooks/__tests__/useMilestonesKeyboardShortcuts.test.ts
@@ -1,0 +1,111 @@
+import { fireEvent, renderHook } from '@testing-library/react';
+import { useMilestonesKeyboardShortcuts } from '../useMilestonesKeyboardShortcuts';
+
+describe('useMilestonesKeyboardShortcuts', () => {
+  it('Ctrl+Shift+N triggers onAddMilestone', () => {
+    const onAddMilestone = jest.fn();
+    const onAddToCalendar = jest.fn();
+    renderHook(() => useMilestonesKeyboardShortcuts({ onAddMilestone, onAddToCalendar }));
+
+    fireEvent.keyDown(document, { key: 'n', ctrlKey: true, shiftKey: true });
+
+    expect(onAddMilestone).toHaveBeenCalledTimes(1);
+    expect(onAddToCalendar).not.toHaveBeenCalled();
+  });
+
+  it('Ctrl+Shift+C triggers onAddToCalendar', () => {
+    const onAddMilestone = jest.fn();
+    const onAddToCalendar = jest.fn();
+    renderHook(() => useMilestonesKeyboardShortcuts({ onAddMilestone, onAddToCalendar }));
+
+    fireEvent.keyDown(document, { key: 'c', ctrlKey: true, shiftKey: true });
+
+    expect(onAddToCalendar).toHaveBeenCalledTimes(1);
+    expect(onAddMilestone).not.toHaveBeenCalled();
+  });
+
+  it('Meta+Shift+N (Mac) also triggers onAddMilestone', () => {
+    const onAddMilestone = jest.fn();
+    const onAddToCalendar = jest.fn();
+    renderHook(() => useMilestonesKeyboardShortcuts({ onAddMilestone, onAddToCalendar }));
+
+    fireEvent.keyDown(document, { key: 'n', metaKey: true, shiftKey: true });
+
+    expect(onAddMilestone).toHaveBeenCalledTimes(1);
+  });
+
+  it('plain Ctrl+N (no Shift) is ignored — avoids clashing with the browser', () => {
+    const onAddMilestone = jest.fn();
+    const onAddToCalendar = jest.fn();
+    renderHook(() => useMilestonesKeyboardShortcuts({ onAddMilestone, onAddToCalendar }));
+
+    fireEvent.keyDown(document, { key: 'n', ctrlKey: true, shiftKey: false });
+
+    expect(onAddMilestone).not.toHaveBeenCalled();
+  });
+
+  it('plain "n" with no modifier is ignored', () => {
+    const onAddMilestone = jest.fn();
+    const onAddToCalendar = jest.fn();
+    renderHook(() => useMilestonesKeyboardShortcuts({ onAddMilestone, onAddToCalendar }));
+
+    fireEvent.keyDown(document, { key: 'n' });
+
+    expect(onAddMilestone).not.toHaveBeenCalled();
+  });
+
+  it('is ignored while an input has focus (respects typing)', () => {
+    const onAddMilestone = jest.fn();
+    const onAddToCalendar = jest.fn();
+    renderHook(() => useMilestonesKeyboardShortcuts({ onAddMilestone, onAddToCalendar }));
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    fireEvent.keyDown(input, { key: 'n', ctrlKey: true, shiftKey: true });
+
+    expect(onAddMilestone).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it('is ignored while a textarea has focus', () => {
+    const onAddMilestone = jest.fn();
+    const onAddToCalendar = jest.fn();
+    renderHook(() => useMilestonesKeyboardShortcuts({ onAddMilestone, onAddToCalendar }));
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+
+    fireEvent.keyDown(textarea, { key: 'c', ctrlKey: true, shiftKey: true });
+
+    expect(onAddToCalendar).not.toHaveBeenCalled();
+    document.body.removeChild(textarea);
+  });
+
+  it('does nothing when enabled is false', () => {
+    const onAddMilestone = jest.fn();
+    const onAddToCalendar = jest.fn();
+    renderHook(() =>
+      useMilestonesKeyboardShortcuts({ onAddMilestone, onAddToCalendar, enabled: false }),
+    );
+
+    fireEvent.keyDown(document, { key: 'n', ctrlKey: true, shiftKey: true });
+
+    expect(onAddMilestone).not.toHaveBeenCalled();
+  });
+
+  it('removes its listener on unmount', () => {
+    const onAddMilestone = jest.fn();
+    const onAddToCalendar = jest.fn();
+    const { unmount } = renderHook(() =>
+      useMilestonesKeyboardShortcuts({ onAddMilestone, onAddToCalendar }),
+    );
+
+    unmount();
+    fireEvent.keyDown(document, { key: 'n', ctrlKey: true, shiftKey: true });
+
+    expect(onAddMilestone).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useMilestonesKeyboardShortcuts.ts
+++ b/src/hooks/useMilestonesKeyboardShortcuts.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/** True when `target` is a text-entry element that keyboard shortcuts must not fire over. */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable;
+}
+
+export interface UseMilestonesKeyboardShortcutsOptions {
+  /** Opens the milestone creation form. Bound to Ctrl/Cmd+Shift+N. */
+  onAddMilestone: () => void;
+  /** Downloads the current milestone list as an .ics calendar file. Bound to Ctrl/Cmd+Shift+C. */
+  onAddToCalendar: () => void;
+  /** Set to `false` to detach the listener, e.g. while a dialog already owns keyboard focus. */
+  enabled?: boolean;
+}
+
+/**
+ * Global keyboard shortcuts for milestones' primary actions.
+ *
+ * | Shortcut | Action |
+ * |----------|--------|
+ * | `Ctrl/Cmd + Shift + N` | Add milestone |
+ * | `Ctrl/Cmd + Shift + C` | Add to calendar |
+ *
+ * Shift is included specifically to avoid clashing with browser/native
+ * shortcuts (e.g. Ctrl/Cmd+N for a new window). Ignored while a text input,
+ * textarea, select, or contenteditable element has focus so normal typing is
+ * never intercepted.
+ */
+export function useMilestonesKeyboardShortcuts({
+  onAddMilestone,
+  onAddToCalendar,
+  enabled = true,
+}: UseMilestonesKeyboardShortcutsOptions): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || !event.shiftKey) return;
+      if (isTypingTarget(event.target)) return;
+
+      const key = event.key.toLowerCase();
+      if (key === 'n') {
+        event.preventDefault();
+        onAddMilestone();
+      } else if (key === 'c') {
+        event.preventDefault();
+        onAddToCalendar();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [enabled, onAddMilestone, onAddToCalendar]);
+}
+
+export default useMilestonesKeyboardShortcuts;


### PR DESCRIPTION
## Summary
Adds discoverable keyboard shortcuts for milestones' primary actions, per the issue's requirements.

- `Ctrl/Cmd + Shift + N` — Add milestone (opens the creation form)
- `Ctrl/Cmd + Shift + C` — Add to calendar (downloads the `.ics` file)

Implementation:
- New `useMilestonesKeyboardShortcuts` hook (`src/hooks/useMilestonesKeyboardShortcuts.ts`), wired into `src/app/milestones/page.tsx`.
- **Avoids clashing with browser/native keys**: uses the `Shift` modifier (matching the existing `WalletPage` shortcut convention in this repo), so it never collides with e.g. `Ctrl/Cmd+N` (new window).
- **Respects input focus**: ignored while a text `input`, `textarea`, `select`, or `contenteditable` element has focus, so normal typing is never intercepted.
- **Discoverable hint**: renders the existing `KbdHint` component next to the toolbar buttons (`Ctrl+Shift+N — add milestone`, `Ctrl+Shift+C — add to calendar`), following the same pattern already used on the wallet page.
- Disabled (`enabled={!showForm}`) while the creation form is open, so it doesn't fire underneath the dialog.
- Documented in `docs/keyboard.md` alongside the other global shortcuts.

## Tests
- `src/hooks/__tests__/useMilestonesKeyboardShortcuts.test.ts` (9 tests): both shortcuts fire on Ctrl/Meta+Shift+key, ignored without Shift, ignored with no modifier, ignored while an input/textarea has focus, no-op when `enabled=false`, listener cleanup on unmount.
- `src/app/milestones/__tests__/MilestonesKeyboardShortcuts.test.tsx` (5 tests): hints render, `Ctrl+Shift+C` and `Meta+Shift+C` call `downloadMilestonesICS` with the current milestone list, plain `Ctrl+C` is a no-op, and the shortcut is ignored while the sort `<select>` has focus.

**Note on `Ctrl+Shift+N` page-level coverage:** I did not add a page-level test asserting that `Ctrl+Shift+N` opens the creation dialog. On this branch's current `main`, `MilestoneCreationForm` has a pre-existing bug unrelated to this change — `useFormValidation` is imported but never invoked, so `validateAndSubmit` is undefined and the form throws on render (caught by `SafeBoundary`, which is why it doesn't crash the app, but it does mean the dialog can't actually be exercised in a test right now). This affects 11 pre-existing test suites project-wide (confirmed via `git stash` — same 35 failed suites / 463 failed tests before and after this change). The `Ctrl+Shift+N` → `onAddMilestone` wiring itself is fully covered at the hook level instead.

### Test output
```
$ npx jest src/hooks/__tests__/useMilestonesKeyboardShortcuts.test.ts src/app/milestones/__tests__/MilestonesKeyboardShortcuts.test.tsx

PASS src/app/milestones/__tests__/MilestonesKeyboardShortcuts.test.tsx
PASS src/hooks/__tests__/useMilestonesKeyboardShortcuts.test.ts

Test Suites: 2 passed, 2 total
Tests:       14 passed, 14 total
Snapshots:   0 total
```

Full suite, before vs. after this change (via `git stash -u`), confirming no regressions:
```
# main (clean baseline)
Test Suites: 35 failed, 136 passed, 171 total
Tests:       463 failed, 3380 passed, 3843 total

# this branch
Test Suites: 35 failed, 138 passed, 173 total
Tests:       463 failed, 3394 passed, 3857 total
```
Same 35 pre-existing failing suites / 463 pre-existing failing tests in both runs; the only difference is the 2 new suites / 14 new tests added by this PR, all passing.

`npx eslint src/hooks/useMilestonesKeyboardShortcuts.ts src/hooks/__tests__/useMilestonesKeyboardShortcuts.test.ts src/app/milestones/page.tsx src/app/milestones/__tests__/MilestonesKeyboardShortcuts.test.tsx` — clean, no errors.

`npm run build` / `tsc --noEmit` could not be used to verify this branch end-to-end: a fresh checkout of `main` already fails `next build` (unrelated duplicate imports in `src/app/reputation/page.tsx`) and `tsc --noEmit` reports `TS6305` errors from `.next/types/**` not existing yet (this repo's typed-routes output only exists after a build). Verified instead via the Jest suite above.

Closes #1007