### PR TITLE
fix: add explicit aria-label to HeaderActions icon-only toggle

### DIFF
--- a/src/components/HeaderActions.tsx
+++ b/src/components/HeaderActions.tsx
@@ -62,6 +62,7 @@ export default function HeaderActions(): React.JSX.Element {
           type="button"
           aria-expanded={isOpen ? 'true' : 'false'}
           aria-controls={menuId}
+          aria-label={isOpen ? 'Close wallet actions' : 'Open wallet actions'}
           onClick={handleToggle}
           className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white sm:hidden"
         >

--- a/src/components/__tests__/HeaderActions.test.tsx
+++ b/src/components/__tests__/HeaderActions.test.tsx
@@ -74,6 +74,7 @@ describe('HeaderActions — initial render', () => {
     const toggle = getToggle();
     expect(toggle).toBeInTheDocument();
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute('aria-label', 'Open wallet actions');
   });
 
   it('renders the controlled wallet-actions panel', () => {
@@ -142,6 +143,7 @@ describe('HeaderActions — ARIA attribute wiring', () => {
     // After opening, find toggle by updated label
     const toggle = screen.getByRole('button', { name: /close wallet actions/i });
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(toggle).toHaveAttribute('aria-label', 'Close wallet actions');
   });
 
   it('aria-expanded returns to "false" after the second click', () => {


### PR DESCRIPTION
## Description

<!-- Summarize the changes in this PR and the motivation behind them. -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`
closes #861 
