### PR TITLE
a11y(contracts): support high-contrast mode

### DIFF
--- a/src/app/contracts/__tests__/contracts-a11y-high-contrast.test.tsx
+++ b/src/app/contracts/__tests__/contracts-a11y-high-contrast.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * contracts-a11y-high-contrast.test.tsx
+ *
+ * Structural coverage for forced-colors / high-contrast support on the
+ * contracts view (issue: "Add high-contrast mode support to contracts").
+ * jsdom does not evaluate `@media (forced-colors: active)`, so — mirroring
+ * the existing wallet/reputation high-contrast tests — these assert the
+ * presence of the `data-*` hooks the CSS in `globals.css` targets, plus an
+ * axe audit of the rendered structure.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ContractsList from '@/components/contracts/ContractsList';
+import ContractsPage from '../page';
+import * as repository from '@/lib/repository';
+import { assertNoA11yViolations } from '@/test-utils/a11y';
+import type { Contract } from '@/types/domain';
+
+jest.mock('@/lib/exportContracts', () => ({
+  downloadContractsCsv: jest.fn(),
+  downloadContractsJson: jest.fn(),
+}));
+
+const CONTRACTS: Contract[] = [
+  {
+    id: 'contract-1',
+    contractName: 'Website redesign',
+    parties: [
+      { label: 'Client', address: 'GCLIENT' },
+      { label: 'Freelancer', address: 'GFREELANCER' },
+    ],
+    totalValue: 2500,
+    currency: 'USD',
+    status: 'Active',
+    createdAt: '2026-07-20',
+    milestoneCount: 3,
+  },
+];
+
+describe('a11y: high-contrast — Contracts', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('contracts list has data-contracts-list attribute for forced-colors targeting', () => {
+    const { container } = render(<ContractsList contracts={CONTRACTS} />);
+    expect(container.querySelector('[data-contracts-list]')).toBeInTheDocument();
+  });
+
+  it('list items remain within the tagged list container', () => {
+    const { container } = render(<ContractsList contracts={CONTRACTS} />);
+    const items = container.querySelectorAll('[data-contracts-list] li');
+    expect(items).toHaveLength(1);
+  });
+
+  it('has no axe violations when rendered with contracts', async () => {
+    const { container } = render(<ContractsList contracts={CONTRACTS} />);
+    await assertNoA11yViolations(container);
+  });
+
+  it('contracts page root has data-contracts-page attribute for forced-colors targeting', () => {
+    jest.spyOn(repository, 'listContracts').mockReturnValue(CONTRACTS);
+    const { container } = render(<ContractsPage />);
+    expect(container.querySelector('[data-contracts-page]')).toBeInTheDocument();
+  });
+
+  it('density toggle stays keyboard-focusable (forced-colors focus restoration target)', () => {
+    jest.spyOn(repository, 'listContracts').mockReturnValue(CONTRACTS);
+    render(<ContractsPage />);
+    const toggle = screen.getByRole('button', { name: /switch to compact density/i });
+    toggle.focus();
+    expect(toggle).toHaveFocus();
+  });
+});

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -122,7 +122,7 @@ const ContractsPage: React.FC = () => {
   );
 
   return (
-    <main className="min-h-screen p-8 pb-24">
+    <main data-contracts-page className="min-h-screen p-8 pb-24">
       <h1 className="text-2xl font-bold mb-6">Contracts</h1>
 
       <p className="sr-only" role="status" aria-live="polite" aria-atomic="true">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -251,6 +251,25 @@ body {
   [data-reputation-list] button {
     border: 1px solid ButtonText !important;
   }
+
+  /* ── Contracts-specific high-contrast rules ──
+     Ensures the contracts list and its controls (search, sort, export,
+     density toggle) remain legible with a visible focus indicator when
+     forced-colors mode is active (e.g. Windows High Contrast). */
+
+  /* Contracts list items: visible container boundary per item */
+  [data-contracts-list] li {
+    border: 1px solid CanvasText !important;
+  }
+
+  /* Several contracts controls use `outline-none` paired with a Tailwind
+     focus ring (box-shadow), which forced-colors mode does not render —
+     leaving no visible focus indicator at all. Restore a native outline
+     for every focus-visible element scoped to the contracts page. */
+  [data-contracts-page] :focus-visible {
+    outline: 2px solid Highlight !important;
+    outline-offset: 2px;
+  }
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/components/contracts/ContractsList.tsx
+++ b/src/components/contracts/ContractsList.tsx
@@ -73,6 +73,7 @@ const ContractsList = memo(
           )}
         </div>
         <ul
+          data-contracts-list
           className={`transition-[gap] ${isCompact ? 'space-y-2' : 'space-y-4'}`}
           aria-label="Contracts list"
         >


### PR DESCRIPTION
## Summary
Adds forced-colors / Windows High Contrast support to the contracts view, per the issue's requirements.

**The real bug this fixes:** several contracts controls (the density toggle button, search input, sort select) use Tailwind's `focus-visible:outline-none` / `focus:outline-none` paired with a box-shadow-based focus ring (`ring-2`). Under `forced-colors: active`, box-shadow is not rendered, and since the native outline was explicitly removed, focused elements end up with **no visible focus indicator at all**.

## Changes
- `src/app/globals.css`: new "Contracts-specific high-contrast rules" section inside the existing `@media (forced-colors: active)` block (following the same pattern already used for wallet and reputation):
  - `[data-contracts-page] :focus-visible { outline: 2px solid Highlight !important; outline-offset: 2px; }` — restores a visible focus indicator for every focusable control on the page.
  - `[data-contracts-list] li { border: 1px solid CanvasText !important; }` — visible boundary per contract card.
  - All rules are scoped inside the `forced-colors: active` media query, so **normal mode is untouched** — no layout regression.
- `src/app/contracts/page.tsx`: added `data-contracts-page` to the page's `<main>` (targeting hook only, no visual change in normal mode).
- `src/components/contracts/ContractsList.tsx`: added `data-contracts-list` to the list `<ul>` (targeting hook only).

## Tests
jsdom doesn't evaluate `@media (forced-colors: active)`, so — mirroring the existing wallet/reputation high-contrast tests (`wallet-a11y-motion-contrast.test.tsx`, `reputation-a11y-high-contrast.test.tsx`) — the new suite asserts the presence of the `data-*` hooks the CSS targets, that focus still works correctly on the affected control, and runs an axe audit:

`src/app/contracts/__tests__/contracts-a11y-high-contrast.test.tsx` (5 tests):
- contracts list has `data-contracts-list` for forced-colors targeting
- list items remain within the tagged list container
- no axe violations when rendered with contracts
- contracts page root has `data-contracts-page` for forced-colors targeting
- density toggle stays keyboard-focusable (the forced-colors focus-restoration target)

### Test output
```
$ npx jest src/app/contracts/__tests__/contracts-a11y-high-contrast.test.tsx

PASS src/app/contracts/__tests__/contracts-a11y-high-contrast.test.tsx
  a11y: high-contrast — Contracts
    ✓ contracts list has data-contracts-list attribute for forced-colors targeting
    ✓ list items remain within the tagged list container
    ✓ has no axe violations when rendered with contracts
    ✓ contracts page root has data-contracts-page attribute for forced-colors targeting
    ✓ density toggle stays keyboard-focusable (forced-colors focus restoration target)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
```

Full `contract`-scoped suite, before vs. after this change (via `git stash -u`), confirming no regressions:
```
# main (clean baseline)
Test Suites: 4 failed, 24 passed, 28 total
Tests:       10 failed, 569 passed, 579 total

# this branch
Test Suites: 4 failed, 25 passed, 29 total
Tests:       10 failed, 574 passed, 584 total
```
Same 4 pre-existing failing suites / 10 pre-existing failing tests in both runs (unrelated to this change — `CreateContractForm.test.tsx`, `ContractRowItem.test.tsx`, `ContractsDensityToggle.test.tsx`, `ContractsHooksDocs.test.ts`); the only difference is the 1 new suite / 5 new tests added by this PR, all passing.

`npx eslint src/app/contracts/page.tsx src/components/contracts/ContractsList.tsx src/app/contracts/__tests__/contracts-a11y-high-contrast.test.tsx` — clean, no errors.

`npm run build` / `tsc --noEmit` could not be used to verify this branch end-to-end: a fresh checkout of `main` already fails `next build` (unrelated duplicate imports in `src/app/reputation/page.tsx`) and `tsc --noEmit` reports `TS6305` errors from `.next/types/**` not existing yet (this repo's typed-routes output only exists after a build). Verified instead via the Jest suite above.

Closes #1003