### PR TITLE
test(milestones): scope per-milestone title queries to the list region

### DIFF
--- a/src/app/milestones/__tests__/page.test.tsx
+++ b/src/app/milestones/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, within, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MilestonesPage, { SAMPLE_MILESTONES, SAMPLE_DISMISSED_KEY } from '../page';
 import { listMilestones, saveMilestone } from '@/lib/repository';
@@ -71,6 +71,22 @@ async function renderPage() {
   const result = render(<MilestonesPage />);
   await act(async () => {});
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// List-scoped query helpers
+//
+// MilestonesList renders a focused/workable region (aria-labelledby
+// "milestones-title milestones-count") that contains every milestone <article>.
+// The due-soon reminder banner lives outside this region in the same
+// <section>, so unscoped `screen.getByText(<title>)` would multiply-match any
+// milestone whose title is also surfaced in the reminder (notably "Active
+// Work" in the shared fixtures). Scope every per-milestone title assertion to
+// this region via `within(...)` so the tests mean what they actually say.
+// ---------------------------------------------------------------------------
+const MILESTONES_LIST_REGION_NAME = /milestones\s+\d+\s+total/i;
+function getMilestonesListRegion(): HTMLElement {
+  return screen.getByRole('region', { name: MILESTONES_LIST_REGION_NAME });
 }
 
 // ---------------------------------------------------------------------------
@@ -202,11 +218,12 @@ describe('MilestoneFilter — filtering behaviour', () => {
     await renderPage();
 
     await waitFor(() => {
-      expect(screen.getByText('Active Work')).toBeInTheDocument();
-      expect(screen.getByText('Pending Task')).toBeInTheDocument();
-      expect(screen.getByText('Done Milestone')).toBeInTheDocument();
-      expect(screen.getByText('Settled Payment')).toBeInTheDocument();
-      expect(screen.getByText('Under Dispute')).toBeInTheDocument();
+      const list = getMilestonesListRegion();
+      expect(within(list).getByText('Active Work')).toBeInTheDocument();
+      expect(within(list).getByText('Pending Task')).toBeInTheDocument();
+      expect(within(list).getByText('Done Milestone')).toBeInTheDocument();
+      expect(within(list).getByText('Settled Payment')).toBeInTheDocument();
+      expect(within(list).getByText('Under Dispute')).toBeInTheDocument();
     });
   });
 
@@ -217,11 +234,12 @@ describe('MilestoneFilter — filtering behaviour', () => {
     await user.click(screen.getByRole('radio', { name: 'Active' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Active Work')).toBeInTheDocument();
-      expect(screen.queryByText('Pending Task')).not.toBeInTheDocument();
-      expect(screen.queryByText('Done Milestone')).not.toBeInTheDocument();
-      expect(screen.queryByText('Settled Payment')).not.toBeInTheDocument();
-      expect(screen.queryByText('Under Dispute')).not.toBeInTheDocument();
+      const list = getMilestonesListRegion();
+      expect(within(list).getByText('Active Work')).toBeInTheDocument();
+      expect(within(list).queryByText('Pending Task')).not.toBeInTheDocument();
+      expect(within(list).queryByText('Done Milestone')).not.toBeInTheDocument();
+      expect(within(list).queryByText('Settled Payment')).not.toBeInTheDocument();
+      expect(within(list).queryByText('Under Dispute')).not.toBeInTheDocument();
     });
   });
 
@@ -232,9 +250,10 @@ describe('MilestoneFilter — filtering behaviour', () => {
     await user.click(screen.getByRole('radio', { name: 'Pending' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Pending Task')).toBeInTheDocument();
-      expect(screen.queryByText('Active Work')).not.toBeInTheDocument();
-      expect(screen.queryByText('Done Milestone')).not.toBeInTheDocument();
+      const list = getMilestonesListRegion();
+      expect(within(list).getByText('Pending Task')).toBeInTheDocument();
+      expect(within(list).queryByText('Active Work')).not.toBeInTheDocument();
+      expect(within(list).queryByText('Done Milestone')).not.toBeInTheDocument();
     });
   });
 
@@ -245,9 +264,10 @@ describe('MilestoneFilter — filtering behaviour', () => {
     await user.click(screen.getByRole('radio', { name: 'Completed' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Done Milestone')).toBeInTheDocument();
-      expect(screen.queryByText('Active Work')).not.toBeInTheDocument();
-      expect(screen.queryByText('Pending Task')).not.toBeInTheDocument();
+      const list = getMilestonesListRegion();
+      expect(within(list).getByText('Done Milestone')).toBeInTheDocument();
+      expect(within(list).queryByText('Active Work')).not.toBeInTheDocument();
+      expect(within(list).queryByText('Pending Task')).not.toBeInTheDocument();
     });
   });
 
@@ -258,9 +278,10 @@ describe('MilestoneFilter — filtering behaviour', () => {
     await user.click(screen.getByRole('radio', { name: 'Paid' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Settled Payment')).toBeInTheDocument();
-      expect(screen.queryByText('Active Work')).not.toBeInTheDocument();
-      expect(screen.queryByText('Under Dispute')).not.toBeInTheDocument();
+      const list = getMilestonesListRegion();
+      expect(within(list).getByText('Settled Payment')).toBeInTheDocument();
+      expect(within(list).queryByText('Active Work')).not.toBeInTheDocument();
+      expect(within(list).queryByText('Under Dispute')).not.toBeInTheDocument();
     });
   });
 
@@ -271,9 +292,10 @@ describe('MilestoneFilter — filtering behaviour', () => {
     await user.click(screen.getByRole('radio', { name: 'Disputed' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Under Dispute')).toBeInTheDocument();
-      expect(screen.queryByText('Active Work')).not.toBeInTheDocument();
-      expect(screen.queryByText('Pending Task')).not.toBeInTheDocument();
+      const list = getMilestonesListRegion();
+      expect(within(list).getByText('Under Dispute')).toBeInTheDocument();
+      expect(within(list).queryByText('Active Work')).not.toBeInTheDocument();
+      expect(within(list).queryByText('Pending Task')).not.toBeInTheDocument();
     });
   });
 
@@ -283,21 +305,25 @@ describe('MilestoneFilter — filtering behaviour', () => {
 
     // Pending
     await user.click(screen.getByRole('radio', { name: 'Pending' }));
-    await waitFor(() => expect(screen.getByText('Pending Task')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(within(getMilestonesListRegion()).getByText('Pending Task')).toBeInTheDocument(),
+    );
 
     // Disputed
     await user.click(screen.getByRole('radio', { name: 'Disputed' }));
     await waitFor(() => {
-      expect(screen.getByText('Under Dispute')).toBeInTheDocument();
-      expect(screen.queryByText('Pending Task')).not.toBeInTheDocument();
+      const list = getMilestonesListRegion();
+      expect(within(list).getByText('Under Dispute')).toBeInTheDocument();
+      expect(within(list).queryByText('Pending Task')).not.toBeInTheDocument();
     });
 
     // Back to All
     await user.click(screen.getByRole('radio', { name: 'All' }));
     await waitFor(() => {
-      expect(screen.getByText('Active Work')).toBeInTheDocument();
-      expect(screen.getByText('Pending Task')).toBeInTheDocument();
-      expect(screen.getByText('Under Dispute')).toBeInTheDocument();
+      const list = getMilestonesListRegion();
+      expect(within(list).getByText('Active Work')).toBeInTheDocument();
+      expect(within(list).getByText('Pending Task')).toBeInTheDocument();
+      expect(within(list).getByText('Under Dispute')).toBeInTheDocument();
     });
   });
 });
@@ -546,8 +572,9 @@ describe('"Active" filter — edge cases', () => {
     await user.click(screen.getByRole('radio', { name: 'Active' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Active Work')).toBeInTheDocument();
-      expect(screen.queryByText('Pending Task')).not.toBeInTheDocument();
+      const list = getMilestonesListRegion();
+      expect(within(list).getByText('Active Work')).toBeInTheDocument();
+      expect(within(list).queryByText('Pending Task')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
closes #486 
Fixes the four pre-existing `waitFor` timeouts in `src/app/milestones/__tests__/page.test.tsx` by scoping per-milestone title queries to the milestones list region. **Strictly test-only** — no production change.

## Root cause

The shared fixture `mixedMilestones` (in `src/app/milestones/page.test.tsx`) includes item `m-1` "Active Work" with `dueDate '2026-08-01'` (≈ 2 days from "today" at the time of writing). `MilestonesList` renders a due-soon reminder banner that surfaces that title as an `<a href="#milestone-m-1">Active Work</a>` link inside the same `<section>` as each rendered `<article>` milestone card.

That means after any click on a status filter:

- `screen.getByText('Active Work')` matches more than one element (the card title under the list region AND the reminder link outside it) and throws — `waitFor` then times out at its 1000 ms default.
- For non-Active filters (Pending / Completed / Paid / Disputed), `screen.queryByText('Active Work')` finds 1 match (the reminder link), so its `not.toBeInTheDocument()` assertion fails.
- The cycling-through-filters test fails at every step that depends on `getByText('…')` against an item whose title also leaks into the reminder.

## Fix

Introduced one tiny helper at the top of the test file:

```ts
const MILESTONES_LIST_REGION_NAME = /milestones\s+\d+\s+total/i;
function getMilestonesListRegion(): HTMLElement {
  return screen.getByRole('region', { name: MILESTONES_LIST_REGION_NAME });
}
```

That `role="region"` is the inner scrollable container in `MilestonesList` whose accessible name is built by `aria-labelledby="milestones-title milestones-count"` (concatenates the visible `<h2>Milestones</h2>` heading with the live `<span>X total</span>` count). Every per-milestone title query in the affected tests now goes through `within(getMilestonesListRegion())`. The due-soon reminder banner is correctly **outside** that region, so it remains a live product feature and is not affected.

`within` was added to the existing `@testing-library/react` import. The helper is one line of body and the regex matches the existing accessible-name format.

## Outcomes

- Targeted test file: **47 / 47 passed** (was 4 failed → 0 failed).
- `npm run lint`: 0 errors / 0 warnings.
- The four previously failing tests in section 3 (*"Active" filter shows only Active milestones*, etc.) and the affected case in section 7 (*shows Active milestones when Active radio is clicked*) are now green.
- The `*.tsx` source files (`page.tsx`, `MilestonesList`, `MilestoneFilter`, etc.) are intentionally **not** touched.

## Diff scope

| Path | +/- |
| --- | --- |
| `src/app/milestones/__tests__/page.test.tsx` | +58 / -31 |

Single file, test-only.

## Followups considered but not applied

- Could add a regression test asserting the due-soon reminder is still present in the unfiltered view, so future scoping-by-region changes do not accidentally suppress the reminder. Left for a future PR to keep this one minimal.
- Could collapse the duplicated `const list = getMilestonesListRegion(); within(list).…` block per test into a single `expect(...within(getMilestonesListRegion())).…` expression, but the explicit two-line form is far more diffable for reviewers.

## Checklist

- [x] Each canonical test case now exercises what it actually means (titles are scoped to the list, not the whole document).
- [x] Lint clean.
- [x] No production / UX change.
- [x] Diff is single-file, test-only.
