### PR TITLE
.A11y/wallet 71 contrast

### DIFF
--- a/docs/components/Accessibility.md
+++ b/docs/components/Accessibility.md
@@ -685,3 +685,33 @@ page, not just this component) and is out of scope for this issue.
 - Tested in `src/components/__tests__/a11y.test.tsx` under `a11y: prefers-reduced-motion — milestones` and `a11y: forced-colors / high contrast — milestones`.
 - Confirmed zero `jest-axe` violations across all states.
 
+---
+
+## Wallet — High-Contrast / Forced-Colors Support (issue #1018)
+
+**Standard:** WCAG 2.1 AA — 1.4.11 Non-text Contrast & 2.4.7 Focus Visible.
+
+### Defects found and fixed
+
+1. **Invisible keyboard focus on the per-row delete button** (`WalletItemList.tsx`): the button used `focus:outline-none focus:ring-2 focus:ring-rose-500`. Tailwind's `outline-none` sets `outline-color: transparent` (not `outline-style: none`) — forced-colors mode explicitly preserves author-specified `transparent` rather than remapping it, so the outline stayed invisible. The box-shadow-based `ring` is separately stripped under forced-colors. Net result: this control had **zero** visible focus indicator in high-contrast mode. Fixed by switching to `focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500`, matching the already-correct pattern in `WalletBulkToolbar`'s buttons.
+2. **Color-only status pills** (Active/Pending/Archived): the wallet items table rendered its own inline pill using fixed Tailwind pastel backgrounds with no border, which flattens to an indistinguishable chip under forced-colors. Fixed by replacing it with the shared `StatusBadge` component (`role="status"`, audited CSS-variable tokens, already covered by the existing `[role="status"]` forced-colors border rule below). `StatusBadge`'s `StatusType` was extended with a new `Archived` value and a neutral token pair (`--status-neutral-bg` / `--status-neutral-foreground`), contrast-verified at **9.45:1** (light) and **9.85:1** (dark) — both well above the 4.5:1 AA minimum.
+3. **Selection and toolbar boundaries conveyed by background tint alone**: selected wallet-item rows only had a translucent blue background (no `aria-selected`, no border); the bulk-actions toolbar container, its buttons, and its selected-count pill relied on background color for definition with no border on some elements (e.g. the destructive Delete button). All of these collapse under forced-colors, which zeroes out backgrounds and (in some engines) box-shadows.
+
+### Implementation Details
+
+1. **`aria-selected`** added to each `<tr>` in `WalletItemList` — a genuine accessibility improvement in its own right (previously the selected state was not exposed to assistive tech at all), and gives the forced-colors rule below a stable selector that doesn't depend on tint.
+2. **High-Contrast / Forced-Colors Mode (`@media (forced-colors: active)`)** — extends the existing block in `globals.css`:
+   - `[role="toolbar"]`: `1px solid CanvasText` border around the bulk-actions toolbar.
+   - `[role="toolbar"] button`: `1px solid ButtonText` border on every toolbar action button (covers the Delete button, which has no border in normal mode).
+   - `.wallet-count-badge`: `1px solid CanvasText` border on the selected-count pill (new class hook added to `WalletBulkToolbar`, otherwise invisible — decorative-only in normal mode).
+   - `tr[aria-selected='true']`: `2px solid Highlight` inset outline so selected rows remain visible once the background tint is gone.
+   - Status pills are already covered by the pre-existing `[role="status"]` rule (`1px solid CanvasText`) since `StatusBadge` uses that role.
+3. **No layout regression in normal mode**: all forced-colors rules are scoped inside the `@media (forced-colors: active)` block and only affect rendering when that mode is active. The one visible normal-mode change is that the wallet status pill now uses `StatusBadge`'s standard sizing (`px-3 py-1 text-sm` + icon) instead of the wallet's previous bespoke smaller pill (`px-2.5 py-0.5 text-xs`, no icon) — a deliberate, minor sizing change made to reuse the already-audited, forced-colors-safe shared component rather than duplicating color logic; it does not alter the table's column layout.
+
+### Testing & Verification
+
+- New `src/components/wallet/__tests__/WalletItemList.test.tsx` (this component previously had no test file): rendering, selection, `aria-selected`, `StatusBadge` integration (including a regression guard against the old color-only pill classes), delete-button focus-visible regression guard, and three `jest-axe` checks (no selection / partial selection / full selection) — all zero violations.
+- Extended `WalletBulkToolbar.test.tsx`: `role="toolbar"` presence, `.wallet-count-badge` class hook, a regression guard confirming every toolbar button uses a real `focus-visible:outline` (not `outline-none`), a `jest-axe` check, and a branch-coverage gap fix (non-Escape keypress).
+- Extended `StatusBadge.test.tsx`: `Archived` added to every existing per-status test loop (rendering, icon, themed classes, regression guard, aria-label), plus a dedicated themed-class test and snapshot for `Archived`.
+- **Coverage**: 100% statements/branches/functions/lines across `WalletItemList.tsx`, `WalletBulkToolbar.tsx`, and `StatusBadge.tsx`.
+- **Full-suite regression check**: ran the complete 1772-test suite before and after this change (via `git stash` A/B comparison). The set of failing test suites is identical between the two runs (this repo has pre-existing, unrelated breakage — broken JSX, undefined vars, parsing errors across ~45 suites, matching the repo's own `CI_BUILD_FIXES.md`/`TEST_FIX_SUMMARY.md`). This change introduces zero new failures anywhere in the suite.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,6 +44,13 @@
   --status-error-foreground: #9f1239;
   --status-warning-bg: #fef3c7;
   --status-warning-foreground: #92400e;
+
+  /* a11y/wallet-71-contrast: neutral token for StatusBadge's `Archived`
+     status, used by the wallet items list. 9.45:1 against this
+     foreground -- verified AA. Matches the slate scale already used
+     elsewhere in the light theme. */
+  --status-neutral-bg: #f1f5f9;
+  --status-neutral-foreground: #334155;
 }
 
 [data-theme='dark'] {
@@ -91,6 +98,11 @@
   --status-error-foreground: #fda4af;
   --status-warning-bg: #78350f;
   --status-warning-foreground: #fcd34d;
+
+  /* a11y/wallet-71-contrast: dark-mode pair for the `Archived` neutral
+     token. 9.85:1 against this foreground -- verified AA. */
+  --status-neutral-bg: #1e293b;
+  --status-neutral-foreground: #cbd5e1;
 }
 
 body {
@@ -166,6 +178,36 @@ body {
     background-color: Highlight !important;
     color: HighlightText !important;
     border: 1px solid Highlight !important;
+  }
+
+  /* a11y/wallet-71-contrast: WalletBulkToolbar and WalletItemList.
+     Backgrounds/box-shadows are stripped under forced-colors, so any
+     boundary or state that relied on tint alone needs an explicit
+     border here. Status pill borders are already covered above via
+     [role="status"]. */
+
+  /* Toolbar container boundary (background tint disappears). */
+  [role="toolbar"] {
+    border: 1px solid CanvasText !important;
+  }
+
+  /* Toolbar buttons: some (e.g. the destructive Delete action) have no
+     border in normal mode since they rely on solid background color for
+     definition; give every toolbar button a visible boundary. */
+  [role="toolbar"] button {
+    border: 1px solid ButtonText !important;
+  }
+
+  /* Selected-count pill in the toolbar -- decorative background only. */
+  .wallet-count-badge {
+    border: 1px solid CanvasText !important;
+  }
+
+  /* Selected wallet-item row: exposed via aria-selected rather than
+     background tint alone, so it survives forced-colors. */
+  tr[aria-selected='true'] {
+    outline: 2px solid Highlight !important;
+    outline-offset: -2px;
   }
 }
 

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -6,7 +6,7 @@
  * Meets WCAG 2.1 AA requirements.
  */
 
-export type StatusType = 'Active' | 'Completed' | 'Disputed' | 'Pending' | 'Paid';
+export type StatusType = 'Active' | 'Completed' | 'Disputed' | 'Pending' | 'Paid' | 'Archived';
 
 export interface StatusBadgeProps {
   /** The status value to display */
@@ -23,6 +23,12 @@ export interface StatusBadgeProps {
  * `data-theme`. Replaced with CSS variables defined in globals.css so
  * both themes get an audited, intentional pair.
  * Ratios recorded in docs/components/Accessibility.md.
+ *
+ * a11y/wallet-71-contrast: added `Archived` (neutral slate token pair) so
+ * the wallet items list can reuse this shared, already-audited badge
+ * instead of its own color-only inline pill. Ratios: 9.45:1 (light),
+ * 9.85:1 (dark) — both well above WCAG AA's 4.5:1. See
+ * docs/components/Accessibility.md.
  */
 export const statusColorMap: Record<StatusType, string> = {
   Active: 'bg-[var(--status-success-bg)] text-[var(--status-success-foreground)]',
@@ -30,6 +36,7 @@ export const statusColorMap: Record<StatusType, string> = {
   Disputed: 'bg-[var(--status-error-bg)] text-[var(--status-error-foreground)]',
   Pending: 'bg-[var(--status-warning-bg)] text-[var(--status-warning-foreground)]',
   Paid: 'bg-[var(--status-success-bg)] text-[var(--status-success-foreground)]',
+  Archived: 'bg-[var(--status-neutral-bg)] text-[var(--status-neutral-foreground)]',
 };
 
 /** Non-color icon token paired with each status (aria-hidden; label provides text). */
@@ -39,6 +46,7 @@ export const statusIconMap: Record<StatusType, string> = {
   Disputed:  '⚠',
   Pending:   '⏳',
   Paid:      '✔',
+  Archived:  '⊘',
 };
 
 /**

--- a/src/components/__tests__/StatusBadge.test.tsx
+++ b/src/components/__tests__/StatusBadge.test.tsx
@@ -8,6 +8,7 @@ const STATUS_ICONS: Record<StatusType, string> = {
   Disputed:  '⚠',
   Pending:   '⏳',
   Paid:      '✔',
+  Archived:  '⊘',
 };
 
 describe('StatusBadge', () => {
@@ -18,7 +19,7 @@ describe('StatusBadge', () => {
     });
 
     it('renders all status types correctly', () => {
-      const statuses: StatusType[] = ['Active', 'Completed', 'Disputed', 'Pending', 'Paid'];
+      const statuses: StatusType[] = ['Active', 'Completed', 'Disputed', 'Pending', 'Paid', 'Archived'];
 
       statuses.forEach((status) => {
         const { unmount } = render(<StatusBadge status={status} />);
@@ -28,7 +29,7 @@ describe('StatusBadge', () => {
     });
 
     it('renders an icon for each status', () => {
-      const statuses: StatusType[] = ['Active', 'Completed', 'Disputed', 'Pending', 'Paid'];
+      const statuses: StatusType[] = ['Active', 'Completed', 'Disputed', 'Pending', 'Paid', 'Archived'];
 
       statuses.forEach((status) => {
         const { container, unmount } = render(<StatusBadge status={status} />);
@@ -88,6 +89,16 @@ describe('StatusBadge', () => {
       expect(span?.className).toContain('text-[var(--status-success-foreground)]');
     });
 
+    // a11y/wallet-71-contrast: neutral token added so the wallet items
+    // list can reuse this shared badge instead of its own color-only
+    // inline pill. 9.45:1 (light) / 9.85:1 (dark) -- both AA+.
+    it('applies correct themed classes for Archived status', () => {
+      const { container } = render(<StatusBadge status="Archived" />);
+      const span = container.querySelector('span');
+      expect(span?.className).toContain('bg-[var(--status-neutral-bg)]');
+      expect(span?.className).toContain('text-[var(--status-neutral-foreground)]');
+    });
+
     it('applies base badge styles consistently', () => {
       const { container } = render(<StatusBadge status="Active" />);
       const span = container.querySelector('span');
@@ -101,7 +112,7 @@ describe('StatusBadge', () => {
     });
 
     it('no longer uses fixed Tailwind pastel color classes (regression guard)', () => {
-      const statuses: StatusType[] = ['Active', 'Completed', 'Disputed', 'Pending', 'Paid'];
+      const statuses: StatusType[] = ['Active', 'Completed', 'Disputed', 'Pending', 'Paid', 'Archived'];
 
       statuses.forEach((status) => {
         const { container, unmount } = render(<StatusBadge status={status} />);
@@ -142,7 +153,7 @@ describe('StatusBadge', () => {
     });
 
     it('has appropriate aria-label for each status', () => {
-      const statuses: StatusType[] = ['Active', 'Completed', 'Disputed', 'Pending', 'Paid'];
+      const statuses: StatusType[] = ['Active', 'Completed', 'Disputed', 'Pending', 'Paid', 'Archived'];
 
       statuses.forEach((status) => {
         const { unmount } = render(<StatusBadge status={status} />);
@@ -181,6 +192,11 @@ describe('StatusBadge', () => {
 
     it('matches snapshot for Paid status', () => {
       const { container } = render(<StatusBadge status="Paid" />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('matches snapshot for Archived status', () => {
+      const { container } = render(<StatusBadge status="Archived" />);
       expect(container.firstChild).toMatchSnapshot();
     });
 

--- a/src/components/__tests__/__snapshots__/Navbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Navbar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Navbar rendered structure snapshots matches the empty default navigation structure without an active route 1`] = `
 <nav

--- a/src/components/__tests__/__snapshots__/StatusBadge.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/StatusBadge.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StatusBadge snapshot tests matches snapshot for Active status 1`] = `
 <span
@@ -12,6 +12,21 @@ exports[`StatusBadge snapshot tests matches snapshot for Active status 1`] = `
     ▶
   </span>
   Active
+</span>
+`;
+
+exports[`StatusBadge snapshot tests matches snapshot for Archived status 1`] = `
+<span
+  aria-label="Status: Archived"
+  class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-semibold bg-[var(--status-neutral-bg)] text-[var(--status-neutral-foreground)] "
+  role="status"
+>
+  <span
+    aria-hidden="true"
+  >
+    ⊘
+  </span>
+  Archived
 </span>
 `;
 

--- a/src/components/wallet/WalletBulkToolbar.tsx
+++ b/src/components/wallet/WalletBulkToolbar.tsx
@@ -51,7 +51,7 @@ export const WalletBulkToolbar: React.FC<WalletBulkToolbarProps> = ({
       className="sticky top-20 z-30 mb-4 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-blue-200 bg-blue-50/95 px-4 py-3 shadow-md backdrop-blur transition-all dark:border-blue-900/50 dark:bg-slate-800/95"
     >
       <div className="flex items-center gap-3">
-        <span className="inline-flex items-center justify-center rounded-full bg-blue-600 px-2.5 py-0.5 text-xs font-bold text-white">
+        <span className="wallet-count-badge inline-flex items-center justify-center rounded-full bg-blue-600 px-2.5 py-0.5 text-xs font-bold text-white">
           {selectedCount}
         </span>
         <span className="text-sm font-medium text-slate-800 dark:text-slate-100">

--- a/src/components/wallet/WalletItemList.tsx
+++ b/src/components/wallet/WalletItemList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef } from 'react';
+import StatusBadge from '@/components/StatusBadge';
 import type { WalletItem } from '@/types/domain';
 
 export interface WalletItemListProps {
@@ -71,6 +72,7 @@ export const WalletItemList: React.FC<WalletItemListProps> = ({
               <tr
                 key={item.id}
                 data-testid={`wallet-item-row-${item.id}`}
+                aria-selected={isSelected}
                 className={`transition-colors hover:bg-slate-50/80 dark:hover:bg-slate-800/40 ${
                   isSelected ? 'bg-blue-50/40 dark:bg-slate-800/60' : ''
                 }`}
@@ -98,17 +100,7 @@ export const WalletItemList: React.FC<WalletItemListProps> = ({
                   {item.balance.toLocaleString()} {item.currency}
                 </td>
                 <td className="px-4 py-4">
-                  <span
-                    className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-semibold ${
-                      item.status === 'Active'
-                        ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300'
-                        : item.status === 'Pending'
-                        ? 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300'
-                        : 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300'
-                    }`}
-                  >
-                    {item.status}
-                  </span>
+                  <StatusBadge status={item.status} />
                 </td>
                 <td className="px-4 py-4 text-xs text-slate-500 dark:text-slate-400">{item.createdAt}</td>
                 <td className="px-4 py-4 text-right">
@@ -116,7 +108,7 @@ export const WalletItemList: React.FC<WalletItemListProps> = ({
                     <button
                       type="button"
                       onClick={() => onDeleteItem(item.id)}
-                      className="rounded-lg p-1 text-slate-400 transition hover:bg-rose-50 hover:text-rose-600 focus:outline-none focus:ring-2 focus:ring-rose-500 dark:hover:bg-rose-950/50"
+                      className="rounded-lg p-1 text-slate-400 transition hover:bg-rose-50 hover:text-rose-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 dark:hover:bg-rose-950/50"
                       aria-label={`Delete ${item.name}`}
                     >
                       <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">

--- a/src/components/wallet/__tests__/WalletBulkToolbar.test.tsx
+++ b/src/components/wallet/__tests__/WalletBulkToolbar.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { WalletBulkToolbar } from '../WalletBulkToolbar';
+import { testA11y } from '@/test-utils/a11y';
 
 describe('WalletBulkToolbar', () => {
   const defaultProps = {
@@ -59,5 +60,42 @@ describe('WalletBulkToolbar', () => {
     render(<WalletBulkToolbar {...defaultProps} />);
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(defaultProps.onClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not clear selection when a non-Escape key is pressed', () => {
+    render(<WalletBulkToolbar {...defaultProps} />);
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(defaultProps.onClearSelection).not.toHaveBeenCalled();
+  });
+
+  // a11y/wallet-71-contrast: the count pill's own background is stripped
+  // under forced-colors, so it needs a stable selector for the CSS rule
+  // in globals.css (`.wallet-count-badge`) to attach a visible border to.
+  describe('forced-colors support (a11y/wallet-71-contrast)', () => {
+    it('has role="toolbar" so the forced-colors container border applies', () => {
+      render(<WalletBulkToolbar {...defaultProps} />);
+      expect(screen.getByRole('toolbar')).toBeInTheDocument();
+    });
+
+    it('exposes the wallet-count-badge class hook on the selected-count pill', () => {
+      render(<WalletBulkToolbar {...defaultProps} selectedCount={2} />);
+      expect(screen.getByText('2').className).toContain('wallet-count-badge');
+    });
+
+    it('already uses a real focus-visible outline (not outline-none) on every action button', () => {
+      render(<WalletBulkToolbar {...defaultProps} />);
+      const exportBtn = screen.getByRole('button', { name: /export 2 selected items/i });
+      const deleteBtn = screen.getByRole('button', { name: /delete 2 selected items/i });
+      [exportBtn, deleteBtn].forEach((btn) => {
+        expect(btn.className).not.toMatch(/focus:outline-none|focus-visible:outline-none/);
+        expect(btn.className).toContain('focus-visible:outline');
+      });
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has zero axe violations', async () => {
+      await testA11y(<WalletBulkToolbar {...defaultProps} />);
+    });
   });
 });

--- a/src/components/wallet/__tests__/WalletItemList.test.tsx
+++ b/src/components/wallet/__tests__/WalletItemList.test.tsx
@@ -1,0 +1,203 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WalletItemList } from '../WalletItemList';
+import { testA11y } from '@/test-utils/a11y';
+import type { WalletItem } from '@/types/domain';
+
+const ITEMS: WalletItem[] = [
+  {
+    id: 'w-1',
+    name: 'Stellar Lumens (XLM)',
+    type: 'Native Asset',
+    balance: 12500,
+    currency: 'XLM',
+    address: 'GAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQDZ7H',
+    status: 'Active',
+    createdAt: '2026-01-15',
+  },
+  {
+    id: 'w-2',
+    name: 'Escrow Lock Key #402',
+    type: 'Security Credential',
+    balance: 1,
+    currency: 'KEY',
+    status: 'Pending',
+    createdAt: '2026-03-10',
+  },
+  {
+    id: 'w-3',
+    name: 'Archived Client Token',
+    type: 'Custom Asset',
+    balance: 50,
+    currency: 'ACT',
+    status: 'Archived',
+    createdAt: '2025-11-20',
+  },
+];
+
+describe('WalletItemList', () => {
+  const defaultProps = {
+    items: ITEMS,
+    selectedIds: new Set<string>(),
+    onToggleSelect: jest.fn(),
+    onToggleSelectAll: jest.fn(),
+    onDeleteItem: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders nothing when items is empty', () => {
+      const { container } = render(<WalletItemList {...defaultProps} items={[]} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders a row for each item', () => {
+      render(<WalletItemList {...defaultProps} />);
+      expect(screen.getByTestId('wallet-item-row-w-1')).toBeInTheDocument();
+      expect(screen.getByTestId('wallet-item-row-w-2')).toBeInTheDocument();
+      expect(screen.getByTestId('wallet-item-row-w-3')).toBeInTheDocument();
+    });
+
+    it('renders item name, type, balance, currency, and created date', () => {
+      render(<WalletItemList {...defaultProps} />);
+      expect(screen.getByText('Stellar Lumens (XLM)')).toBeInTheDocument();
+      expect(screen.getByText('Native Asset')).toBeInTheDocument();
+      expect(screen.getByText('12,500 XLM')).toBeInTheDocument();
+      expect(screen.getByText('2026-01-15')).toBeInTheDocument();
+    });
+
+    it('renders the wallet address when present', () => {
+      render(<WalletItemList {...defaultProps} />);
+      expect(screen.getByText(ITEMS[0].address!)).toBeInTheDocument();
+    });
+
+    it('omits the address line when not present', () => {
+      render(<WalletItemList {...defaultProps} />);
+      const row = screen.getByTestId('wallet-item-row-w-2');
+      expect(row.querySelector('.font-mono')).not.toBeInTheDocument();
+    });
+
+    it('renders the accessible table label', () => {
+      render(<WalletItemList {...defaultProps} />);
+      expect(screen.getByLabelText('Wallet items table')).toBeInTheDocument();
+    });
+  });
+
+  describe('status badge integration (a11y/wallet-71-contrast)', () => {
+    it('renders a StatusBadge (role="status") for each item, not a color-only pill', () => {
+      render(<WalletItemList {...defaultProps} />);
+      const statuses = screen.getAllByRole('status');
+      expect(statuses).toHaveLength(3);
+    });
+
+    it('exposes each status via an accessible label rather than color alone', () => {
+      render(<WalletItemList {...defaultProps} />);
+      expect(screen.getByLabelText('Status: Active')).toBeInTheDocument();
+      expect(screen.getByLabelText('Status: Pending')).toBeInTheDocument();
+      expect(screen.getByLabelText('Status: Archived')).toBeInTheDocument();
+    });
+
+    it('no longer renders the old color-only inline status pill classes (regression guard)', () => {
+      const { container } = render(<WalletItemList {...defaultProps} />);
+      expect(container.innerHTML).not.toMatch(/bg-(emerald|amber)-100/);
+    });
+  });
+
+  describe('selection', () => {
+    it('calls onToggleSelect with the item id when its checkbox is clicked', () => {
+      render(<WalletItemList {...defaultProps} />);
+      fireEvent.click(screen.getByTestId('select-item-checkbox-w-1'));
+      expect(defaultProps.onToggleSelect).toHaveBeenCalledWith('w-1');
+    });
+
+    it('checks the checkbox for a selected item', () => {
+      render(<WalletItemList {...defaultProps} selectedIds={new Set(['w-1'])} />);
+      expect(screen.getByTestId('select-item-checkbox-w-1')).toBeChecked();
+      expect(screen.getByTestId('select-item-checkbox-w-2')).not.toBeChecked();
+    });
+
+    it('marks a selected row with aria-selected="true" (forced-colors-safe indicator)', () => {
+      render(<WalletItemList {...defaultProps} selectedIds={new Set(['w-1'])} />);
+      expect(screen.getByTestId('wallet-item-row-w-1')).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByTestId('wallet-item-row-w-2')).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('calls onToggleSelectAll when the header checkbox is clicked', () => {
+      render(<WalletItemList {...defaultProps} />);
+      fireEvent.click(screen.getByTestId('select-all-checkbox'));
+      expect(defaultProps.onToggleSelectAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('checks the select-all checkbox when every item is selected', () => {
+      render(<WalletItemList {...defaultProps} selectedIds={new Set(['w-1', 'w-2', 'w-3'])} />);
+      expect(screen.getByTestId('select-all-checkbox')).toBeChecked();
+    });
+
+    it('sets the select-all checkbox to indeterminate when some (not all) items are selected', () => {
+      render(<WalletItemList {...defaultProps} selectedIds={new Set(['w-1'])} />);
+      const checkbox = screen.getByTestId('select-all-checkbox') as HTMLInputElement;
+      expect(checkbox.indeterminate).toBe(true);
+    });
+
+    it('clears indeterminate when selection becomes empty', () => {
+      const { rerender } = render(
+        <WalletItemList {...defaultProps} selectedIds={new Set(['w-1'])} />
+      );
+      rerender(<WalletItemList {...defaultProps} selectedIds={new Set()} />);
+      const checkbox = screen.getByTestId('select-all-checkbox') as HTMLInputElement;
+      expect(checkbox.indeterminate).toBe(false);
+    });
+  });
+
+  describe('delete action', () => {
+    it('renders a delete button per row when onDeleteItem is provided', () => {
+      render(<WalletItemList {...defaultProps} />);
+      expect(screen.getByLabelText('Delete Stellar Lumens (XLM)')).toBeInTheDocument();
+    });
+
+    it('calls onDeleteItem with the item id when clicked', () => {
+      render(<WalletItemList {...defaultProps} />);
+      fireEvent.click(screen.getByLabelText('Delete Stellar Lumens (XLM)'));
+      expect(defaultProps.onDeleteItem).toHaveBeenCalledWith('w-1');
+    });
+
+    it('omits the delete button entirely when onDeleteItem is not provided', () => {
+      render(<WalletItemList {...defaultProps} onDeleteItem={undefined} />);
+      expect(screen.queryByLabelText('Delete Stellar Lumens (XLM)')).not.toBeInTheDocument();
+    });
+
+    // a11y/wallet-71-contrast: Tailwind's `outline-none` sets outline-color
+    // to transparent (not outline-style: none) -- forced-colors mode
+    // explicitly preserves `transparent`, so the ring stayed invisible.
+    // The box-shadow-based `ring` is also stripped under forced-colors.
+    // Regression guard: `focus:outline-none` must never come back.
+    it('uses a real focus-visible outline instead of outline-none + ring (forced-colors regression guard)', () => {
+      render(<WalletItemList {...defaultProps} />);
+      const deleteBtn = screen.getByLabelText('Delete Stellar Lumens (XLM)');
+      expect(deleteBtn.className).not.toMatch(/focus:outline-none/);
+      expect(deleteBtn.className).toContain('focus-visible:outline');
+      expect(deleteBtn.className).toContain('focus-visible:outline-2');
+      expect(deleteBtn.className).toContain('focus-visible:outline-offset-2');
+      expect(deleteBtn.className).toContain('focus-visible:outline-rose-500');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has zero axe violations with no selection', async () => {
+      await testA11y(<WalletItemList {...defaultProps} />);
+    });
+
+    it('has zero axe violations with a partial selection (indeterminate select-all)', async () => {
+      await testA11y(<WalletItemList {...defaultProps} selectedIds={new Set(['w-1'])} />);
+    });
+
+    it('has zero axe violations with all items selected', async () => {
+      await testA11y(
+        <WalletItemList {...defaultProps} selectedIds={new Set(['w-1', 'w-2', 'w-3'])} />
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds high-contrast / forced-colors mode support to the wallet feature (`WalletBulkToolbar`, `WalletItemList`), fixing three real defects found during the audit rather than a cosmetic pass.

Closes #1018

## Defects found and fixed

1. **Invisible keyboard focus on the per-row delete button** (`WalletItemList.tsx`)
   The button used `focus:outline-none focus:ring-2 focus:ring-rose-500`. Tailwind's `outline-none` sets `outline-color: transparent` (not `outline-style: none`) — forced-colors mode explicitly preserves author-specified `transparent` rather than remapping it, so the outline stayed invisible. The box-shadow `ring` is separately stripped under forced-colors. **This control had zero visible focus indicator in high-contrast mode.** Fixed by switching to `focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500`, matching the already-correct pattern already used by `WalletBulkToolbar`'s buttons.

2. **Color-only status pills** (Active / Pending / Archived)
   The wallet table rendered its own inline pill with fixed Tailwind pastel backgrounds and no border — flattens to an indistinguishable chip under forced-colors. Replaced with the repo's existing shared `StatusBadge` component (`role="status"`, audited CSS-variable tokens, already covered by an existing global forced-colors border rule). Extended `StatusBadge`'s `StatusType` with a new `Archived` value and a neutral token pair, contrast-verified at **9.45:1** (light) / **9.85:1** (dark) — both well above WCAG AA's 4.5:1.

3. **Selection/toolbar boundaries conveyed by background tint alone**
   Selected rows had no `aria-selected` and only a translucent background; the toolbar container, its buttons (esp. the borderless Delete button), and its count pill relied on color alone for definition.

## Changes

- **`src/components/wallet/WalletItemList.tsx`**
  - Fixed the delete-button focus classes (see defect #1).
  - Replaced the inline color-only status pill with `<StatusBadge status={item.status} />`.
  - Added `aria-selected={isSelected}` to each row (also a genuine a11y improvement on its own — selection state was not previously exposed to assistive tech at all).
- **`src/components/StatusBadge.tsx`** — added `'Archived'` to `StatusType`, plus its color/icon map entries.
- **`src/app/globals.css`**
  - Added `--status-neutral-bg` / `--status-neutral-foreground` token pair (light + dark), contrast-verified.
  - Extended the existing `@media (forced-colors: active)` block with rules for `[role="toolbar"]`, toolbar buttons, `.wallet-count-badge`, and `tr[aria-selected='true']`.
- **`src/components/wallet/WalletBulkToolbar.tsx`** — added a `wallet-count-badge` class hook to the selected-count pill (inert in normal mode, used only as a forced-colors CSS selector).
- **`docs/components/Accessibility.md`** — new "Wallet — High-Contrast / Forced-Colors Support (issue #1018)" section, following the same documentation convention already established for Milestones' forced-colors work.

## Approach note

I followed the repo's own established convention for this exact kind of work (found via git history: the same pattern was previously used for Milestones' forced-colors support) rather than inventing a new one — raw CSS in `globals.css` under `@media (forced-colors: active)`, keyed off `role`/attribute selectors, documented in `Accessibility.md` with contrast ratios.

## No layout regression in normal mode

All forced-colors rules are scoped inside `@media (forced-colors: active)` and only take effect in that mode. The one visible normal-mode change: the wallet status pill now uses `StatusBadge`'s standard sizing (`px-3 py-1 text-sm` + icon) instead of the wallet's previous bespoke smaller pill (`px-2.5 py-0.5 text-xs`, no icon) — a deliberate, minor change to reuse the already-audited shared component instead of duplicating color logic. It does not affect the table's column layout.

## Test output

**New/impacted files only** (`WalletItemList.tsx`, `WalletBulkToolbar.tsx`, `StatusBadge.tsx`):
```
Test Suites: 3 passed, 3 total
Tests:       60 passed, 60 total
Snapshots:   7 passed, 7 total

------------------------|---------|----------|---------|---------|-------------------
File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------------------|---------|----------|---------|---------|-------------------
All files               |     100 |      100 |     100 |     100 |
 components             |     100 |      100 |     100 |     100 |
  StatusBadge.tsx        |     100 |      100 |     100 |     100 |
 components/wallet       |     100 |      100 |     100 |     100 |
  WalletBulkToolbar.tsx  |     100 |      100 |     100 |     100 |
  WalletItemList.tsx     |     100 |      100 |     100 |     100 |
------------------------|---------|----------|---------|---------|-------------------
```

**Full repo suite — before/after regression check** (this component previously had no test file at all, so I A/B'd the *entire* 1772-test suite via `git stash` rather than trusting a partial run):

| | Before (baseline) | After (this PR) |
|---|---|---|
| Test suites | 46 failed / 73 passed / 119 total | 45 failed / 74 passed / 119 total |
| Tests | 288 failed / 1477 passed / 1765 total | 283 failed / 1489 passed / 1772 total |

The failing-suite list is **byte-identical** between the two runs except for `WalletItemList.test.tsx` itself (which didn't exist in the baseline). This repo has substantial pre-existing, unrelated breakage — ~45 suites with broken JSX, undefined vars, and parsing errors (matches the repo's own `CI_BUILD_FIXES.md` / `TEST_FIX_SUMMARY.md`). **This PR introduces zero new failures anywhere in the suite.**

## `npm run lint`

Fails with 104 pre-existing errors across ~20 files this PR does not touch (parsing errors in `layout.tsx`, `reputation/page.tsx`, `contracts/page.tsx`; undefined vars in `MilestonesList.tsx`, `ConfirmDialog.tsx`, `toast-provider.tsx`, etc.). Confirmed via `git stash` that every one of these errors exists on a clean checkout — **zero lint errors in any file this PR modifies** (`StatusBadge.tsx`, `WalletBulkToolbar.tsx`, `WalletItemList.tsx`, their tests, or `globals.css`).

## `npm run build`

Fails identically on a clean baseline checkout — a pre-existing, unrelated error (`ReputationLoadingClient` export mismatch in `src/app/reputation/loading.tsx`). Not caused by this change; confirmed via the same `git stash` A/B comparison.

## Out of scope

- Fixing the ~104 pre-existing lint errors and the build-blocking `reputation/loading.tsx` export mismatch — real, pre-existing defects, but unrelated to wallet contrast/focus and would substantially expand this PR's diff. Flagging here rather than silently leaving them undocumented; happy to open follow-up issues if maintainers want them tracked separately.