### PR TITLE
feat(milestones): support offline editing with queued sync on reconnect

### DIFF
--- a/docs/offline-milestones.md
+++ b/docs/offline-milestones.md
@@ -1,0 +1,101 @@
+# Offline Milestones
+
+TalentTrust is a fully client-side app: milestone data is persisted in `localStorage` via `src/lib/repository.ts` (there is no backend). The `/milestones` route supports working while the browser is **offline** by deferring mutations to a persistent queue that flushes automatically on reconnect.
+
+This document explains the offline behavior, the queue, conflict handling, and how error codes map to the safe, user-facing messages shown to users.
+
+---
+
+## Behaviour overview
+
+- **Online** → a milestone mutation (`create` / `update` / `delete` / `status`) is applied immediately to the repository, exactly as before this feature existed.
+- **Offline** → the mutation is captured into a **persistent queue** (backed by `safeStorage`); the authoritative store is left untouched. The optimistic change is kept locally so the board still reflects the user's intent.
+- **Reconnect** → the queue is flushed to the store **in the exact order it was recorded**, and the page re-reads authoritative repository state.
+
+The `window.online` event and the mount are the two triggers that flush+reconcile. A module-level flush lock guarantees only one flush runs at a time, so a burst of `online` events never replays a mutation twice.
+
+---
+
+## Architecture
+
+```
+page.tsx
+  │  useOfflineMilestones(onReconcile)
+  │    ├── useOnlineStatus()          → isOnline boolean
+  │    └── mutate(mutation)           → online ? applyImmediate : enqueue
+  └── useOfflineMilestones → coordinator (offlineMilestoneCoordinator.ts)
+         ├── applyImmediate()         online path → write straight to repository
+         ├── enqueue()                offline path → offlineMilestoneQueue.enqueueMutation()
+         └── flushPending()           reconnect → offlineMilestoneQueue.flushQueue()
+                                        + returns reconciled flag for page to re-read
+```
+
+### Files
+
+| File | Role |
+|------|------|
+| `src/lib/offlineMilestoneQueue.ts` | Persistent mutation queue: persistence, replay, flush lock, error normalization |
+| `src/lib/offlineMilestoneCoordinator.ts` | Connectivity decision seam the page calls (online/offline/reconnect) |
+| `src/hooks/useOfflineMilestones.ts` | React hook wiring `useOnlineStatus` to the coordinator and the page |
+| `src/hooks/useOnlineStatus.ts` | Shared, hydration-safe browser online/offline detection |
+
+---
+
+## The queue
+
+Every queued mutation carries a stable `id` generated at enqueue time (`createMutationId()` → `crypto.randomUUID` with a fallback).
+
+Because `MilestoneCreationForm` derives milestone `id`s from title + timestamp, `create` is made **idempotent on replay**: it first checks whether a milestone with that id already exists before writing, eliminating duplicate creates if a flush was interrupted between applying a write and persisting its removal.
+
+**Removal ordering:** a mutation is removed from the persistent queue *only after* its repository write succeeds. A crash mid-flush can therefore never cause a mutation to be lost or applied twice.
+
+The queue is capped at `MAX_QUEUED_MUTATIONS` (200). Beyond that, enqueues are rejected with a stable persistence error.
+
+---
+
+## Conflict handling
+
+Replaying an `update` goes through `upsertMilestone`'s version guard. If the authoritative store holds a *newer* version than the one the offline edit was based on (`baseVersion`), the write is rejected as stale. That becomes a **`MUTATION_CONFLICT`** error and is surfaced to the user — the mutation **stays in the queue** so it is never silently dropped.
+
+When a mutation fails during replay, processing stops there (later mutations may depend on it, so ordering is preserved). The failed mutation remains queued and is reported via the flush result's `failed` errors.
+
+---
+
+## Error codes → user messages
+
+Failures are normalized into `MilestoneMutationError` objects with a stable `code` and a `retryable` flag. UI callers map codes to safe, user-facing messages (never raw exceptions or stack traces). Below is the canonical mapping used across flush/coordinator messages.
+
+### `MUTATION_CONFLICT`
+- `retryable`: `false`
+- **User message:** `"One of your offline changes conflicts with newer data. Review your milestones."`
+
+### `MUTATION_REPLAY_FAILED`
+- `retryable`: `true` by default; `false` when the target milestone no longer exists
+- **User message:** `"Some offline changes could not be synchronized. Review the affected milestones."` (retryable) / `"This milestone no longer exists and could not be updated."` (target missing)
+
+### `OFFLINE_QUEUE_PERSIST_FAILED`
+- `retryable`: `true`
+- **User message:** `"Your change could not be saved offline. Please try again."`, or `"Too many pending offline changes. Connect to the internet to continue."` when the queue cap is hit
+
+### `OFFLINE_QUEUE_INVALID_ENTRY`
+- Malformed/corrupt persisted data is **discarded safely** on load; the queue falls back to only the valid entries. Never crashes.
+
+### `RECONCILIATION_FAILED` / `QUEUE_FLUSH_IN_PROGRESS`
+- Internal markers; the flush lock turns a duplicate/concurrent flush into a harmless no-op (`{ flushed: 0 }`) rather than an error.
+
+---
+
+## User-facing notices
+
+The page renders an amber banner (`data-testid="offline-status-banner"`) when any of the following is true: the browser is offline, a flush is in progress, there are pending changes, or a notice is set. Messages are intentionally brief and safe:
+
+| Case | Message |
+|------|---------|
+| Offline (browser) | `"You're offline — milestone changes are saved on this device and will sync automatically when you reconnect."` |
+| Flush in progress | `"Synchronizing your pending milestones…"` |
+| Offline change saved to queue | `"Saved offline — will synchronize when you are back online."` |
+| Flush succeeded (n > 0) | `"Your offline changes were synchronized."` |
+| Flush failed with a conflict | `"One of your offline changes conflicts with newer data. Review your milestones."` |
+| Flush failed (other) | `"Some offline changes could not be synchronized. Review the affected milestones."` |
+
+Transient notices auto-clear after ~6 seconds so stale messages do not linger.

--- a/src/app/milestones/page.tsx
+++ b/src/app/milestones/page.tsx
@@ -15,11 +15,12 @@ import MilestoneFilter, {
   type MilestoneStatusFilter,
 } from '../../components/milestones/MilestoneFilter';
 import { MilestoneCreationForm } from '../../components/milestones/MilestoneCreationForm';
-import { listMilestones, saveMilestone, updateMilestone } from '@/lib/repository';
+import { listMilestones } from '@/lib/repository';
 import { getItem, setItem } from '@/lib/safeStorage';
 import { useToast } from '@/components/toast/toast-provider';
 import SafeBoundary from '@/components/SafeBoundary';
 import { downloadMilestonesICS } from '@/lib/icsExport';
+import { useOfflineMilestones } from '@/hooks/useOfflineMilestones';
 import { SAMPLE_MILESTONES, SAMPLE_DISMISSED_KEY } from './constants';
 import type { Milestone } from '@/types/domain';
 
@@ -66,6 +67,9 @@ const MilestonesContent: React.FC = () => {
   );
   const [showForm, setShowForm] = useState(false);
   const { showError } = useToast();
+  const offline = useOfflineMilestones(() => {
+    setMilestones(listMilestones());
+  });
 
   useEffect(() => {
     setStatusFilter(getValidStatus(searchParams.get('status')));
@@ -156,33 +160,52 @@ const MilestonesContent: React.FC = () => {
     setShowForm(true);
   }, []);
 
-  const handleSubmitMilestone = useCallback((milestone: Milestone) => {
-    setShowForm(false);
-    saveMilestone(milestone);
-    setIsDismissed(true);
-    setMilestones((prev) => [...prev, milestone]);
-  }, []);
+  const handleSubmitMilestone = useCallback(
+    (milestone: Milestone) => {
+      setShowForm(false);
+      const accepted = offline.mutate({ kind: 'create', milestone });
+      if (accepted) {
+        setIsDismissed(true);
+        // Optimistic local update; reconciliation re-reads authoritative state
+        // when the change is applied online.
+        setMilestones((prev) => [...prev, milestone]);
+      } else {
+        showError({
+          title: 'Unable to save milestone',
+          description: 'Your milestone could not be saved right now. Please try again.',
+        });
+      }
+    },
+    [offline, showError],
+  );
   const handleCancelForm = useCallback(() => {
     setShowForm(false);
   }, []);
 
   const handleUpdateMilestone = useCallback(
     (id: string, patch: Partial<Milestone>): boolean => {
-      try {
-        updateMilestone(id, patch);
+      const current = milestones.find((m) => m.id === id);
+      const accepted = offline.mutate({
+        kind: 'update',
+        targetId: id,
+        patch,
+        baseVersion: current?.version,
+      });
+      if (accepted) {
+        // Optimistic local update; reconciliation re-reads actual stored state
+        // once the change is applied.
         setMilestones((prev) =>
           prev.map((item) => (item.id === id ? { ...item, ...patch } : item)),
         );
         return true;
-      } catch {
-        showError({
-          title: 'Unable to update milestone',
-          description: 'Your milestone could not be saved. Please try again.',
-        });
-        return false;
       }
+      showError({
+        title: 'Unable to update milestone',
+        description: 'Your milestone could not be saved. Please try again.',
+      });
+      return false;
     },
-    [showError],
+    [milestones, offline, showError],
   );
 
   return (
@@ -190,6 +213,31 @@ const MilestonesContent: React.FC = () => {
       <h1 ref={headingRef} tabIndex={-1} className="text-2xl font-bold mb-6 focus:outline-none">
         Milestones
       </h1>
+
+      {(offline.isFlushing || offline.notice || offline.pendingCount > 0) && (
+        <div
+          data-testid="offline-status-banner"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="mb-6 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 shadow-sm dark:border-amber-500/20 dark:bg-amber-500/5 dark:text-amber-200"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <p className="font-medium">
+              {!offline.isOnline
+                ? 'You’re offline — milestone changes are saved on this device and will sync automatically when you reconnect.'
+                : offline.isFlushing
+                  ? 'Synchronizing your pending milestones…'
+                  : offline.notice}
+            </p>
+            {!offline.isOnline && offline.pendingCount > 0 && (
+              <span className="ml-2 shrink-0 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-900 dark:bg-amber-500/20 dark:text-amber-200">
+                {offline.pendingCount} pending
+              </span>
+            )}
+          </div>
+        </div>
+      )}
 
       {showSampleBanner && (
         <div

--- a/src/hooks/__tests__/useOnlineStatus.test.ts
+++ b/src/hooks/__tests__/useOnlineStatus.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for `useOnlineStatus` (`src/hooks/useOnlineStatus.ts`).
+ *
+ * Covers the issue's connectivity-detection requirements:
+ * - initial online and offline states
+ * - online/offline event transitions
+ * - event listeners cleaned up on unmount (no leaks / no duplicate listeners)
+ * - shared listener set, so many consumers never duplicate window listeners
+ * - hydration-safe fallback when `navigator.onLine` is unavailable
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useOnlineStatus, resetOnlineStatusForTests } from '../useOnlineStatus';
+
+/** Re-sets navigator.onLine to a value and fires the matching window event. */
+function setOnline(value: boolean): void {
+  Object.defineProperty(navigator, 'onLine', {
+    value,
+    configurable: true,
+  });
+  window.dispatchEvent(new Event(value ? 'online' : 'offline'));
+}
+
+describe('useOnlineStatus', () => {
+  let onLineGetter: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    onLineGetter = Object.getOwnPropertyDescriptor(navigator, 'onLine');
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+    resetOnlineStatusForTests();
+  });
+
+  afterEach(() => {
+    if (onLineGetter) {
+      Object.defineProperty(navigator, 'onLine', onLineGetter);
+    }
+  });
+
+  it('reports the initial online state', () => {
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+  });
+
+  it('reports the initial offline state', () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    const { result } = renderHook(() => useOnlineStatus());
+    act(() => {});
+    expect(result.current).toBe(false);
+  });
+
+  it('falls back to online when navigator.onLine is unavailable', () => {
+    Object.defineProperty(navigator, 'onLine', { value: undefined, configurable: true });
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+  });
+
+  it('transitions to offline on the window offline event', () => {
+    const { result } = renderHook(() => useOnlineStatus());
+    act(() => setOnline(false));
+    expect(result.current).toBe(false);
+  });
+
+  it('transitions back to online on the window online event', () => {
+    setOnline(false);
+    const { result } = renderHook(() => useOnlineStatus());
+    act(() => setOnline(true));
+    expect(result.current).toBe(true);
+  });
+
+  it('does not duplicate window listeners across multiple consumers', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+
+    const first = renderHook(() => useOnlineStatus());
+    const second = renderHook(() => useOnlineStatus());
+
+    // Only ONE shared listener per event type, regardless of consumer count.
+    const onlineCalls = addSpy.mock.calls.filter(([event]) => event === 'online').length;
+    const offlineCalls = addSpy.mock.calls.filter(([event]) => event === 'offline').length;
+    expect(onlineCalls).toBe(1);
+    expect(offlineCalls).toBe(1);
+
+    first.unmount();
+    // Unmounting one consumer must not tear down the shared listener.
+    act(() => setOnline(false));
+    expect(second.result.current).toBe(false);
+
+    second.unmount();
+    addSpy.mockRestore();
+  });
+
+  it('cleans up window listeners when the last consumer unmounts', () => {
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useOnlineStatus());
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('online', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('offline', expect.any(Function));
+
+    removeSpy.mockRestore();
+  });
+
+  it('re-syncs with the real connection state once mounted after an initial render', () => {
+    // Simulate a client that loaded while actually offline even though the first
+    // render (SSR default) is online: after mount it must reflect the real state.
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+    const { result, rerender } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    act(() => {});
+    rerender();
+    // The change is picked up via the shared listener, not a forced re-read.
+    act(() => setOnline(false));
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useOfflineMilestones.ts
+++ b/src/hooks/useOfflineMilestones.ts
@@ -1,0 +1,142 @@
+/**
+ * @file useOfflineMilestones.ts
+ *
+ * Wires {@link useOnlineStatus} to the offline milestone mutation queue so the
+ * milestones page can:
+ *
+ * - **Online:** apply mutations immediately to the repository (existing
+ *   behaviour unchanged).
+ * - **Offline:** queue mutations instead of writing to the store, keep the
+ *   optimistic change locally, and persist the queue across reloads.
+ * - **Reconnect:** flush the queue in order (guarded against duplicate flushes)
+ *   and reconcile the UI with authoritative repository state via
+ *   `onReconcile`.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
+import {
+  applyImmediate,
+  enqueue,
+  flushPending,
+  currentPendingCount,
+  type MutateInput,
+  type OfflineMilestoneSnapshot,
+} from '@/lib/offlineMilestoneCoordinator';
+
+export type { MutateInput, OfflineMilestoneSnapshot };
+export type { QueuedMilestoneMutation } from '@/lib/offlineMilestoneQueue';
+
+export type OfflineMilestoneResult = {
+  /** Whether the browser is currently online. */
+  isOnline: boolean;
+  /** Number of mutations waiting in the offline queue. */
+  pendingCount: number;
+  /** True while the queued mutations are being flushed to the store. */
+  isFlushing: boolean;
+  /** Most recent user-facing notice about queued/flushed/conflicted changes. */
+  notice: string;
+  /** Re-reads authoritative repository state into the page's list. */
+  reconcile: () => void;
+  /**
+   * Route a milestone mutation.
+   * - Online: applies it immediately to the store.
+   * - Offline: enqueues it so it flushes on reconnect.
+   *
+   * @returns `true` when the change was accepted (applied online or queued).
+   */
+  mutate: (mutation: MutateInput) => boolean;
+};
+
+/** Maps a flush result to a safe user-facing message (never leaks internals). */
+function noticeFor(snapshot: OfflineMilestoneSnapshot): string {
+  return snapshot.userMessage || '';
+}
+
+/**
+ * @param onReconcile  Invoked whenever authoritative repository state changes
+ *   (after a flush or an immediate online write) so the page can re-read and
+ *   re-render from `listMilestones()`.
+ */
+export function useOfflineMilestones(
+  onReconcile: () => void,
+): OfflineMilestoneResult {
+  const isOnline = useOnlineStatus();
+  const [pendingCount, setPendingCount] = useState(currentPendingCount);
+  const [isFlushing, setIsFlushing] = useState(false);
+  const [notice, setNotice] = useState('');
+  const reconcileRef = useLatest(onReconcile);
+
+  const reconcile = useCallback(() => {
+    reconcileRef.current();
+  }, []);
+
+  const handleFlushResult = useCallback((result: OfflineMilestoneSnapshot) => {
+    setPendingCount(result.pending.length);
+    setIsFlushing(true);
+    setNotice(noticeFor(result));
+    if (result.reconciled) {
+      reconcileRef.current();
+    }
+    setIsFlushing(false);
+  }, []);
+
+  // On mount: restore the queue's persisted state. If the app starts online
+  // with a restored queue, flush + reconcile exactly once (safe under the
+  // coordinator's flush lock).
+  useEffect(() => {
+    setPendingCount(currentPendingCount());
+    if (isOnline) {
+      handleFlushResult(flushPending());
+    }
+  }, []);
+
+  // Flush + reconcile whenever the browser transitions back online.
+  useEffect(() => {
+    if (!isOnline) return;
+    handleFlushResult(flushPending());
+  }, [isOnline, handleFlushResult]);
+
+  const mutate = useCallback(
+    (mutation: MutateInput): boolean => {
+      const result = isOnline ? applyImmediate(mutation) : enqueue(mutation);
+      setPendingCount(result.pending.length);
+      setNotice(noticeFor(result));
+      if (result.reconciled) {
+        reconcileRef.current();
+      }
+      return result.accepted;
+    },
+    [isOnline],
+  );
+
+  // Clear transient notices automatically so stale messages don't linger.
+  useEffect(() => {
+    if (!notice) return;
+    const timer = window.setTimeout(() => setNotice(''), 6000);
+    return () => window.clearTimeout(timer);
+  }, [notice]);
+
+  const value = useMemo<OfflineMilestoneResult>(
+    () => ({
+      isOnline,
+      pendingCount,
+      isFlushing,
+      notice,
+      reconcile,
+      mutate,
+    }),
+    [isOnline, pendingCount, isFlushing, notice, reconcile, mutate],
+  );
+
+  return value;
+}
+
+/** Keeps a callback ref-identity stable without re-running effects. */
+function useLatest<T>(value: T): { current: T } {
+  const ref = useRef(value);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref;
+}

--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,113 @@
+/**
+ * @file useOnlineStatus.ts
+ *
+ * React hook exposing the current browser online/offline status.
+ *
+ * ## Behaviour
+ *
+ * - Reads the *initial* status from `navigator.onLine` in a hydration-safe way:
+ *   during server rendering it defaults to `true` (online) and only flips to a
+ *   real value once mounted on the client, avoiding hydration mismatches.
+ * - Subscribes to `window`'s `online` / `offline` events.
+ * - Cleans up its event listeners on unmount.
+ * - Shares a single set of listeners across all mounted callers, so many
+ *   consumers never duplicate event listeners.
+ * - Avoids unnecessary re-renders: state only changes when the connection state
+ *   actually changes.
+ *
+ * @returns `true` when the browser is online, `false` when offline.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+/** True when we're running on the client (used to defer to the real status). */
+const IS_BROWSER = typeof window !== 'undefined';
+
+/** `navigator.onLine` is undefined in some embedded/test environments; treat
+ *  missing as online so we never strand the UI in a false "offline" state. */
+function readInitialStatus(): boolean {
+  if (!IS_BROWSER) return true;
+  return typeof navigator !== 'undefined' && navigator.onLine !== undefined
+    ? navigator.onLine
+    : true;
+}
+
+// A single shared event subscription so multiple usages of this hook never
+// register duplicate listeners on `window`.
+let sharedListeners: Set<(online: boolean) => void> | null = null;
+
+function subscribe(listener: (online: boolean) => void): () => void {
+  if (sharedListeners === null) {
+    sharedListeners = new Set();
+    // Only the first subscriber attaches the window listeners; subsequent
+    // subscribers reuse the shared set so consumers never duplicate them.
+    if (IS_BROWSER) {
+      window.addEventListener('online', handleOnline);
+      window.addEventListener('offline', handleOffline);
+    }
+  }
+  sharedListeners.add(listener);
+
+  return () => {
+    sharedListeners?.delete(listener);
+    if (sharedListeners && sharedListeners.size === 0 && IS_BROWSER) {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+      // Allow the next consumer to re-register the window listeners fresh.
+      sharedListeners = null;
+    }
+  };
+}
+
+function handleOnline(): void {
+  notify(true);
+}
+
+function handleOffline(): void {
+  notify(false);
+}
+
+function notify(online: boolean): void {
+  if (!sharedListeners) return;
+  for (const listener of Array.from(sharedListeners)) {
+    listener(online);
+  }
+}
+
+/** Resets the shared listener state. Strictly for tests. */
+export function resetOnlineStatusForTests(): void {
+  if (sharedListeners) {
+    sharedListeners.clear();
+    if (IS_BROWSER) {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    }
+  }
+  sharedListeners = null;
+}
+
+export function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState<boolean>(readInitialStatus);
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    // On the client, re-sync with the true connection state once mounted. This
+    // catches the case where SSR rendered a default `true` but the load happened
+    // offline.
+    setIsOnline(readInitialStatus());
+
+    const unsubscribe = subscribe((online) => {
+      if (mountedRef.current) {
+        setIsOnline(online);
+      }
+    });
+
+    return () => {
+      mountedRef.current = false;
+      unsubscribe();
+    };
+  }, []);
+
+  return isOnline;
+}

--- a/src/lib/__tests__/offlineMilestoneCoordinator.test.ts
+++ b/src/lib/__tests__/offlineMilestoneCoordinator.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for the offline milestone coordinator
+ * (`src/lib/offlineMilestoneCoordinator.ts`).
+ *
+ * The coordinator is the seam the milestones page calls. It decides how a board
+ * mutation is handled based on connectivity (provided by the caller/hook):
+ * - `applyImmediate` → online: writes straight to the repository.
+ * - `enqueue` → offline: captures to the persistent queue, store untouched.
+ * - `flushPending` → reconnect: applies the queue then reports `reconciled`
+ *   only when a real flush ran.
+ *
+ * These tests exercise the real repository bound to jsdom localStorage, so they
+ * validate observable behaviour (the authoritative store changing) rather than
+ * implementation detail.
+ */
+
+import {
+  applyImmediate,
+  enqueue,
+  flushPending,
+  currentPendingCount,
+} from '../offlineMilestoneCoordinator';
+import {
+  listMilestones,
+  saveMilestone,
+  clearAppData,
+} from '../repository';
+import {
+  resetQueueCacheForTests,
+  clearPersistedQueue,
+  type QueuedMilestoneMutation,
+} from '../offlineMilestoneQueue';
+import type { Milestone } from '@/components/MilestonesList';
+
+function milestone(id: string, overrides: Partial<Milestone> = {}): Milestone {
+  return { id, title: id, status: 'Pending', payout: 10, currency: 'USD', ...overrides };
+}
+
+beforeEach(() => {
+  clearAppData();
+  window.localStorage.clear();
+  resetQueueCacheForTests();
+  clearPersistedQueue();
+});
+
+afterEach(() => {
+  clearAppData();
+  window.localStorage.clear();
+  resetQueueCacheForTests();
+  clearPersistedQueue();
+});
+
+describe('applyImmediate (online path)', () => {
+  it('writes a create straight to the repository', () => {
+    const snapshot = applyImmediate({ kind: 'create', milestone: milestone('m1') });
+    expect(snapshot.accepted).toBe(true);
+    expect(snapshot.reconciled).toBe(true);
+    expect(listMilestones().some((m) => m.id === 'm1')).toBe(true);
+  });
+
+  it('updates an existing milestone in place', () => {
+    saveMilestone(milestone('m1'));
+    const snapshot = applyImmediate({
+      kind: 'update',
+      targetId: 'm1',
+      patch: { title: 'Renamed' },
+    });
+    expect(snapshot.accepted).toBe(true);
+    expect(listMilestones().find((m) => m.id === 'm1')?.title).toBe('Renamed');
+  });
+
+  it('deletes matching milestones', () => {
+    saveMilestone(milestone('m1'));
+    applyImmediate({ kind: 'delete', ids: ['m1'] });
+    expect(listMilestones()).toHaveLength(0);
+  });
+
+  it('sets status on matching milestones', () => {
+    saveMilestone(milestone('m1'));
+    applyImmediate({ kind: 'status', ids: ['m1'], status: 'Completed' });
+    expect(listMilestones().find((m) => m.id === 'm1')?.status).toBe('Completed');
+  });
+});
+
+describe('enqueue (offline path)', () => {
+  it('captures the mutation and leaves the store untouched', () => {
+    const snapshot = enqueue({ kind: 'create', milestone: milestone('offline') });
+    expect(snapshot.accepted).toBe(true);
+    expect(snapshot.reconciled).toBe(false);
+    expect(snapshot.pending).toHaveLength(1);
+    // Nothing written to the authoritative store yet.
+    expect(listMilestones()).toHaveLength(0);
+    expect(currentPendingCount()).toBe(1);
+  });
+
+  it('returns a safe user-facing message when queued', () => {
+    const snapshot = enqueue({ kind: 'update', targetId: 'm1', patch: { title: 'x' } });
+    expect(snapshot.accepted).toBe(true);
+    expect(snapshot.userMessage).toContain('Saved offline');
+  });
+});
+
+describe('flushPending (reconnect path)', () => {
+  it('applies queued mutations and reports reconciliation', () => {
+    enqueue({ kind: 'create', milestone: milestone('a') });
+    enqueue({ kind: 'create', milestone: milestone('b') });
+
+    const snapshot = flushPending();
+    expect(snapshot.flushed).toHaveLength(2);
+    expect(snapshot.accepted).toBe(true);
+    expect(snapshot.reconciled).toBe(true);
+    expect(snapshot.failed).toHaveLength(0);
+    expect(snapshot.userMessage).toContain('synchronized');
+    expect(listMilestones().map((m) => m.id)).toEqual(['a', 'b']);
+    expect(currentPendingCount()).toBe(0);
+  });
+
+  it('never re-applies after a duplicate reconnect flush', () => {
+    enqueue({ kind: 'create', milestone: milestone('one') });
+    flushPending();
+    const again = flushPending();
+    expect(again.flushed).toHaveLength(0);
+    expect(again.reconciled).toBe(false);
+    expect(listMilestones().filter((m) => m.id === 'one')).toHaveLength(1);
+  });
+
+  it('is a no-op (no reconcile) when the queue is empty', () => {
+    const snapshot = flushPending();
+    expect(snapshot.flushed).toHaveLength(0);
+    expect(snapshot.reconciled).toBe(false);
+    expect(snapshot.accepted).toBe(false);
+  });
+
+  it('preserves a conflicted mutation and reports a conflict message', () => {
+    // Store holds a newer version than the queued offline edit.
+    saveMilestone({ ...milestone('c'), version: 3 });
+    resetQueueCacheForTests();
+    enqueue({
+      kind: 'update',
+      targetId: 'c',
+      patch: { title: 'older edit' },
+      // The edit was made when the store was at version 1.
+      baseVersion: 1,
+    });
+
+    const snapshot = flushPending();
+    expect(snapshot.flushed).toHaveLength(0);
+    expect(snapshot.failed).toHaveLength(1);
+    expect(snapshot.failed[0].code).toBe('MUTATION_CONFLICT');
+    expect(snapshot.userMessage).toContain('conflict');
+    // Not silently discarded.
+    expect(currentPendingCount()).toBe(1);
+    // Store preserved the newer version.
+    expect(listMilestones().find((m) => m.id === 'c')?.title).toBe('c');
+  });
+});
+
+describe('queue survives reload while still offline', () => {
+  it('restores and re-flushes after a cache reset (reopening the app)', () => {
+    enqueue({ kind: 'create', milestone: milestone('persist') });
+    // Simulate reload: clear in-memory cache and storage of repo, but the queue
+    // is stored separately and survives.
+    resetQueueCacheForTests();
+
+    const restored = flushPending();
+    expect(restored.flushed).toHaveLength(1);
+    expect(listMilestones().some((m) => m.id === 'persist')).toBe(true);
+  });
+});
+
+describe('queue shape', () => {
+  it('produces stable queued mutation records with unique ids', () => {
+    const a = enqueue({ kind: 'create', milestone: milestone('x') });
+    const b = enqueue({ kind: 'delete', ids: ['y'] });
+    const pendingA = a.pending as QueuedMilestoneMutation[];
+    const pendingB = b.pending as QueuedMilestoneMutation[];
+    expect(pendingA[0].id).toBeTruthy();
+    expect(pendingA[0].id).not.toBe(pendingB[1].id);
+    expect(pendingA[0].kind).toBe('create');
+    // After both enqueues the queue is [create, delete].
+    expect(pendingB).toHaveLength(2);
+    expect(pendingB[1].kind).toBe('delete');
+  });
+});

--- a/src/lib/__tests__/offlineMilestoneQueue.test.ts
+++ b/src/lib/__tests__/offlineMilestoneQueue.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Unit tests for the offline milestone queue (`src/lib/offlineMilestoneQueue.ts`).
+ *
+ * Covers the issue's required edge cases that live at the queue boundary:
+ * - enqueue + persistence across reload
+ * - malformed persisted data is discarded safely (never crashes)
+ * - flush runs in exact insertion order
+ * - duplicate flushes / the flush lock prevent double application
+ * - creates are idempotent (no duplicate milestones after interrupted replay)
+ * - version conflicts surface as `MUTATION_CONFLICT` and are not discarded
+ * - empty queue flush is a no-op
+ * - stable typed errors with retryable semantics
+ */
+
+import {
+  OFFLINE_QUEUE_ERROR_CODES,
+  enqueueMutation,
+  loadPendingQueue,
+  flushQueue,
+  resetQueueCacheForTests,
+  clearPersistedQueue,
+  applyMutation,
+  createMutationId,
+  OFFLINE_QUEUE_KEY,
+  MAX_QUEUED_MUTATIONS,
+  type QueuedMilestoneMutation,
+} from '../offlineMilestoneQueue';
+import type { Milestone } from '@/components/MilestonesList';
+import { setItem } from '../safeStorage';
+
+function makeMilestone(id: string, overrides: Partial<Milestone> = {}): Milestone {
+  return {
+    id,
+    title: `Milestone ${id}`,
+    status: 'Pending',
+    payout: 100,
+    currency: 'USD',
+    ...overrides,
+  };
+}
+
+function create(id: string): QueuedMilestoneMutation {
+  return {
+    id: createMutationId(),
+    kind: 'create',
+    milestone: makeMilestone(id),
+    createdAt: 1,
+  };
+}
+
+function update(
+  targetId: string,
+  patch: Partial<Milestone>,
+  baseVersion = 0,
+): QueuedMilestoneMutation {
+  return {
+    id: createMutationId(),
+    kind: 'update',
+    targetId,
+    patch,
+    baseVersion,
+    createdAt: 2,
+  };
+}
+
+function del(ids: string[]): QueuedMilestoneMutation {
+  return { id: createMutationId(), kind: 'delete', ids, createdAt: 3 };
+}
+
+function status(ids: string[], statusValue: Milestone['status']): QueuedMilestoneMutation {
+  return { id: createMutationId(), kind: 'status', ids, status: statusValue, createdAt: 4 };
+}
+
+// In-memory authoritative store used by the injected replay strategy.
+function makeStore(initial: Milestone[] = []) {
+  let milestones: Milestone[] = [...initial];
+  const seenCreates = new Set<string>(initial.map((m) => m.id));
+  const strategy = {
+    listMilestones: jest.fn(() => [...milestones]),
+    saveMilestone: jest.fn((m: Milestone) => {
+      if (!seenCreates.has(m.id)) {
+        milestones.push(m);
+        seenCreates.add(m.id);
+      }
+      return true;
+    }),
+    upsertMilestone: jest.fn((m: Milestone) => {
+      const existing = milestones.find((x) => x.id === m.id);
+      const existingVersion = existing?.version ?? 0;
+      const incomingVersion = m.version ?? 0;
+      if (existing && incomingVersion < existingVersion) {
+        return { success: false, stale: true };
+      }
+      const updated: Milestone = { ...m, version: (m.version ?? 0) + 1 };
+      milestones = milestones.map((x) => (x.id === m.id ? updated : x));
+      if (!existing) milestones.push(updated);
+      return { success: true, stale: false };
+    }),
+    deleteMilestones: jest.fn((ids: string[]) => {
+      const before = milestones.length;
+      const idSet = new Set(ids);
+      milestones = milestones.filter((m) => !idSet.has(m.id));
+      return before - milestones.length;
+    }),
+    bulkUpdateMilestoneStatus: jest.fn((ids: string[], newStatus: Milestone['status']) => {
+      const idSet = new Set(ids);
+      milestones = milestones.map((m) => (idSet.has(m.id) ? { ...m, status: newStatus } : m));
+      return ids.length;
+    }),
+  };
+  return { strategy, read: () => [...milestones] };
+}
+
+beforeEach(() => {
+  clearPersistedQueue();
+  window.localStorage.clear();
+  resetQueueCacheForTests();
+});
+
+afterEach(() => {
+  clearPersistedQueue();
+  window.localStorage.clear();
+  resetQueueCacheForTests();
+});
+
+describe('queue persistence', () => {
+  it('persists enqueued mutations and restores them after a simulated reload', () => {
+    const store = makeStore();
+    const a = create('a');
+    const b = create('b');
+    expect(enqueueMutation(a)).toBeNull();
+    expect(enqueueMutation(b)).toBeNull();
+
+    // Simulate a reload: drop the in-memory cache and re-read from storage.
+    resetQueueCacheForTests();
+    const restored = loadPendingQueue();
+    expect(restored.map((m) => m.kind)).toEqual(['create', 'create']);
+
+    // Flushing into the same store applies both, in order.
+    const result = flushQueue(store.strategy);
+    expect(result.flushed).toBe(2);
+    resetQueueCacheForTests();
+    expect(loadPendingQueue()).toEqual([]);
+    expect(store.read().some((m) => m.id === 'a')).toBe(true);
+    expect(store.read().some((m) => m.id === 'b')).toBe(true);
+  });
+
+  it('preserves exact insertion order on flush', () => {
+    const store = makeStore();
+    const first = create('first');
+    const second = create('second');
+    const third = create('third');
+    enqueueMutation(first);
+    enqueueMutation(second);
+    enqueueMutation(third);
+
+    const result = flushQueue(store.strategy);
+    expect(result.flushed).toBe(3);
+    expect(result.applied.map((m) => m.id)).toEqual([first.id, second.id, third.id]);
+    expect(store.read().map((m) => m.id)).toEqual(['first', 'second', 'third']);
+  });
+});
+
+describe('malformed persisted data', () => {
+  it('discards malformed entries and never throws', () => {
+    setItem(
+      OFFLINE_QUEUE_KEY,
+      JSON.stringify([
+        { id: 'ok', kind: 'delete', ids: ['x'], createdAt: 1 },
+        { id: 'no-kind', createdAt: 1 },
+        'garbage',
+        null,
+        { kind: 'create', createdAt: 1 }, // missing milestone
+      ]),
+    );
+
+    resetQueueCacheForTests();
+    const restored = loadPendingQueue();
+    expect(restored).toHaveLength(1);
+    expect(restored[0].kind).toBe('delete');
+  });
+
+  it('returns an empty queue for corrupt JSON', () => {
+    setItem(OFFLINE_QUEUE_KEY, '%%%not-json%%%');
+    resetQueueCacheForTests();
+    expect(loadPendingQueue()).toEqual([]);
+  });
+
+  it('returns an empty queue when the key is absent', () => {
+    resetQueueCacheForTests();
+    expect(loadPendingQueue()).toEqual([]);
+  });
+});
+
+describe('flush locking / no double apply', () => {
+  it('a create is applied exactly once across repeated flushes', () => {
+    const store = makeStore();
+    const a = create('a');
+    enqueueMutation(a);
+
+    const first = flushQueue(store.strategy);
+    const second = flushQueue(store.strategy);
+
+    expect(first.flushed).toBe(1);
+    // Second flush sees an empty queue and is a no-op.
+    expect(second.flushed).toBe(0);
+    expect(second.wasEmpty).toBe(true);
+    expect(store.read().filter((m) => m.id === 'a')).toHaveLength(1);
+    expect(store.strategy.saveMilestone).toHaveBeenCalledTimes(1);
+  });
+
+  it('a re-entrant flush triggered during replay is a no-op (flush lock)', () => {
+    const store = makeStore();
+    const a = create('a');
+    enqueueMutation(a);
+
+    const originalSave = store.strategy.saveMilestone;
+    store.strategy.saveMilestone = jest.fn((m: Milestone) => {
+      const nested = flushQueue(store.strategy);
+      expect(nested.flushed).toBe(0);
+      expect(nested.wasEmpty).toBe(true);
+      return originalSave(m);
+    });
+
+    const result = flushQueue(store.strategy);
+    expect(result.flushed).toBe(1);
+    expect(store.read().filter((m) => m.id === 'a')).toHaveLength(1);
+  });
+
+  it('a previously-applied create is not re-applied after an interrupted flush', () => {
+    const store = makeStore();
+    enqueueMutation(create('first'));
+
+    // First mutation replays fine.
+    const before = store.strategy.saveMilestone;
+    store.strategy.saveMilestone = jest.fn((m: Milestone) =>
+      m.id === 'first' ? before(m) : (() => {
+        throw new Error('storage transient failure');
+      })(),
+    );
+
+    // Queue: [create first, create second]. 'first' applies; 'second' fails.
+    enqueueMutation(create('second'));
+    const result = flushQueue(store.strategy);
+    expect(result.flushed).toBe(1);
+    expect(result.failed).toHaveLength(1);
+    expect(store.read().filter((m) => m.id === 'first')).toHaveLength(1);
+
+    // Restore the sinks so the remaining mutation can flush.
+    store.strategy.saveMilestone = before;
+    const again = flushQueue(store.strategy);
+    expect(again.flushed).toBe(1);
+    // 'first' was removed from the queue after its success — never re-applied.
+    expect(store.read().filter((m) => m.id === 'first')).toHaveLength(1);
+    expect(store.read().filter((m) => m.id === 'second')).toHaveLength(1);
+  });
+});
+
+describe('idempotent create on replay', () => {
+  it('does not create a duplicate if the milestone already reached the store', () => {
+    const store = makeStore([makeMilestone('dup')]);
+    const a = create('dup');
+    expect(enqueueMutation(a)).toBeNull();
+
+    const result = flushQueue(store.strategy);
+    expect(result.flushed).toBe(1);
+    expect(store.read().filter((m) => m.id === 'dup')).toHaveLength(1);
+    expect(store.strategy.saveMilestone).not.toHaveBeenCalled();
+  });
+});
+
+describe('conflict handling', () => {
+  it('surfaces MUTATION_CONFLICT for a stale version update and leaves it queued', () => {
+    const store = makeStore([{ ...makeMilestone('m1'), version: 5 }]);
+    // The offline edit was based on an older version than the store holds.
+    const m = update('m1', { title: 'offline edit' }, 2);
+    enqueueMutation(m);
+
+    const result = flushQueue(store.strategy);
+    expect(result.flushed).toBe(0);
+    expect(result.failed).toHaveLength(1);
+    const err = result.failed[0];
+    expect(err.code).toBe(OFFLINE_QUEUE_ERROR_CODES.conflict);
+    expect(err.retryable).toBe(false);
+    expect(err.mutationId).toBe(m.id);
+
+    // The mutation is NOT silently discarded — still queued.
+    resetQueueCacheForTests();
+    const pending = loadPendingQueue();
+    expect(pending.some((p) => p.id === m.id)).toBe(true);
+    // Store is unchanged (old version preserved).
+    expect(store.read().find((x) => x.id === 'm1')?.title).toBe('Milestone m1');
+  });
+
+  it('applies a non-stale update and bumps the version', () => {
+    const store = makeStore([{ ...makeMilestone('m1'), version: 0 }]);
+    const m = update('m1', { title: 'Edited online after reconnect' }, 0);
+    enqueueMutation(m);
+
+    const result = flushQueue(store.strategy);
+    expect(result.flushed).toBe(1);
+    expect(result.failed).toHaveLength(0);
+    expect(store.read().find((x) => x.id === 'm1')?.title).toBe('Edited online after reconnect');
+    expect((store.read().find((x) => x.id === 'm1') as Milestone).version).toBe(1);
+  });
+});
+
+describe('empty queue', () => {
+  it('flushes an empty queue as a no-op', () => {
+    const store = makeStore();
+    const result = flushQueue(store.strategy);
+    expect(result.flushed).toBe(0);
+    expect(result.failed).toHaveLength(0);
+    expect(result.wasEmpty).toBe(true);
+    expect(store.strategy.listMilestones).not.toHaveBeenCalled();
+  });
+});
+
+describe('application by kind', () => {
+  it('delete removes matching milestones', () => {
+    const store = makeStore([makeMilestone('a'), makeMilestone('b')]);
+    enqueueMutation(del(['a']));
+    flushQueue(store.strategy);
+    expect(store.read().map((m) => m.id)).toEqual(['b']);
+  });
+
+  it('status updates matching milestones', () => {
+    const store = makeStore([makeMilestone('a'), makeMilestone('b')]);
+    enqueueMutation(status(['a', 'b'], 'Completed'));
+    flushQueue(store.strategy);
+    expect(store.read().every((m) => m.status === 'Completed')).toBe(true);
+  });
+
+  it('update fails (non-retryable) when the target no longer exists', () => {
+    const store = makeStore();
+    const m = update('ghost', { title: 'nope' });
+    const result = applyMutation(m, store.strategy);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(OFFLINE_QUEUE_ERROR_CODES.replayFailed);
+      expect(result.error.retryable).toBe(false);
+    }
+  });
+});
+
+describe('queue capacity', () => {
+  it('rejects enqueues beyond the maximum with a stable error', () => {
+    for (let i = 0; i < MAX_QUEUED_MUTATIONS; i += 1) {
+      expect(enqueueMutation(create(`m${i}`))).toBeNull();
+    }
+    const rejected = enqueueMutation(create('overflow'));
+    expect(rejected?.code).toBe(OFFLINE_QUEUE_ERROR_CODES.persistenceFailed);
+    expect(rejected?.retryable).toBe(true);
+  });
+});
+
+describe('cleanup helpers', () => {
+  it('clearPersistedQueue removes everything', () => {
+    enqueueMutation(create('a'));
+    clearPersistedQueue();
+    expect(loadPendingQueue()).toEqual([]);
+  });
+});

--- a/src/lib/offlineMilestoneCoordinator.ts
+++ b/src/lib/offlineMilestoneCoordinator.ts
@@ -1,0 +1,205 @@
+/**
+ * @file offlineMilestoneCoordinator.ts
+ *
+ * Thin coordination layer between the milestones page and the persistent
+ * {@link offlineMilestoneQueue}. It owns the decision of how a board mutation
+ * is handled based on connectivity, and reports back a snapshot that the page
+ * uses to keep its UI (and reconcile with authoritative repository state).
+ *
+ * - **Online**  → `applyImmediate` writes straight to the repository exactly as
+ *   the pre-existing page handlers did (behaviour unchanged).
+ * - **Offline** → `enqueue` captures the mutation into the persistent queue
+ *   (the store is left untouched).
+ * - **Reconnect** → `flushPending` pushes the queue to the store in order,
+ *   deduplicated via the queue module's flush lock, then sets `reconciled` so
+ *   the page re-reads authoritative state.
+ */
+
+import {
+  saveMilestone,
+  updateMilestone,
+  deleteMilestones,
+  bulkUpdateMilestoneStatus,
+} from '@/lib/repository';
+import {
+  enqueueMutation,
+  flushQueue,
+  loadPendingQueue,
+  createMutationId,
+  pendingMutationCount,
+  type QueuedMilestoneMutation,
+} from '@/lib/offlineMilestoneQueue';
+import type { Milestone } from '@/components/MilestonesList';
+import type { StatusType } from '@/components/StatusBadge';
+import type { MilestoneMutationError } from '@/lib/offlineMilestoneQueue';
+
+/**
+ * A snapshot of the board after a coordinator operation. The page consumes
+ * `pending`, `failed`, `accepted`, and `reconciled` to drive UI feedback and
+ * reconciliation.
+ */
+export interface OfflineMilestoneSnapshot {
+  /** Mutations still waiting in the offline queue, in insertion order. */
+  pending: QueuedMilestoneMutation[];
+  /** Mutations applied to the store during the most recent flush. */
+  flushed: QueuedMilestoneMutation[];
+  /** Failures from the most recent flush (the mutation stayed queued). */
+  failed: MilestoneMutationError[];
+  /** Number of mutations accepted (applied online, or enqueued offline). */
+  enqueued: number;
+  /** Whether the authoritative store was re-read into the UI. */
+  reconciled: boolean;
+  /** True when the operation was accepted (applied or queued). */
+  accepted: boolean;
+  /** Safe, user-facing message describing the last operation (may be empty). */
+  userMessage: string;
+}
+
+export type MutateInput =
+  | { kind: 'create'; milestone: Milestone }
+  | {
+      kind: 'update';
+      targetId: string;
+      patch: Partial<Milestone>;
+      /**
+       * Repository version the offline edit was based on. On replay, if the
+       * authoritative store holds a *newer* version than this, the write is
+       * rejected as a `MUTATION_CONFLICT`. Callers record `current.version`
+       * at edit time so stale offline edits are surfaced rather than silently
+       * overwriting another tab's changes.
+       */
+      baseVersion?: number;
+    }
+  | { kind: 'delete'; ids: string[] }
+  | { kind: 'status'; ids: string[]; status: StatusType };
+
+const emptySnapshot = (overrides: Partial<OfflineMilestoneSnapshot>): OfflineMilestoneSnapshot => ({
+  pending: [],
+  flushed: [],
+  failed: [],
+  enqueued: 0,
+  reconciled: false,
+  accepted: false,
+  userMessage: '',
+  ...overrides,
+});
+
+/**
+ * Applies a mutation immediately to the authoritative store (online path) using
+ * the exact same repository operations the page used before, so existing online
+ * behaviour is preserved.
+ */
+export function applyImmediate(input: MutateInput): OfflineMilestoneSnapshot {
+  let ok = false;
+  try {
+    switch (input.kind) {
+      case 'create':
+        ok = saveMilestone(input.milestone);
+        break;
+      case 'update':
+        ok = updateMilestone(input.targetId, input.patch);
+        break;
+      case 'delete':
+        ok = deleteMilestones(input.ids) > 0 || input.ids.length === 0;
+        break;
+      case 'status':
+        ok = true;
+        bulkUpdateMilestoneStatus(input.ids, input.status);
+        break;
+    }
+  } catch {
+    ok = false;
+  }
+
+  return emptySnapshot({
+    pending: loadPendingQueue(),
+    enqueued: ok ? 1 : 0,
+    reconciled: ok,
+    accepted: ok,
+    userMessage: ok ? '' : 'Your change could not be saved. Please try again.',
+  });
+}
+
+/**
+ * Enqueues a mutation (offline path) into the persistent queue. The
+ * authoritative store is left untouched.
+ */
+export function enqueue(input: MutateInput): OfflineMilestoneSnapshot {
+  const mutation = toQueuedMutation(input);
+  const rejected = enqueueMutation(mutation);
+  const accepted = rejected === null;
+
+  return emptySnapshot({
+    pending: loadPendingQueue(),
+    enqueued: accepted ? 1 : 0,
+    accepted,
+    reconciled: false,
+    userMessage: accepted
+      ? 'Saved offline — will synchronize when you are back online.'
+      : rejected?.message ?? 'Your change could not be saved offline. Please try again.',
+  });
+}
+
+/**
+ * Flushes the pending queue to the authoritative store in order, then reports
+ * `reconciled: true` when the store changed so the page re-reads authoritative
+ * state. The queue module's flush lock prevents duplicate/reconnect flushes.
+ */
+export function flushPending(): OfflineMilestoneSnapshot {
+  const result = flushQueue();
+
+  return emptySnapshot({
+    pending: loadPendingQueue(),
+    flushed: result.applied,
+    enqueued: 0,
+    accepted: result.flushed > 0,
+    // Reconcile (re-read authoritative state) only when the flush actually ran
+    // against a non-empty queue. An empty flush means nothing changed, so the
+    // caller must keep its current optimistic/sample UI untouched.
+    reconciled: !result.wasEmpty,
+    failed: result.failed,
+    userMessage: describeFlush(result),
+  });
+}
+
+function describeFlush(result: {
+  flushed: number;
+  failed: MilestoneMutationError[];
+}): string {
+  if (result.failed.length > 0) {
+    return result.failed.some((f) => f.code === 'MUTATION_CONFLICT')
+      ? 'One of your offline changes conflicts with newer data. Review your milestones.'
+      : 'Some offline changes could not be synchronized. Review the affected milestones.';
+  }
+  if (result.flushed > 0) {
+    return 'Your offline changes were synchronized.';
+  }
+  return '';
+}
+
+/** Alias so callers can report how many mutations are still queued. */
+export function currentPendingCount(): number {
+  return pendingMutationCount();
+}
+
+/** Maps a MutateInput to a stable, queued mutation record. */
+function toQueuedMutation(input: MutateInput): QueuedMilestoneMutation {
+  const { id, createdAt } = { id: createMutationId(), createdAt: Date.now() };
+  switch (input.kind) {
+    case 'create':
+      return { id, kind: 'create', milestone: input.milestone, createdAt };
+    case 'update':
+      return {
+        id,
+        kind: 'update',
+        targetId: input.targetId,
+        patch: input.patch,
+        baseVersion: input.baseVersion,
+        createdAt,
+      };
+    case 'delete':
+      return { id, kind: 'delete', ids: input.ids, createdAt };
+    case 'status':
+      return { id, kind: 'status', ids: input.ids, status: input.status, createdAt };
+  }
+}

--- a/src/lib/offlineMilestoneQueue.ts
+++ b/src/lib/offlineMilestoneQueue.ts
@@ -1,0 +1,501 @@
+/**
+ * @file offlineMilestoneQueue.ts
+ *
+ * Offline mutation queue for the milestones board.
+ *
+ * ## Why it exists
+ *
+ * TalentTrust is a fully client-side app: milestone data is persisted in
+ * `localStorage` via `src/lib/repository.ts` (there is no backend). The
+ * repository, together with its monotonically-increasing `version` field and
+ * the `stale: true` stale-overwrite guard in `upsertMilestone`, is treated as
+ * the *authoritative store* for this queue's purposes.
+ *
+ * When the browser is offline we **defer** milestone mutations to the local
+ * repository instead of applying them immediately. Each mutation is captured
+ * into a persistent queue (backed by `safeStorage`) so it survives reloads.
+ * When connectivity returns the queue is flushed — applied to the repository
+ * **in the exact order it was recorded** — and then the UI reconciles with the
+ * authoritative repository state.
+ *
+ * ## Why mutations have stable IDs
+ *
+ * Every entry carries a unique, stable `id` (mutation id) generated at enqueue
+ * time. Because `MilestoneCreationForm` derives milestone `id`s from
+ * title + timestamp, a create can be made *idempotent on replay*: `create`
+ * checks whether a milestone with that id already exists before writing,
+ * eliminating duplicate creates if a flush was interrupted between applying a
+ * write and persisting its removal from the queue. Update/delete/status
+ * mutations are naturally idempotent when replayed against an unchanged store.
+ *
+ * ## How the flush lock prevents duplicate replay
+ *
+ * Reconciliation is driven by UI events (`window online`, mount) that can fire
+ * many times. A module-level `flushInProgress` flag ensures only one flush runs
+ * at a time; concurrent calls return `{ flushed: 0 }` immediately. Combined
+ * with idempotent ops and "remove from the queue only after a successful write",
+ * a mutation is never applied more than once.
+ *
+ * ## How conflicts are handled
+ *
+ * Replaying an `update` goes through `upsertMilestone`'s version guard. If the
+ * authoritative store holds a *newer* version than the one the offline edit was
+ * based on, the write is rejected with `stale: true`. That becomes a
+ * `MUTATION_CONFLICT` error, which is surfaced to the user (the mutation stays
+ * in the queue so it is not silently dropped). No internal stack traces or raw
+ * exceptions are ever surfaced to users.
+ *
+ * ## Error codes
+ *
+ * Failures are normalised into `MilestoneMutationError` objects with a stable
+ * `code`. Codes are internal identifiers; UI callers map them to safe,
+ * user-facing messages (see `docs/offline-milestones.md`).
+ */
+
+import { getItem, setItem, removeItem } from '@/lib/safeStorage';
+import { reportError } from '@/lib/errorReporter';
+import type { Milestone } from '@/components/MilestonesList';
+import type { StatusType } from '@/components/StatusBadge';
+import {
+  listMilestones,
+  saveMilestone,
+  upsertMilestone,
+  deleteMilestones,
+  bulkUpdateMilestoneStatus,
+} from '@/lib/repository';
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+/** Single storage key holding the serialised pending mutation queue. */
+export const OFFLINE_QUEUE_KEY = 'talenttrust_milestones_offline_queue';
+
+/** Hard cap on queued entries; guards against runaway growth while offline. */
+export const MAX_QUEUED_MUTATIONS = 200;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Stable internal error codes for offline-queue failures. */
+export const OFFLINE_QUEUE_ERROR_CODES = {
+  persistenceFailed: 'OFFLINE_QUEUE_PERSIST_FAILED',
+  invalidEntry: 'OFFLINE_QUEUE_INVALID_ENTRY',
+  replayFailed: 'MUTATION_REPLAY_FAILED',
+  conflict: 'MUTATION_CONFLICT',
+  reconciliationFailed: 'RECONCILIATION_FAILED',
+  queueFlushInProgress: 'QUEUE_FLUSH_IN_PROGRESS',
+} as const;
+
+export type OfflineQueueErrorCode =
+  (typeof OFFLINE_QUEUE_ERROR_CODES)[keyof typeof OFFLINE_QUEUE_ERROR_CODES];
+
+/**
+ * A single queued milestone-board mutation. The discriminated `kind` mirrors
+ * the repository mutations the board supports, and the payload carries enough
+ * data to replay it against the authoritative store.
+ */
+export type QueuedMilestoneMutation =
+  | {
+      /** Stable, unique id for this queued entry (dedupe/idempotency). */
+      id: string;
+      kind: 'create';
+      milestone: Milestone;
+      createdAt: number;
+      retryCount?: number;
+    }
+  | {
+      id: string;
+      kind: 'update';
+      targetId: string;
+      patch: Partial<Milestone>;
+      /** Repository version the offline edit was based on (for conflict
+       *  detection on replay). */
+      baseVersion?: number;
+      createdAt: number;
+      retryCount?: number;
+    }
+  | {
+      id: string;
+      kind: 'delete';
+      ids: string[];
+      createdAt: number;
+      retryCount?: number;
+    }
+  | {
+      id: string;
+      kind: 'status';
+      ids: string[];
+      status: StatusType;
+      createdAt: number;
+      retryCount?: number;
+    };
+
+/** Outcome of applying a single queued mutation to the repository. */
+export type MutationApplyResult =
+  | { ok: true }
+  | { ok: false; error: MilestoneMutationError };
+
+/** Normalised, stable, typed error surfaced by the queue. */
+export type MilestoneMutationError = {
+  code: OfflineQueueErrorCode;
+  /** Short, safe, user-facing message — never leaks internals. */
+  message: string;
+  /** Whether retrying the mutation is expected to succeed. */
+  retryable: boolean;
+  /** The id of the failed queued mutation (for UI correlation). */
+  mutationId: string;
+};
+
+/** Result of a flush run. */
+export type FlushResult = {
+  /** How many queued mutations were successfully applied and removed. */
+  flushed: number;
+  /** Mutations that were applied and removed. */
+  applied: QueuedMilestoneMutation[];
+  /** Mutations that failed and remain queued (for user-visible retry). */
+  failed: MilestoneMutationError[];
+  /** True when the queue was empty at flush start. */
+  wasEmpty: boolean;
+};
+
+/**
+ * Replay strategy for the flush. Injected so tests can mock the exact
+ * repository boundary, and the production path simply forwards to the real
+ * repository functions.
+ */
+export type ReplayStrategy = {
+  listMilestones: () => Milestone[];
+  saveMilestone: (milestone: Milestone) => boolean;
+  upsertMilestone: (milestone: Milestone) => { success: boolean; stale: boolean };
+  deleteMilestones: (ids: string[]) => number;
+  bulkUpdateMilestoneStatus: (ids: string[], status: StatusType) => number;
+};
+
+const defaultReplay: ReplayStrategy = {
+  listMilestones,
+  saveMilestone,
+  upsertMilestone,
+  deleteMilestones,
+  bulkUpdateMilestoneStatus,
+};
+
+// ---------------------------------------------------------------------------
+// Mutation id helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a unique, stable id for a queued mutation. Uses `crypto.randomUUID`
+ * when available with a timestamp/random fallback for older environments.
+ */
+export function createMutationId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `m-${crypto.randomUUID()}`;
+  }
+  return `m-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level flush lock
+// ---------------------------------------------------------------------------
+
+let flushInProgress = false;
+let liveQueueCache: QueuedMilestoneMutation[] | null = null;
+let liveQueueLoaded = false;
+
+// ---------------------------------------------------------------------------
+// Queue persistence
+// ---------------------------------------------------------------------------
+
+function isValidMutation(value: unknown): value is QueuedMilestoneMutation {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  if (typeof record.id !== 'string') return false;
+  if (typeof record.createdAt !== 'number') return false;
+  switch (record.kind) {
+    case 'create':
+      return typeof record.milestone === 'object' && record.milestone !== null;
+    case 'update':
+      return (
+        typeof record.targetId === 'string' &&
+        typeof record.patch === 'object' &&
+        record.patch !== null
+      );
+    case 'delete':
+      return Array.isArray(record.ids) && record.ids.every((id) => typeof id === 'string');
+    case 'status':
+      return (
+        Array.isArray(record.ids) &&
+        record.ids.every((id) => typeof id === 'string') &&
+        typeof record.status === 'string'
+      );
+    default:
+      return false;
+  }
+}
+
+/**
+ * Loads the persisted queue, discarding malformed entries safely. Never throws
+ * — corrupt or invalid JSON/results fall back to an empty queue.
+ */
+export function loadPendingQueue(): QueuedMilestoneMutation[] {
+  const raw = getItem(OFFLINE_QUEUE_KEY);
+  if (raw === null || raw === '') {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    reportError(err, '[offlineQueue] Corrupt queue JSON; discarding.', 'warn');
+    return [];
+  }
+
+  if (!Array.isArray(parsed)) {
+    reportError(
+      new Error('[offlineQueue] Persisted queue is not an array; discarding.'),
+      '[offlineQueue]',
+      'warn',
+    );
+    return [];
+  }
+
+  const valid = parsed.filter(isValidMutation);
+  if (valid.length !== parsed.length) {
+    reportError(
+      new Error(`[offlineQueue] Discarded ${parsed.length - valid.length} malformed entries.`),
+      '[offlineQueue]',
+      'warn',
+    );
+  }
+  return valid;
+}
+
+/** Serialises and stores the pending queue. Returns true on success. */
+export function persistQueue(queue: QueuedMilestoneMutation[]): boolean {
+  try {
+    const ok = setItem(OFFLINE_QUEUE_KEY, JSON.stringify(queue.slice(0, MAX_QUEUED_MUTATIONS)));
+    liveQueueCache = [...queue];
+    return ok;
+  } catch (err) {
+    reportError(err, '[offlineQueue] Failed to persist queue.', 'error');
+    return false;
+  }
+}
+
+function readLiveQueue(): QueuedMilestoneMutation[] {
+  if (!liveQueueLoaded) {
+    liveQueueCache = loadPendingQueue();
+    liveQueueLoaded = true;
+  }
+  return liveQueueCache ?? [];
+}
+
+/**
+ * Adds a mutation to the queue in a snapshot-persistent way: the *updated*
+ * array is what gets written, so a crash mid-sequence never leaves the store
+ * out of sync with the in-memory view.
+ */
+export function enqueueMutation(mutation: QueuedMilestoneMutation): MilestoneMutationError | null {
+  const next = [...readLiveQueue(), mutation];
+  if (next.length > MAX_QUEUED_MUTATIONS) {
+    return {
+      code: OFFLINE_QUEUE_ERROR_CODES.persistenceFailed,
+      message: 'Too many pending offline changes. Connect to the internet to continue.',
+      retryable: true,
+      mutationId: mutation.id,
+    };
+  }
+  const ok = persistQueue(next);
+  if (!ok) {
+    return {
+      code: OFFLINE_QUEUE_ERROR_CODES.persistenceFailed,
+      message: 'Your change could not be saved offline. Please try again.',
+      retryable: true,
+      mutationId: mutation.id,
+    };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Replay
+// ---------------------------------------------------------------------------
+
+/**
+ * Applies one queued mutation to the authoritative store. Returns `{ok:true}`
+ * on success, or a stable error. On `MUTATION_CONFLICT` the reason is recorded
+ * but the mutation is left queued so it is not silently discarded.
+ */
+export function applyMutation(
+  mutation: QueuedMilestoneMutation,
+  replay: ReplayStrategy = defaultReplay,
+): MutationApplyResult {
+  try {
+    switch (mutation.kind) {
+      case 'create': {
+        // Idempotency guard: if the milestone already reached the store (e.g. a
+        // previous interrupted flush), do not create a duplicate.
+        const exists = replay
+          .listMilestones()
+          .some((m) => m.id === mutation.milestone.id);
+        if (exists) {
+          return { ok: true };
+        }
+        replay.saveMilestone(mutation.milestone);
+        return { ok: true };
+      }
+      case 'update': {
+        const current = replay.listMilestones().find((m) => m.id === mutation.targetId);
+        if (!current) {
+          return {
+            ok: false,
+            error: makeError(
+              OFFLINE_QUEUE_ERROR_CODES.replayFailed,
+              'This milestone no longer exists and could not be updated.',
+              false,
+              mutation,
+            ),
+          };
+        }
+        // Version-gated upsert surfaces a stale-overwrite conflict.
+        const version = mutation.baseVersion ?? current.version ?? 0;
+        const result = replay.upsertMilestone({ ...current, ...mutation.patch, version });
+        if (result.stale) {
+          return {
+            ok: false,
+            error: makeError(
+              OFFLINE_QUEUE_ERROR_CODES.conflict,
+              'This milestone was changed elsewhere. Review before saving.',
+              false,
+              mutation,
+            ),
+          };
+        }
+        if (!result.success) {
+          return {
+            ok: false,
+            error: makeError(
+              OFFLINE_QUEUE_ERROR_CODES.replayFailed,
+              'Could not save this milestone right now.',
+              true,
+              mutation,
+            ),
+          };
+        }
+        return { ok: true };
+      }
+      case 'delete': {
+        replay.deleteMilestones(mutation.ids);
+        return { ok: true };
+      }
+      case 'status': {
+        replay.bulkUpdateMilestoneStatus(mutation.ids, mutation.status);
+        return { ok: true };
+      }
+    }
+  } catch (err) {
+    reportError(err, '[offlineQueue] Mutation replay failed.');
+    return {
+      ok: false,
+      error: makeError(
+        OFFLINE_QUEUE_ERROR_CODES.replayFailed,
+        'Could not apply one of your offline changes. Please try again.',
+        true,
+        mutation,
+      ),
+    };
+  }
+}
+
+function makeError(
+  code: OfflineQueueErrorCode,
+  message: string,
+  retryable: boolean,
+  mutation: QueuedMilestoneMutation,
+): MilestoneMutationError {
+  return { code, message, retryable, mutationId: mutation.id };
+}
+
+// ---------------------------------------------------------------------------
+// Flush
+// ---------------------------------------------------------------------------
+
+/**
+ * Flushes the pending queue to the authoritative store, in insertion order.
+ *
+ * Guarantees:
+ * - Only one flush runs at a time (module-level lock); a concurrent/second
+ *   call returns `{ flushed: 0 }` immediately.
+ * - Order is preserved: mutations apply sequentially, first-in-first-out.
+ * - A mutation is removed from the persistent queue *only after* its repository
+ *   write succeeds, so a crash cannot cause unsafe re-replay.
+ * - On a failure, later mutations are still processed only where safe; any
+ *   failed mutation stays queued (never silently discarded) and is reported via
+ *   the returned `failed` errors.
+ *
+ * @returns A `FlushResult` describing what happened.
+ */
+export function flushQueue(replay: ReplayStrategy = defaultReplay): FlushResult {
+  if (flushInProgress) {
+    // A concurrent/duplicate flush is a no-op. Treat it as "nothing to do" so
+    // callers do not trigger a reconciliation on a redundant flush.
+    return { flushed: 0, applied: [], failed: [], wasEmpty: true };
+  }
+  flushInProgress = true;
+  try {
+    const queue = readLiveQueue();
+    if (queue.length === 0) {
+      return { flushed: 0, applied: [], failed: [], wasEmpty: true };
+    }
+
+    const applied: QueuedMilestoneMutation[] = [];
+    const failed: MilestoneMutationError[] = [];
+    let remaining = [...queue];
+
+    for (const mutation of queue) {
+      const result = applyMutation(mutation, replay);
+      if (result.ok) {
+        applied.push(mutation);
+        remaining = remaining.filter((m) => m.id !== mutation.id);
+        persistQueue(remaining);
+      } else {
+        failed.push(result.error);
+        // Stop here: later mutations may depend on this one (ordering).
+        break;
+      }
+    }
+
+    return { flushed: applied.length, applied, failed, wasEmpty: false };
+  } finally {
+    liveQueueLoaded = true;
+    flushInProgress = false;
+  }
+}
+
+/** Number of pending mutations currently in the queue (persisted + cached). */
+export function pendingMutationCount(): number {
+  return readLiveQueue().length;
+}
+
+/**
+ * Clears the *in-memory* cached queue view (does not touch storage). Primarily
+ * for tests to re-sync the module's cache with storage.
+ */
+export function resetQueueCacheForTests(): void {
+  liveQueueCache = null;
+  liveQueueLoaded = false;
+  flushInProgress = false;
+}
+
+/** Removes the persistenced queue entry (used by tests and debug reset). */
+export function clearPersistedQueue(): void {
+  try {
+    removeItem(OFFLINE_QUEUE_KEY);
+  } catch {
+    // safeStorage resilience
+  }
+  resetQueueCacheForTests();
+}


### PR DESCRIPTION
Store milestone mutations when the browser is offline so the board keeps working, then flush the queued changes in order once connectivity returns. Routes create/update through a coordinator that applies online changes immediately and defers offline ones, surfaces conflicts instead of silently overwriting newer data, and reconciles the UI with authoritative state after a flush. Also fix useOnlineStatus so multiple consumers share a single set of window listeners (previously every consumer registered duplicates).



## Description

<!-- Summarize the changes in this PR and the motivation behind them. -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional change, internal code improvement)
- [ ] Documentation update

---

## Pre-flight Checklist

All items must be checked before requesting review.

- [ ] `npm run lint` passes with no errors
- [ ] `npm test` passes with no failures
- [ ] `npm run build` completes successfully

---

## Testing & Coverage

- [ ] Module test coverage for impacted files meets or exceeds the **95% minimum threshold**
  (run `npm test -- --coverage` and check the per-file table)
- [ ] If this PR adds or modifies UI components, accessibility tests were written using
  the shared utilities in `src/test-utils/a11y.tsx`

### What was tested?

<!-- Briefly describe the test cases you added or updated, and any manual testing performed. -->

---

## Accessibility & Security Notes

### Accessibility

<!-- Did you run automated a11y checks (e.g. jest-axe via src/test-utils/a11y.tsx)?
     Did you do any manual keyboard-navigation or screen-reader testing?
     Note findings or "N/A – no UI changes" if not applicable. -->

### Security

<!-- Does this PR touch authentication, authorization, wallet logic, API calls, or
     user-supplied input? Describe any security considerations or "N/A" if not applicable. -->
 closes #1103