### PR TITLE
test(contracts): cover keyboard navigation

### DIFF
--- a/src/app/contracts/__tests__/contracts-keyboard-navigation.test.tsx
+++ b/src/app/contracts/__tests__/contracts-keyboard-navigation.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * contracts-keyboard-navigation.test.tsx
+ *
+ * Coverage for contracts's keyboard operability (issue: "Add tests for
+ * contracts keyboard navigation"). This is test-only: no behavioural
+ * changes are made unless a defect is found while writing these tests.
+ *
+ * Covers:
+ *  - Logical tab order across the toolbar (search -> sort -> CSV -> JSON ->
+ *    Create Contract -> density toggle)
+ *  - Enter / Space activation of toolbar buttons
+ *  - Create Contract dialog: opens with focus on the first field, Tab/
+ *    Shift+Tab wrap at the dialog boundary, Escape cancels and restores
+ *    focus to the trigger button
+ */
+
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ContractsPage from '../page';
+import * as repository from '@/lib/repository';
+import * as exportContracts from '@/lib/exportContracts';
+import { PreferencesProvider } from '@/lib/preferences';
+import type { Contract } from '@/types/domain';
+
+jest.mock('@/lib/exportContracts', () => ({
+  downloadContractsCsv: jest.fn(),
+  downloadContractsJson: jest.fn(),
+}));
+
+jest.mock('@/components/toast/toast-provider', () => ({
+  useToast: () => ({
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+    toasts: [],
+    dismissToast: jest.fn(),
+  }),
+}));
+
+const CONTRACTS: Contract[] = [
+  {
+    id: 'contract-1',
+    contractName: 'Website redesign',
+    parties: [
+      { label: 'Client', address: 'GCLIENT' },
+      { label: 'Freelancer', address: 'GFREELANCER' },
+    ],
+    totalValue: 2500,
+    currency: 'USD',
+    status: 'Active',
+    createdAt: '2026-07-20',
+    milestoneCount: 3,
+  },
+];
+
+const mockedDownloadCsv = exportContracts.downloadContractsCsv as jest.MockedFunction<
+  typeof exportContracts.downloadContractsCsv
+>;
+const mockedDownloadJson = exportContracts.downloadContractsJson as jest.MockedFunction<
+  typeof exportContracts.downloadContractsJson
+>;
+
+function renderContractsPage() {
+  jest.spyOn(repository, 'listContracts').mockReturnValue(CONTRACTS);
+  return render(
+    <PreferencesProvider>
+      <ContractsPage />
+    </PreferencesProvider>,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('contracts keyboard navigation — tab order', () => {
+  it('tabs from search to sort to CSV to JSON to Create Contract to density toggle', async () => {
+    const user = userEvent.setup();
+    renderContractsPage();
+
+    const search = screen.getByLabelText('Search contracts');
+    search.focus();
+    expect(search).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByLabelText('Sort by')).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Export contracts as CSV' })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Export contracts as JSON' })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Create Contract' })).toHaveFocus();
+
+    await user.tab();
+    expect(
+      screen.getByRole('button', { name: /switch to compact density/i }),
+    ).toHaveFocus();
+  });
+});
+
+describe('contracts keyboard navigation — Enter/Space activation', () => {
+  it('Enter on the CSV button triggers the CSV export', async () => {
+    const user = userEvent.setup();
+    renderContractsPage();
+
+    screen.getByRole('button', { name: 'Export contracts as CSV' }).focus();
+    await user.keyboard('{Enter}');
+
+    expect(mockedDownloadCsv).toHaveBeenCalledTimes(1);
+  });
+
+  it('Space on the JSON button triggers the JSON export', async () => {
+    const user = userEvent.setup();
+    renderContractsPage();
+
+    screen.getByRole('button', { name: 'Export contracts as JSON' }).focus();
+    await user.keyboard('[Space]');
+
+    expect(mockedDownloadJson).toHaveBeenCalledTimes(1);
+  });
+
+  it('Enter on the density toggle switches to compact density', async () => {
+    const user = userEvent.setup();
+    renderContractsPage();
+
+    const toggle = screen.getByRole('button', { name: /switch to compact density/i });
+    toggle.focus();
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByRole('button', { name: /switch to comfortable density/i })).toHaveFocus();
+  });
+
+  it('Enter on Create Contract opens the creation dialog', async () => {
+    const user = userEvent.setup();
+    renderContractsPage();
+
+    screen.getByRole('button', { name: 'Create Contract' }).focus();
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+describe('contracts keyboard navigation — creation dialog', () => {
+  it('opens with focus on the Contract Name field', async () => {
+    const user = userEvent.setup();
+    renderContractsPage();
+
+    await user.click(screen.getByRole('button', { name: 'Create Contract' }));
+
+    expect(screen.getByLabelText(/contract name/i)).toHaveFocus();
+  });
+
+  it('Escape cancels the dialog and restores focus to the trigger button', async () => {
+    const user = userEvent.setup();
+    renderContractsPage();
+
+    await user.click(screen.getByRole('button', { name: 'Create Contract' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    // The toolbar (and its "Create Contract" button) unmounts while the
+    // dialog is open, so this must be the freshly-remounted button, not the
+    // pre-open reference.
+    expect(screen.getByRole('button', { name: 'Create Contract' })).toHaveFocus();
+  });
+
+  it('Shift+Tab from the first field wraps focus to the last dialog control (Create Contract submit)', async () => {
+    const user = userEvent.setup();
+    renderContractsPage();
+
+    await user.click(screen.getByRole('button', { name: 'Create Contract' }));
+    expect(screen.getByLabelText(/contract name/i)).toHaveFocus();
+
+    await user.tab({ shift: true });
+
+    const dialog = screen.getByRole('dialog');
+    const submit = within(dialog).getByRole('button', { name: 'Create Contract' });
+    expect(submit).toHaveFocus();
+  });
+
+  it('Tab from the last dialog control wraps focus back to the first field', async () => {
+    const user = userEvent.setup();
+    renderContractsPage();
+
+    await user.click(screen.getByRole('button', { name: 'Create Contract' }));
+    const dialog = screen.getByRole('dialog');
+    const submit = within(dialog).getByRole('button', { name: 'Create Contract' });
+    submit.focus();
+
+    await user.tab();
+
+    expect(screen.getByLabelText(/contract name/i)).toHaveFocus();
+  });
+
+  it('Enter on Cancel closes the dialog', async () => {
+    const user = userEvent.setup();
+    renderContractsPage();
+
+    const trigger = screen.getByRole('button', { name: 'Create Contract' });
+    await user.click(trigger);
+
+    const dialog = screen.getByRole('dialog');
+    within(dialog).getByRole('button', { name: 'Cancel' }).focus();
+    await user.keyboard('{Enter}');
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import EmptyState from '../../components/EmptyState';
 import ContractsList from '../../components/contracts/ContractsList';
 import { ContractCreationForm } from '../../components/ContractCreationForm';
@@ -38,6 +38,23 @@ const ContractsPage: React.FC = () => {
   const { showError } = useToast();
   const { preferences, updatePreference } = usePreferences();
   const { contracts } = fetchState;
+
+  // The toolbar (and its "Create Contract" button) unmounts while the dialog
+  // is open, so useDialogFocusTrap's own restoreFocus can't find it again on
+  // close (the button it captured no longer exists). Once the toolbar
+  // remounts, refocus it here instead. Skipped on mount so this doesn't fire
+  // before the dialog has ever been opened.
+  const createButtonRef = useRef<HTMLButtonElement>(null);
+  const hasOpenedFormRef = useRef(false);
+  useEffect(() => {
+    if (showForm) {
+      hasOpenedFormRef.current = true;
+      return;
+    }
+    if (hasOpenedFormRef.current) {
+      createButtonRef.current?.focus();
+    }
+  }, [showForm]);
 
   const contractsDensity = preferences.contractsDensity;
 
@@ -234,6 +251,7 @@ const ContractsPage: React.FC = () => {
                 JSON
               </button>
               <button
+                ref={createButtonRef}
                 type="button"
                 onClick={handleCreateContract}
                 className="rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-blue-500"


### PR DESCRIPTION
## Summary
Adds keyboard-navigation coverage for the contracts view, per the issue's requirements. This was meant to be test-only, but writing the Escape/restore-focus test surfaced a real, pre-existing defect (see below), which the issue's own instructions explicitly permit fixing ("Do not change behaviour unless a defect is found").

New file: `src/app/contracts/__tests__/contracts-keyboard-navigation.test.tsx` (10 tests, deterministic — no real timers, contracts/page.tsx has none to fake):
- **Tab order**: search -> sort -> CSV -> JSON -> Create Contract -> density toggle.
- **Enter/Space activation**: CSV export, JSON export, density toggle, opening the Create Contract dialog.
- **Creation dialog**: opens with focus on the Contract Name field, Tab from the last control wraps to the first field, Shift+Tab from the first field wraps to the last control, Escape cancels and restores focus, Enter on Cancel closes the dialog.

## The defect
While writing the Escape test, focus was landing on `<body>` instead of back on the "Create Contract" button. Root cause: the toolbar (including the button that opened the dialog) is conditionally rendered on `!showForm`, so it **unmounts the instant the dialog opens**. `useDialogFocusTrap`'s `restoreFocus` (shared by every dialog in this app) captures `document.activeElement` in a `useEffect`, which runs *after* that unmount already happened — so it captures `document.body`, not the actual trigger button. On close, it then tries to focus `document.body`, which does nothing, and keyboard users lose their place entirely after cancelling.

**Fix** (`src/app/contracts/page.tsx`): added a `ref` on the toolbar's "Create Contract" button plus a small `useEffect` that refocuses it once the toolbar remounts after `showForm` goes back to `false`. This runs after `ContractCreationForm`'s own (ineffective) cleanup, so it correctly targets the freshly-mounted button. Deliberately scoped to `page.tsx` only — `useDialogFocusTrap` itself is shared by several other dialogs (`ConfirmDialog`, `CommandPalette`, `SettingsPanel`, `MilestoneCreationForm`) and changing its capture timing was out of scope for a contracts-only issue. The existing show/hide behavior of the toolbar itself is untouched — `page.test.tsx` already has explicit assertions that the list/toolbar disappear while the form is open, and those still pass.

## Tests

### Test output
```
$ npx jest src/app/contracts/__tests__/contracts-keyboard-navigation.test.tsx

PASS src/app/contracts/__tests__/contracts-keyboard-navigation.test.tsx
  contracts keyboard navigation — tab order
    ✓ tabs from search to sort to CSV to JSON to Create Contract to density toggle
  contracts keyboard navigation — Enter/Space activation
    ✓ Enter on the CSV button triggers the CSV export
    ✓ Space on the JSON button triggers the JSON export
    ✓ Enter on the density toggle switches to compact density
    ✓ Enter on Create Contract opens the creation dialog
  contracts keyboard navigation — creation dialog
    ✓ opens with focus on the Contract Name field
    ✓ Escape cancels the dialog and restores focus to the trigger button
    ✓ Shift+Tab from the first field wraps focus to the last dialog control (Create Contract submit)
    ✓ Tab from the last dialog control wraps focus back to the first field
    ✓ Enter on Cancel closes the dialog

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
```

Full `contract`-scoped suite, before vs. after this change (via `git stash -u`), confirming no regressions:
```
# main (clean baseline)
Test Suites: 4 failed, 24 passed, 28 total
Tests:       10 failed, 569 passed, 579 total

# this branch
Test Suites: 4 failed, 25 passed, 29 total
Tests:       10 failed, 579 passed, 589 total
```
Same 4 pre-existing failing suites / 10 pre-existing failing tests in both runs (unrelated to this change — `CreateContractForm.test.tsx`, `ContractRowItem.test.tsx`, `ContractsDensityToggle.test.tsx`, `ContractsHooksDocs.test.ts`); the only difference is the 1 new suite / 10 new tests added by this PR, all passing, plus `page.test.tsx`'s existing 34 tests (including its toolbar-visibility assertions) still pass unmodified.

`npx eslint src/app/contracts/page.tsx src/app/contracts/__tests__/contracts-keyboard-navigation.test.tsx` — clean, no errors.

`npm run build` / `tsc --noEmit` could not be used to verify this branch end-to-end: a fresh checkout of `main` already fails `next build` (unrelated duplicate imports in `src/app/reputation/page.tsx`) and `tsc --noEmit` reports `TS6305` errors from `.next/types/**` not existing yet (this repo's typed-routes output only exists after a build). Verified instead via the Jest suite above.

Closes #1004